### PR TITLE
Improve analyze caption form

### DIFF
--- a/apps/creator/app/analyze/page.tsx
+++ b/apps/creator/app/analyze/page.tsx
@@ -47,7 +47,8 @@ export default function AnalyzePage() {
     const list = capStr
       .split(/\n+/)
       .map((c) => c.trim())
-      .filter((c) => c.length > 0);
+      .filter((c) => c.length > 0)
+      .slice(0, 5);
     if (list.length === 0) return;
 
     setLoading(true);
@@ -125,11 +126,10 @@ export default function AnalyzePage() {
         onSubmit={handleSubmit}
         className="w-full max-w-md bg-white/5 border border-white/10 rounded-lg p-6 space-y-4 backdrop-blur"
       >
-        <label className="block text-sm font-semibold">
-          Paste several recent Instagram captions (one per line):
-        </label>
+        <label className="block text-sm font-semibold">Paste up to 5 captions</label>
         <textarea
           className="w-full h-40 p-3 rounded-md bg-zinc-800 text-white resize-none placeholder-zinc-400"
+          rows={5}
           value={captions}
           onChange={(e) => setCaptions(e.target.value)}
           placeholder={"First caption\nSecond caption"}
@@ -139,11 +139,39 @@ export default function AnalyzePage() {
           className="w-full bg-indigo-600 hover:bg-indigo-700 transition text-white font-semibold py-2 rounded-md disabled:opacity-50"
           disabled={loading || captionList.length === 0}
         >
-          {loading ? "Analyzing..." : "Analyze"}
+          {loading ? (
+            <span className="flex items-center justify-center gap-2">
+              <svg
+                className="animate-spin h-4 w-4 text-white"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="10"
+                  stroke="currentColor"
+                  strokeWidth="4"
+                ></circle>
+                <path
+                  className="opacity-75"
+                  fill="currentColor"
+                  d="M4 12a8 8 0 018-8v8z"
+                ></path>
+              </svg>
+              Analyzing...
+            </span>
+          ) : (
+            "Analyze"
+          )}
         </button>
       </form>
 
-      {error && <p className="text-red-500">{error}</p>}
+      {error && (
+        <p className="text-red-500">Error analyzing captions: {error}</p>
+      )}
 
       {result && (
         <div className="space-y-4 flex flex-col items-center">


### PR DESCRIPTION
## Summary
- limit caption inputs to first 5
- tweak copy to "Paste up to 5 captions"
- use rows attribute for the textarea
- add animated spinner when analyzing
- show an error line if GPT request fails

## Testing
- `npm -w apps/creator run lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68507df0b6b4832cb94d7f56922432dc