### PR TITLE
Add brand pitch generator

### DIFF
--- a/apps/creator/app/api/pitch/route.ts
+++ b/apps/creator/app/api/pitch/route.ts
@@ -1,0 +1,68 @@
+import type { PitchResult } from "@/types/pitch";
+
+export async function POST(req: Request) {
+  try {
+    const { persona, brand } = await req.json();
+    if (!brand || typeof brand !== "string") {
+      return new Response(
+        JSON.stringify({ error: "Brand name is required" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    if (!persona || typeof persona !== "object") {
+      return new Response(
+        JSON.stringify({ error: "Persona data is required" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const messages = [
+      {
+        role: "system",
+        content: [
+          "You craft short brand collaboration pitches for creators.",
+          "Given the creator persona and target brand, explain briefly why the fit makes sense and then provide a copy-paste pitch email.",
+          "Respond ONLY with JSON that matches this TypeScript interface:",
+          "{ reasoning: string; pitch: string }",
+        ].join(" \n"),
+      },
+      {
+        role: "user",
+        content: `Persona: ${JSON.stringify(persona)}\nBrand: ${brand}`,
+      },
+    ];
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({ model: "gpt-4", messages, temperature: 0.7 }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return new Response(
+        JSON.stringify({ error: "OpenAI error", details: errorText }),
+        { status: response.status, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const data = await response.json();
+    const content = data.choices?.[0]?.message?.content ?? "{}";
+    const pitch: PitchResult = JSON.parse(content);
+
+    return new Response(JSON.stringify(pitch), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    console.error("Unexpected error:", error);
+    return new Response(
+      JSON.stringify({ error: "Unexpected error", details: message }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+}

--- a/apps/creator/app/pitch/page.tsx
+++ b/apps/creator/app/pitch/page.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { loadPersonasFromLocal, StoredPersona } from "@/lib/localPersonas";
+import type { PitchResult } from "@/types/pitch";
+
+export default function PitchPage() {
+  const [personas, setPersonas] = useState<StoredPersona[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [brand, setBrand] = useState("");
+  const [result, setResult] = useState<PitchResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setPersonas(loadPersonasFromLocal());
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!personas[selectedIndex]) return;
+
+    setLoading(true);
+    setError("");
+    setResult(null);
+
+    try {
+      const res = await fetch("/api/pitch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ persona: personas[selectedIndex].persona, brand }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Request failed");
+      setResult(data as PitchResult);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Something went wrong";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const copyPitch = () => {
+    if (!result) return;
+    navigator.clipboard.writeText(result.pitch).catch(() => {});
+  };
+
+  if (personas.length === 0) {
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-background text-foreground p-6">
+        <p>No saved personas found. Generate one first.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 space-y-6 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold">Brand Pitch Generator</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 border border-white/10 p-4 rounded-md">
+        <div>
+          <label className="block text-sm font-semibold mb-1">Select Persona</label>
+          <select
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={selectedIndex}
+            onChange={(e) => setSelectedIndex(parseInt(e.target.value, 10))}
+          >
+            {personas.map((p, idx) => (
+              <option key={idx} value={idx}>
+                {(p.persona as { name?: string }).name || `Persona ${idx + 1}`}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-semibold mb-1">Brand Name</label>
+          <input
+            type="text"
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={brand}
+            onChange={(e) => setBrand(e.target.value)}
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          className="bg-indigo-600 hover:bg-indigo-500 transition-colors duration-200 text-white px-4 py-2 rounded-md disabled:opacity-50"
+          disabled={loading || !brand}
+        >
+          {loading ? "Generating..." : "Generate Pitch"}
+        </button>
+      </form>
+
+      {error && <p className="text-red-500">{error}</p>}
+
+      {result && (
+        <div className="space-y-4 border border-white/10 p-4 rounded-md">
+          <h2 className="text-lg font-semibold">Why You&apos;re a Fit</h2>
+          <p className="text-sm text-foreground/80">{result.reasoning}</p>
+          <h2 className="text-lg font-semibold">Pitch</h2>
+          <pre className="whitespace-pre-wrap bg-zinc-800 text-white p-3 rounded-md text-sm">{result.pitch}</pre>
+          <button
+            type="button"
+            onClick={copyPitch}
+            className="bg-green-600 hover:bg-green-500 transition-colors duration-200 text-white px-4 py-2 rounded-md"
+          >
+            Copy Pitch
+          </button>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/creator/types/pitch.ts
+++ b/apps/creator/types/pitch.ts
@@ -1,0 +1,4 @@
+export type PitchResult = {
+  reasoning: string;
+  pitch: string;
+};


### PR DESCRIPTION
## Summary
- add `PitchResult` type for GPT response
- create `/api/pitch` endpoint to generate a brand pitch using a saved persona
- add UI under `/pitch` to select a persona and request a pitch from GPT

## Testing
- `npm run lint -w apps/creator`

------
https://chatgpt.com/codex/tasks/task_e_68508f79174c832caf3aba3e40aa8a03