### PR TITLE
Define and export PersonaProfile type

### DIFF
--- a/apps/creator/app/api/generate/route.ts
+++ b/apps/creator/app/api/generate/route.ts
@@ -1,3 +1,10 @@
+export interface PersonaProfile {
+  name: string;
+  personality: string;
+  interests: string[];
+  summary: string;
+}
+
 export async function POST(req: Request) {
   const {
     handle,
@@ -116,21 +123,25 @@ export async function POST(req: Request) {
       },
       body: JSON.stringify({
         model: "gpt-4",
-        messages: [{ role: "user", content: prompt }],
+        messages: [
+          {
+            role: "system",
+            content:
+              "Respond ONLY with valid JSON using keys name, personality, interests and summary.",
+          },
+          { role: "user", content: prompt },
+        ],
         temperature: 0.85,
       }),
     });
-  
+
     const data = await response.json();
-  
-    return new Response(
-      JSON.stringify({
-        result: data.choices[0].message.content,
-      }),
-      {
-        headers: { "Content-Type": "application/json" },
-      }
-    );
+    const content = data.choices?.[0]?.message?.content ?? "{}";
+    const persona: PersonaProfile = JSON.parse(content);
+
+    return new Response(JSON.stringify(persona), {
+      headers: { "Content-Type": "application/json" },
+    });
   }
   
   


### PR DESCRIPTION
## Summary
- return persona data as a typed object
- export `PersonaProfile` from the API route for reuse on the frontend

## Testing
- `npm run lint` *(fails: Failed to load SWC binary)*

------
https://chatgpt.com/codex/tasks/task_e_6850736916f8832cbf57425a4b64ffe8