### PR TITLE
Add Saved Personas page

### DIFF
--- a/apps/creator/app/saved-personas/page.tsx
+++ b/apps/creator/app/saved-personas/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import PersonaCard, { PersonaProfile } from "@/components/PersonaCard";
+
+export default function SavedPersonasPage() {
+  const [profiles, setProfiles] = useState<PersonaProfile[]>([]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const stored = localStorage.getItem("savedPersonas");
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          setProfiles(parsed as PersonaProfile[]);
+        } else if (parsed && typeof parsed === "object") {
+          setProfiles([parsed as PersonaProfile]);
+        }
+      }
+    } catch (err) {
+      console.error("Failed to load personas", err);
+    }
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 space-y-6">
+      <h1 className="text-2xl font-bold">Saved Personas</h1>
+      {profiles.length === 0 ? (
+        <p className="text-foreground/60">No saved personas found.</p>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {profiles.map((profile, idx) => (
+            <PersonaCard key={idx} profile={profile} />
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add new saved-personas page in the creator app
- read `savedPersonas` data from `localStorage`
- display personas in a responsive grid with `PersonaCard`

## Testing
- `npm run lint` *(fails: failed to download @next/swc due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685074e7d748832c96976ed962380218