### PR TITLE
Add Save Persona option

### DIFF
--- a/apps/creator/app/page.tsx
+++ b/apps/creator/app/page.tsx
@@ -67,6 +67,19 @@ export default function Home() {
       setIsLoading(false);
     }
   };
+
+  const handleSave = () => {
+    if (!persona) return;
+    try {
+      const stored = localStorage.getItem("savedPersonas");
+      const list = stored ? JSON.parse(stored) : [];
+      const personas = Array.isArray(list) ? list : [list];
+      personas.push(persona);
+      localStorage.setItem("savedPersonas", JSON.stringify(personas));
+    } catch (err) {
+      console.error("Failed to save persona", err);
+    }
+  };
   
   {!advancedMode ? (
     <button
@@ -182,8 +195,15 @@ export default function Home() {
       </form>
 
       {persona && (
-  <div className="prose prose-invert max-w-3xl mx-auto mt-12">
+  <div className="prose prose-invert max-w-3xl mx-auto mt-12 flex flex-col items-center gap-4">
     <ReactMarkdown>{persona}</ReactMarkdown>
+    <button
+      type="button"
+      onClick={handleSave}
+      className="bg-green-600 hover:bg-green-700 transition text-white font-semibold py-2 px-4 rounded-md"
+    >
+      Save Persona
+    </button>
   </div>
 )}
     </div>


### PR DESCRIPTION
## Summary
- allow saving persona to localStorage from main persona page
- add button under persona result

## Testing
- `npm run lint` *(fails: ENETUNREACH while downloading swc)*

------
https://chatgpt.com/codex/tasks/task_e_685078aed318832ca81a700a4fcbc77c