### PR TITLE
Add PersonaCard component

### DIFF
--- a/apps/creator/components/PersonaCard.tsx
+++ b/apps/creator/components/PersonaCard.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+export interface PersonaProfile {
+  name: string;
+  personality: string;
+  interests: string[];
+  summary: string;
+}
+
+export default function PersonaCard({ profile }: { profile: PersonaProfile }) {
+  return (
+    <div className="bg-background border border-foreground/20 rounded-xl p-6 shadow-md space-y-3">
+      <h2 className="text-xl font-semibold text-foreground">{profile.name}</h2>
+      <p className="text-sm text-foreground/70">{profile.personality}</p>
+      <div className="flex flex-wrap gap-2">
+        {profile.interests.map((interest) => (
+          <span key={interest} className="bg-foreground/10 text-foreground text-xs px-2 py-1 rounded-full">
+            {interest}
+          </span>
+        ))}
+      </div>
+      <p className="text-sm text-foreground/80">{profile.summary}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `PersonaCard.tsx` component for creator app
- define `PersonaProfile` interface and render persona details in Tailwind styled card

## Testing
- `npm run lint` *(fails: ENETUNREACH)*
- `npx tsc -b tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_68507229b58c832c95f3b700d0345123