### PR TITLE
Add persona slug page

### DIFF
--- a/apps/brand/app/data/creators.ts
+++ b/apps/brand/app/data/creators.ts
@@ -9,6 +9,7 @@ export type Creator = {
   engagementRate: number;
   tags: string[];
   tone: string;
+  markdown?: string;
 };
 
 export const creators = [

--- a/apps/brand/components/CreatorCard.tsx
+++ b/apps/brand/components/CreatorCard.tsx
@@ -23,10 +23,10 @@ export default function CreatorCard({ creator }: { creator: Creator }) {
     <span>{creator.engagementRate}% ER</span>
   </div>
   <Link
-    href={`/creator/${creator.id}`}
+    href={`/dashboard/persona/${creator.handle.replace(/^@/, "")}`}
     className="inline-block text-sm mt-4 text-Siora-accent underline hover:text-indigo-400"
   >
-    View Profile
+    View
   </Link>
 </motion.div>
   );

--- a/apps/brand/src/app/dashboard/persona/[slug]/page.tsx
+++ b/apps/brand/src/app/dashboard/persona/[slug]/page.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import ReactMarkdown from "react-markdown";
+import { creators } from "@/app/data/creators";
+
+export default function PersonaPage() {
+  const params = useParams();
+  const slugParam = typeof params.slug === "string" ? params.slug : Array.isArray(params.slug) ? params.slug[0] : "";
+
+  const persona = creators.find(
+    (c) => c.handle.replace(/^@/, "").toLowerCase() === slugParam.toLowerCase()
+  );
+
+  if (!persona) {
+    return <main className="p-8 text-center">Persona not found.</main>;
+  }
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 sm:p-10">
+      <div className="prose max-w-none dark:prose-invert">
+        <ReactMarkdown>{persona.markdown}</ReactMarkdown>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- link CreatorCard to new persona page
- type Creator includes optional markdown
- show persona markdown at `/dashboard/persona/[slug]`

## Testing
- `npm run lint -w apps/brand`
- `npm run build -w apps/brand` *(fails: tailwind postcss plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_68508bfbc3f0832ca78e798b763dc1e7