### PR TITLE
Add PersonaInsights component and dashboard

### DIFF
--- a/apps/creator/app/dashboard/page.tsx
+++ b/apps/creator/app/dashboard/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { useEffect, useState } from "react";
+import PersonaInsights from "@/components/PersonaInsights";
+import { loadPersonasFromLocal, StoredPersona } from "@/lib/localPersonas";
+import type { FullPersona } from "@/types/persona";
+
+export default function DashboardPage() {
+  const [items, setItems] = useState<StoredPersona[]>([]);
+
+  useEffect(() => {
+    setItems(loadPersonasFromLocal());
+  }, []);
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 sm:p-10 space-y-6">
+      <h1 className="text-2xl font-bold">Dashboard</h1>
+      {items.length === 0 ? (
+        <p className="text-foreground/60">No personas found.</p>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {items.map((item, idx) => (
+            <div key={idx} className="space-y-2">
+              <PersonaInsights persona={item.persona as FullPersona} />
+              <p className="text-xs text-foreground/60">
+                {new Date(item.timestamp).toLocaleString()}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/creator/components/PersonaInsights.tsx
+++ b/apps/creator/components/PersonaInsights.tsx
@@ -1,0 +1,39 @@
+import type { FullPersona } from '../types/persona'
+
+export default function PersonaInsights({ persona }: { persona: FullPersona }) {
+  const { name, summary, vibe, tone, goals, interests, platforms } = persona
+
+  const tag = (label: string, value?: string) =>
+    value ? (
+      <span className="px-2 py-1 rounded-full text-sm text-white" style={{ backgroundColor: '#6366f1' }}>
+        {label}: {value}
+      </span>
+    ) : null
+
+  return (
+    <div className="border border-white/10 bg-background text-foreground p-4 rounded-xl space-y-3">
+      <h2 className="text-lg font-bold">{name}</h2>
+      <p className="text-sm text-foreground/80">{summary}</p>
+      <div className="flex flex-wrap gap-2">
+        {tag('Vibe', vibe)}
+        {tag('Tone', tone)}
+        {goals && goals.map((g, i) => (
+          <span key={i} className="px-2 py-1 bg-green-200 text-green-800 rounded-full text-sm">
+            {g}
+          </span>
+        ))}
+        {interests &&
+          interests.map((interest, idx) => (
+            <span key={`i-${idx}`} className="px-2 py-1 bg-indigo-100 text-indigo-700 rounded-full text-sm">
+              {interest}
+            </span>
+          ))}
+        {platforms && platforms.map((p, i) => (
+          <span key={`p-${i}`} className="px-2 py-1 bg-pink-100 text-pink-700 rounded-full text-sm">
+            {p}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/creator/types/persona.ts
+++ b/apps/creator/types/persona.ts
@@ -8,3 +8,10 @@ export type PersonaProfile = {
   brandFit?: string
   growthSuggestions?: string
 }
+
+export interface FullPersona extends PersonaProfile {
+  vibe?: string;
+  tone?: string;
+  goals?: string[];
+  platforms?: string[];
+}


### PR DESCRIPTION
## Summary
- add `FullPersona` type describing vibe, tone, goals and platforms
- create `PersonaInsights` component for rendering persona summary with colored tags
- implement `/dashboard` route to list stored personas using the new component

## Testing
- `npm run lint -w apps/creator`

------
https://chatgpt.com/codex/tasks/task_e_68508f6fa66c832c90a82ee93bb4e6c4