### PR TITLE
Add caption history support

### DIFF
--- a/apps/creator/app/analyze/page.tsx
+++ b/apps/creator/app/analyze/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import PersonaCard, { type PersonaProfile } from "@/components/PersonaCard";
 
 type Persona = PersonaProfile;
@@ -10,6 +10,68 @@ export default function AnalyzePage() {
   const [result, setResult] = useState<Persona | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [history, setHistory] = useState<string[]>([]);
+
+  // Load caption history from localStorage on mount
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const stored = localStorage.getItem("captionHistory");
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) {
+          setHistory(parsed as string[]);
+        }
+      }
+    } catch (err) {
+      console.error("Failed to load caption history", err);
+    }
+  }, []);
+
+  const updateHistory = (newCaptions: string) => {
+    try {
+      const stored = localStorage.getItem("captionHistory");
+      let arr: string[] = stored ? JSON.parse(stored) : [];
+      if (!Array.isArray(arr)) arr = [];
+      arr = arr.filter((c) => c !== newCaptions);
+      arr.unshift(newCaptions);
+      if (arr.length > 5) arr = arr.slice(0, 5);
+      localStorage.setItem("captionHistory", JSON.stringify(arr));
+      setHistory(arr);
+    } catch (err) {
+      console.error("Failed to save caption history", err);
+    }
+  };
+
+  const analyzeCaptions = async (capStr: string) => {
+    const list = capStr
+      .split(/\n+/)
+      .map((c) => c.trim())
+      .filter((c) => c.length > 0);
+    if (list.length === 0) return;
+
+    setLoading(true);
+    setResult(null);
+    setError("");
+
+    updateHistory(capStr);
+
+    try {
+      const res = await fetch("/api/generate", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ captions: list }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Request failed");
+      setResult(data);
+    } catch (err: any) {
+      setError(err.message || "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  };
 
   const handleSave = () => {
     if (!result) return;
@@ -23,36 +85,42 @@ export default function AnalyzePage() {
     }
   };
 
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    analyzeCaptions(captions);
+  };
+
+  const handleReanalyze = (capStr: string) => {
+    setCaptions(capStr);
+    analyzeCaptions(capStr);
+  };
+
   const captionList = captions
     .split(/\n+/)
     .map((c) => c.trim())
     .filter((c) => c.length > 0);
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    setLoading(true);
-    setResult(null);
-    setError("");
-
-    try {
-      const res = await fetch("/api/generate", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ captions: captionList }),
-      });
-
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || "Request failed");
-      setResult(data);
-    } catch (err: any) {
-      setError(err.message || "Something went wrong");
-    } finally {
-      setLoading(false);
-    }
-  };
-
   return (
     <main className="min-h-screen bg-gradient-to-br from-slate-900 via-zinc-800 to-black text-white flex flex-col items-center justify-center p-6 space-y-6">
+      {history.length > 0 && (
+        <div className="w-full max-w-md space-y-2">
+          <h3 className="text-sm font-semibold">Recent Caption Sets</h3>
+          <ul className="space-y-2">
+            {history.map((item, idx) => (
+              <li key={idx}>
+                <button
+                  type="button"
+                  onClick={() => handleReanalyze(item)}
+                  className="w-full text-left bg-white/10 hover:bg-white/20 p-2 rounded-md"
+                >
+                  {item.split("\n")[0]}
+                  {item.split("\n").length > 1 ? " ..." : ""}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
       <form
         onSubmit={handleSubmit}
         className="w-full max-w-md bg-white/5 border border-white/10 rounded-lg p-6 space-y-4 backdrop-blur"


### PR DESCRIPTION
## Summary
- keep recent caption submissions in `localStorage['captionHistory']`
- let creators re-run analysis by clicking previous caption sets

## Testing
- `npm run lint` *(fails: ENETUNREACH while downloading swc)*

------
https://chatgpt.com/codex/tasks/task_e_68507cd3386c832c98d6b06512bdf5a3