### PR TITLE
Add brand dashboard search

### DIFF
--- a/apps/brand/README.md
+++ b/apps/brand/README.md
@@ -25,3 +25,7 @@ This app does not require any environment variables by default.
 - `npm run dev:brand` – start the dev server with Turborepo
 - `npm run build -w apps/brand` – create a production build
 - `npm run lint -w apps/brand` – run ESLint
+
+## Dashboard
+
+Visit `/dashboard` in the brand app to search saved creator personas. You can filter by niche, tone and platform. Matches are shown using the `CreatorCard` component.

--- a/apps/brand/src/app/dashboard/page.tsx
+++ b/apps/brand/src/app/dashboard/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import CreatorCard from "@/components/CreatorCard";
+import { creators as mockCreators, type Creator } from "@/app/data/creators";
+
+export default function Dashboard() {
+  const [creators, setCreators] = useState<Creator[]>([]);
+  const [niche, setNiche] = useState("");
+  const [tone, setTone] = useState("");
+  const [platform, setPlatform] = useState("");
+  const [filtered, setFiltered] = useState<Creator[]>([]);
+
+  // load creators from localStorage if available, otherwise use mock data
+  useEffect(() => {
+    let stored: Creator[] | null = null;
+    if (typeof window !== "undefined") {
+      const local = localStorage.getItem("personas");
+      if (local) {
+        try {
+          stored = JSON.parse(local) as Creator[];
+        } catch {
+          stored = null;
+        }
+      }
+    }
+    setCreators(stored || mockCreators);
+  }, []);
+
+  // apply filters whenever options change
+  useEffect(() => {
+    let result = creators;
+    if (niche) {
+      result = result.filter((c) =>
+        c.niche.toLowerCase().includes(niche.toLowerCase())
+      );
+    }
+    if (tone) {
+      result = result.filter((c) =>
+        c.tone.toLowerCase().includes(tone.toLowerCase())
+      );
+    }
+    if (platform) {
+      result = result.filter((c) =>
+        c.platform.toLowerCase().includes(platform.toLowerCase())
+      );
+    }
+    setFiltered(result);
+  }, [niche, tone, platform, creators]);
+
+  return (
+    <div className="p-8 space-y-6">
+      <h1 className="text-2xl font-semibold">Creator Personas</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <input
+          className="p-2 border rounded bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white border-gray-300 dark:border-Siora-border"
+          placeholder="Niche"
+          value={niche}
+          onChange={(e) => setNiche(e.target.value)}
+        />
+        <input
+          className="p-2 border rounded bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white border-gray-300 dark:border-Siora-border"
+          placeholder="Tone"
+          value={tone}
+          onChange={(e) => setTone(e.target.value)}
+        />
+        <input
+          className="p-2 border rounded bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white border-gray-300 dark:border-Siora-border"
+          placeholder="Platform"
+          value={platform}
+          onChange={(e) => setPlatform(e.target.value)}
+        />
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {filtered.map((creator) => (
+          <CreatorCard key={creator.id} creator={creator} />
+        ))}
+        {filtered.length === 0 && (
+          <p className="col-span-full text-center text-gray-500 dark:text-zinc-400">No personas found.</p>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `/dashboard` page in brand app
- use localStorage or mock personas to filter by niche, tone and platform
- show results with existing `CreatorCard`
- document dashboard usage in brand README

## Testing
- `npm run lint -w apps/brand`


------
https://chatgpt.com/codex/tasks/task_e_685088b17bc4832c937302f9c5133633