### PR TITLE
Add persistent persona storage

### DIFF
--- a/apps/creator/app/analyze/page.tsx
+++ b/apps/creator/app/analyze/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import PersonaCard, { type PersonaProfile } from "@/components/PersonaCard";
 
 type Persona = PersonaProfile;
@@ -10,6 +10,19 @@ export default function AnalyzePage() {
   const [result, setResult] = useState<Persona | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [savedPersona, setSavedPersona] = useState<Persona | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const stored = localStorage.getItem("lastPersonaProfile");
+      if (stored) {
+        setSavedPersona(JSON.parse(stored));
+      }
+    } catch (err) {
+      console.error("Failed to load saved persona", err);
+    }
+  }, []);
 
   const handleSave = () => {
     if (!result) return;
@@ -44,6 +57,12 @@ export default function AnalyzePage() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Request failed");
       setResult(data);
+      try {
+        localStorage.setItem("lastPersonaProfile", JSON.stringify(data));
+        setSavedPersona(data);
+      } catch (err) {
+        console.error("Failed to store persona", err);
+      }
     } catch (err: any) {
       setError(err.message || "Something went wrong");
     } finally {
@@ -74,6 +93,16 @@ export default function AnalyzePage() {
           {loading ? "Analyzing..." : "Analyze"}
         </button>
       </form>
+
+      {!result && savedPersona && (
+        <button
+          type="button"
+          onClick={() => setResult(savedPersona)}
+          className="bg-indigo-600 hover:bg-indigo-700 transition text-white font-semibold py-2 px-4 rounded-md"
+        >
+          View My Saved Persona
+        </button>
+      )}
 
       {error && <p className="text-red-500">{error}</p>}
 

--- a/apps/creator/app/page.tsx
+++ b/apps/creator/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from 'next/image';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import styles from './styles.module.css';
 import ReactMarkdown from "react-markdown";
 
@@ -20,6 +20,19 @@ export default function Home() {
   const [struggles, setStruggles] = useState('');
   const [dreamBrands, setDreamBrands] = useState('');
   const [favFormats, setFavFormats] = useState('');
+  const [savedPersona, setSavedPersona] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      const stored = localStorage.getItem('lastPersona');
+      if (stored) {
+        setSavedPersona(JSON.parse(stored));
+      }
+    } catch (err) {
+      console.error('Failed to load saved persona', err);
+    }
+  }, []);
 
 
 
@@ -61,6 +74,12 @@ export default function Home() {
   
       const data = await res.json();
       setPersona(data.result);
+      try {
+        localStorage.setItem('lastPersona', JSON.stringify(data.result));
+        setSavedPersona(data.result);
+      } catch (err) {
+        console.error('Failed to store persona', err);
+      }
     } catch (error) {
       setPersona("Oops, something went wrong. Please try again.");
     } finally {
@@ -193,6 +212,16 @@ export default function Home() {
 
         <p className={styles.stepIndicator}>Step {step + 1} of {questions.length}</p>
       </form>
+
+      {!persona && savedPersona && (
+        <button
+          type="button"
+          onClick={() => setPersona(savedPersona)}
+          className="bg-indigo-600 hover:bg-indigo-700 transition text-white px-4 py-2 rounded-md"
+        >
+          View My Saved Persona
+        </button>
+      )}
 
       {persona && (
   <div className="prose prose-invert max-w-3xl mx-auto mt-12 flex flex-col items-center gap-4">


### PR DESCRIPTION
## Summary
- persist generated persona string to `localStorage`
- enable reopening last persona on load

## Testing
- `npm --workspace apps/creator run lint` *(fails: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68507cf87b50832ca4410f22b46378e4