### PR TITLE
Add app docs and root scripts

### DIFF
--- a/apps/brand/README.md
+++ b/apps/brand/README.md
@@ -1,36 +1,27 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Brand App
 
-## Getting Started
+This directory contains the Next.js dashboard for brands.
 
-First, run the development server:
+## Setup
+
+1. Install dependencies from the repository root:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm install
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+2. Start the development server:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+npm run dev:brand
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+## Environment variables
 
-## Learn More
+This app does not require any environment variables by default.
 
-To learn more about Next.js, take a look at the following resources:
+## Useful commands
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- `npm run dev:brand` – start the dev server with Turborepo
+- `npm run build -w apps/brand` – create a production build
+- `npm run lint -w apps/brand` – run ESLint

--- a/apps/creator/README.md
+++ b/apps/creator/README.md
@@ -1,36 +1,38 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Creator App
 
-## Getting Started
+This directory contains the Next.js application used by creators.
 
-First, run the development server:
+## Setup
+
+1. Install dependencies from the repository root:
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm install
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+2. Copy the example environment file and provide your values:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+```bash
+cp apps/creator/.env.example apps/creator/.env.local
+```
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+Update `.env.local` with the following variables:
 
-## Learn More
+- `DATABASE_URL` – Prisma database connection
+- `NEXTAUTH_URL` – URL for NextAuth (e.g. `http://localhost:3000`)
+- `NEXTAUTH_SECRET` – session secret for NextAuth
+- `EMAIL_SERVER` – SMTP connection string
+- `EMAIL_FROM` – sender address for authentication emails
+- `OPENAI_API_KEY` – your OpenAI API key
 
-To learn more about Next.js, take a look at the following resources:
+3. Start the development server:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```bash
+npm run dev:creator
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+## Useful commands
 
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+- `npm run dev:creator` – start the dev server
+- `npm run build -w apps/creator` – build for production
+- `npm run lint -w apps/creator` – run ESLint

--- a/package.json
+++ b/package.json
@@ -5,7 +5,13 @@
   "workspaces": ["apps/*", "packages/*"],
   "scripts": {
     "dev": "turbo run dev",
-    "build": "turbo run build"
+    "build": "turbo run build",
+    "dev:creator": "npm run dev -w apps/creator",
+    "dev:brand": "npm run dev -w apps/brand",
+    "build:creator": "npm run build -w apps/creator",
+    "build:brand": "npm run build -w apps/brand",
+    "lint": "turbo run lint",
+    "start": "turbo run start"
   },
   "devDependencies": {
     "turbo": "latest"


### PR DESCRIPTION
## Summary
- document setup for the brand app
- document setup for the creator app
- add dev helper scripts in the root package.json

## Testing
- `npm run lint` *(fails: Found `pipeline` field instead of `tasks`)*

------
https://chatgpt.com/codex/tasks/task_e_6850872d9aec832c924eda598f4ebe66