### PR TITLE
Add dark mode styles

### DIFF
--- a/apps/brand/app/globals.css
+++ b/apps/brand/app/globals.css
@@ -1,14 +1,11 @@
 @import url("https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap");
 
-@import "tailwindcss/preflight";
-@import "tailwindcss/utilities";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 body {
-  @apply bg-red-500 text-white;
-}
-
-body {
-  @apply bg-Siora-dark text-white font-sans antialiased;
+  @apply bg-white text-black font-sans antialiased dark:bg-Siora-dark dark:text-white;
 }
 
 html {

--- a/apps/brand/app/layout.tsx
+++ b/apps/brand/app/layout.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="bg-Siora-dark text-white font-sans antialiased min-h-screen">
+      <body className="bg-white text-black dark:bg-Siora-dark dark:text-white font-sans antialiased min-h-screen">
         <main className="max-w-7xl mx-auto px-6 sm:px-8 py-10">{children}</main>
       </body>
     </html>

--- a/apps/brand/app/page.tsx
+++ b/apps/brand/app/page.tsx
@@ -59,7 +59,7 @@ export default function Page() {
   );
 
   return (
-    <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 md:px-10 py-12">
+    <main className="min-h-screen bg-white text-black dark:bg-gradient-radial dark:from-Siora-dark dark:via-Siora-mid dark:to-Siora-light dark:text-white px-6 md:px-10 py-12">
       <div className="max-w-3xl mx-auto space-y-8">
         <h1 className="text-4xl font-extrabold tracking-tight">Find Creators</h1>
 
@@ -67,7 +67,7 @@ export default function Page() {
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="I'm looking for creators who are..."
-          className="w-full p-3 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
+          className="w-full p-3 rounded-lg bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white placeholder-zinc-400 border border-gray-300 dark:border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
         />
 
         {filtered.length === 0 && (

--- a/apps/brand/components/CreatorCard.tsx
+++ b/apps/brand/components/CreatorCard.tsx
@@ -10,15 +10,15 @@ export default function CreatorCard({ creator }: { creator: Creator }) {
   initial={{ opacity: 0, y: 20 }}
   animate={{ opacity: 1, y: 0 }}
   transition={{ duration: 0.3 }}
-  className="bg-Siora-mid border border-Siora-border rounded-2xl p-6 shadow-Siora-hover hover:-translate-y-1 transition-all"
+  className="bg-white dark:bg-Siora-mid border border-gray-300 dark:border-Siora-border rounded-2xl p-6 shadow-Siora-hover hover:-translate-y-1 transition-all"
 >
-  <h2 className="text-lg font-semibold text-white mb-1">
+  <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
     {creator.name}{" "}
     <span className="text-Siora-accent">@{creator.handle}</span>
   </h2>
-  <p className="text-sm text-zinc-400 mb-2">{creator.niche} • {creator.platform}</p>
-  <p className="text-sm text-zinc-300 mb-4">{creator.summary}</p>
-  <div className="flex items-center text-xs text-zinc-400 space-x-4">
+  <p className="text-sm text-gray-500 dark:text-zinc-400 mb-2">{creator.niche} • {creator.platform}</p>
+  <p className="text-sm text-gray-700 dark:text-zinc-300 mb-4">{creator.summary}</p>
+  <div className="flex items-center text-xs text-gray-500 dark:text-zinc-400 space-x-4">
     <span>{creator.followers.toLocaleString()} followers</span>
     <span>{creator.engagementRate}% ER</span>
   </div>

--- a/apps/brand/components/FilterBar.tsx
+++ b/apps/brand/components/FilterBar.tsx
@@ -24,7 +24,7 @@ export default function FilterBar({ onFilter, onSort }: Props) {
       <select
         value={niche}
         onChange={(e) => setNiche(e.target.value)}
-        className="bg-Siora-light text-white p-2 rounded-lg border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
+        className="bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white p-2 rounded-lg border border-gray-300 dark:border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
       >
         <option value="">All Niches</option>
         <option value="Beauty">Beauty</option>
@@ -40,7 +40,7 @@ export default function FilterBar({ onFilter, onSort }: Props) {
       <select
         value={platform}
         onChange={(e) => setPlatform(e.target.value)}
-        className="bg-Siora-light text-white p-2 rounded-lg border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
+        className="bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white p-2 rounded-lg border border-gray-300 dark:border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
       >
         <option value="">All Platforms</option>
         <option value="Instagram">Instagram</option>
@@ -53,7 +53,7 @@ export default function FilterBar({ onFilter, onSort }: Props) {
         placeholder="Min Followers"
         value={minFollowers}
         onChange={(e) => setMinFollowers(e.target.value)}
-        className="bg-Siora-light text-white p-2 rounded-lg border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
+        className="bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white p-2 rounded-lg border border-gray-300 dark:border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
       />
 
       <input
@@ -61,14 +61,14 @@ export default function FilterBar({ onFilter, onSort }: Props) {
         placeholder="Max Followers"
         value={maxFollowers}
         onChange={(e) => setMaxFollowers(e.target.value)}
-        className="bg-Siora-light text-white p-2 rounded-lg border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
+        className="bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white p-2 rounded-lg border border-gray-300 dark:border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
       />
 
       <div className="flex flex-col sm:flex-row gap-2">
         <select
           value={sort}
           onChange={(e) => setSort(e.target.value)}
-          className="flex-1 bg-Siora-light text-white p-2 rounded-lg border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
+          className="flex-1 bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white p-2 rounded-lg border border-gray-300 dark:border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
         >
           <option value="">Sort by</option>
           <option value="followers-desc">Followers ↓</option>

--- a/apps/brand/src/app/globals.css
+++ b/apps/brand/src/app/globals.css
@@ -1,4 +1,6 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 :root {
   --background: #ffffff;
@@ -23,4 +25,5 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  @apply dark:bg-Siora-dark dark:text-white;
 }

--- a/apps/brand/src/app/layout.tsx
+++ b/apps/brand/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-white text-black dark:bg-Siora-dark dark:text-white`}
       >
         {children}
       </body>

--- a/apps/brand/tailwind.config.ts
+++ b/apps/brand/tailwind.config.ts
@@ -1,6 +1,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: "media",
   content: [
     "./app/**/*.{js,ts,jsx,tsx}",
     "./components/**/*.{js,ts,jsx,tsx}",

--- a/apps/creator/components/PersonaCard.tsx
+++ b/apps/creator/components/PersonaCard.tsx
@@ -2,7 +2,7 @@ import { PersonaProfile } from '../types/persona'
 
 export default function PersonaCard({ profile }: { profile: PersonaProfile }) {
   return (
-    <div className="border p-4 rounded-xl shadow-md bg-white text-black space-y-2">
+    <div className="border border-gray-300 dark:border-zinc-700 p-4 rounded-xl shadow-md bg-white text-black dark:bg-zinc-800 dark:text-white space-y-2">
       <h2 className="text-xl font-bold">{profile.name}</h2>
       <p className="italic">{profile.personality}</p>
       <div className="flex flex-wrap gap-2">
@@ -12,7 +12,7 @@ export default function PersonaCard({ profile }: { profile: PersonaProfile }) {
           </span>
         ))}
       </div>
-      <p className="text-sm text-gray-700">{profile.summary}</p>
+      <p className="text-sm text-gray-700 dark:text-gray-300">{profile.summary}</p>
     </div>
   )
 }

--- a/apps/creator/tailwind.config.{js,cjs,mjs,ts,cts,mts}
+++ b/apps/creator/tailwind.config.{js,cjs,mjs,ts,cts,mts}
@@ -1,6 +1,7 @@
 import type { Config } from 'tailwindcss';
 
 const config: Config = {
+  darkMode: "media",
   content: [
     './app/**/*.{js,ts,jsx,tsx}',
     './pages/**/*.{js,ts,jsx,tsx}',


### PR DESCRIPTION
## Summary
- enable `darkMode` in Tailwind configs
- clean up brand CSS and layout for light/dark support
- style creator components for dark mode

## Testing
- `npm run lint` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68507b795398832cb8bb91345f9bc756