### PR TITLE
Improve dark theme styling for creator flow

### DIFF
--- a/apps/creator/app/caption-insights/page.tsx
+++ b/apps/creator/app/caption-insights/page.tsx
@@ -40,7 +40,7 @@ export default function CaptionInsightsPage() {
   };
 
   return (
-    <main className="min-h-screen bg-gradient-to-br from-slate-900 via-zinc-800 to-black text-white flex flex-col items-center justify-center p-6 space-y-6">
+    <main className="min-h-screen bg-gradient-to-br from-slate-900 via-zinc-800 to-black text-white flex flex-col items-center justify-center p-6 md:p-10 space-y-6">
       <form
         onSubmit={handleSubmit}
         className="w-full max-w-md bg-white/5 border border-white/10 rounded-lg p-6 space-y-4 backdrop-blur"
@@ -55,7 +55,7 @@ export default function CaptionInsightsPage() {
         />
         <button
           type="submit"
-          className="w-full bg-indigo-600 hover:bg-indigo-700 transition text-white font-semibold py-2 rounded-md disabled:opacity-50"
+          className="w-full bg-indigo-600 hover:bg-indigo-500 transition-colors duration-200 text-white font-semibold py-2 rounded-md disabled:opacity-50"
           disabled={loading || captionList.length < 3}
         >
           {loading ? (

--- a/apps/creator/app/page.tsx
+++ b/apps/creator/app/page.tsx
@@ -203,13 +203,13 @@ export default function Home() {
             </button>
           )}
           {step < questions.length - 1 ? (
-  <button type="button" onClick={() => setStep(step + 1)} className="bg-zinc-700 text-white px-4 py-2 rounded-md">
+  <button type="button" onClick={() => setStep(step + 1)} className="bg-zinc-700 hover:bg-zinc-600 transition-colors duration-200 text-white px-4 py-2 rounded-md">
     Next
   </button>
 ) : (
   <button
     type="submit"
-    className="bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 transition disabled:opacity-50"
+    className="bg-indigo-600 hover:bg-indigo-500 transition-colors duration-200 text-white px-4 py-2 rounded-md disabled:opacity-50"
     disabled={
       !handle || !niche || !audience || !goal || !tone || !platforms || isLoading ||
       (advancedMode && (!struggles || !dreamBrands || !favFormats))
@@ -243,7 +243,7 @@ export default function Home() {
         <button
           type="button"
           onClick={() => setPersona(storedPersona)}
-          className="mt-4 bg-blue-600 hover:bg-blue-700 transition text-white font-semibold py-2 px-4 rounded-md"
+          className="mt-4 bg-blue-600 hover:bg-blue-500 transition-colors duration-200 text-white font-semibold py-2 px-4 rounded-md"
         >
           View My Saved Persona
         </button>
@@ -251,12 +251,12 @@ export default function Home() {
 
 
       {persona && (
-  <div ref={resultRef} className="prose prose-invert max-w-3xl mx-auto mt-12 flex flex-col items-center gap-4">
+  <div ref={resultRef} className="prose prose-invert max-w-3xl mx-auto mt-12 flex flex-col items-center gap-4 border border-white/10 bg-background p-6 sm:p-8 rounded-xl">
     <ReactMarkdown>{persona}</ReactMarkdown>
     <button
       type="button"
       onClick={handleSave}
-      className="bg-green-600 hover:bg-green-700 transition text-white font-semibold py-2 px-4 rounded-md"
+      className="bg-green-600 hover:bg-green-500 transition-colors duration-200 text-white font-semibold py-2 px-4 rounded-md"
     >
       Save Persona
     </button>

--- a/apps/creator/app/persona/[id]/page.tsx
+++ b/apps/creator/app/persona/[id]/page.tsx
@@ -84,7 +84,7 @@ export default function PersonaPage() {
   };
 
   return (
-    <main className="min-h-screen bg-background text-foreground p-6 flex flex-col items-center gap-6 md:flex-row md:items-start">
+    <main className="min-h-screen bg-background text-foreground p-6 sm:p-10 flex flex-col items-center gap-6 sm:gap-8 md:flex-row md:items-start">
       {profile ? (
         <>
           <PersonaCard profile={profile} />
@@ -92,7 +92,7 @@ export default function PersonaPage() {
           <button
             type="button"
             onClick={handleCopy}
-            className="bg-indigo-600 hover:bg-indigo-700 transition text-white font-semibold py-2 px-4 rounded-md"
+            className="bg-indigo-600 hover:bg-indigo-500 transition-colors duration-200 text-white font-semibold py-2 px-4 rounded-md"
           >
             Copy link
           </button>

--- a/apps/creator/app/personas/page.tsx
+++ b/apps/creator/app/personas/page.tsx
@@ -13,7 +13,7 @@ export default function PersonasPage() {
   }, []);
 
   return (
-    <main className="min-h-screen bg-background text-foreground p-6 space-y-6">
+    <main className="min-h-screen bg-background text-foreground p-6 sm:p-10 space-y-6">
       <h1 className="text-2xl font-bold">My Personas</h1>
       {items.length === 0 ? (
         <p className="text-foreground/60">No saved personas found.</p>

--- a/apps/creator/app/saved-personas/page.tsx
+++ b/apps/creator/app/saved-personas/page.tsx
@@ -25,7 +25,7 @@ export default function SavedPersonasPage() {
   }, []);
 
   return (
-    <main className="min-h-screen bg-background text-foreground p-6 space-y-6">
+    <main className="min-h-screen bg-background text-foreground p-6 sm:p-10 space-y-6">
       <h1 className="text-2xl font-bold">Saved Personas</h1>
       {profiles.length === 0 ? (
         <p className="text-foreground/60">No saved personas found.</p>

--- a/apps/creator/app/styles.module.css
+++ b/apps/creator/app/styles.module.css
@@ -24,6 +24,15 @@
     font-size: 0.875rem;
   }
 }
+
+@media (min-width: 768px) {
+  .wrapper {
+    padding: 4rem;
+  }
+  .formBox {
+    padding: 3rem;
+  }
+}
   
   .logoWrapper {
     text-align: center;
@@ -48,7 +57,7 @@
   
   .formBox {
     background-color: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.15);
     border-radius: 12px;
     padding: 2rem;
     max-width: 500px;
@@ -93,7 +102,7 @@
     padding: 0.6rem 1.2rem;
     border-radius: 8px;
     cursor: pointer;
-    transition: background-color 0.3s ease;
+    transition: background-color 0.2s ease;
   }
   
   .navButton:hover {

--- a/apps/creator/components/InsightsSidebar.tsx
+++ b/apps/creator/components/InsightsSidebar.tsx
@@ -4,7 +4,7 @@ export default function InsightsSidebar({ profile }: { profile: PersonaProfile }
   if (!profile) return null;
 
   return (
-    <aside className="border border-gray-300 dark:border-zinc-700 p-4 rounded-xl shadow-md bg-white text-black dark:bg-zinc-800 dark:text-white space-y-2 w-full max-w-xs">
+    <aside className="border border-white/10 bg-background text-foreground p-4 sm:p-6 rounded-xl shadow-sm space-y-2 w-full max-w-xs">
       <h3 className="text-lg font-bold">Insights</h3>
       <div>
         <span className="font-semibold">Posting:</span> {profile.postingFrequency ?? 'N/A'}

--- a/apps/creator/components/PersonaCard.tsx
+++ b/apps/creator/components/PersonaCard.tsx
@@ -2,7 +2,7 @@ import { PersonaProfile } from '../types/persona'
 
 export default function PersonaCard({ profile }: { profile: PersonaProfile }) {
   return (
-    <div className="border border-gray-300 dark:border-zinc-700 p-4 rounded-xl shadow-md bg-white text-black dark:bg-zinc-800 dark:text-white space-y-2">
+    <div className="border border-white/10 bg-background text-foreground p-4 sm:p-6 rounded-xl shadow-sm space-y-2">
       <h2 className="text-xl font-bold">{profile.name}</h2>
       <p className="italic">{profile.personality}</p>
       <div className="flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- refine the creator onboarding layout
- polish persona cards with new dark theme classes
- tweak insights sidebar styling
- enhance caption insights page and persona detail page
- add responsive spacing in styles module

## Testing
- `npm run lint -w apps/creator`

------
https://chatgpt.com/codex/tasks/task_e_68508a561328832c89b8b1108a22a497