### PR TITLE
Add database-backed persona API

### DIFF
--- a/apps/creator/app/api/personas/[id]/route.ts
+++ b/apps/creator/app/api/personas/[id]/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions, prisma } from '@/lib/auth'
+
+interface Params {
+  params: { id: string }
+}
+
+export async function GET(_req: Request, { params }: Params) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const persona = await prisma.persona.findFirst({
+    where: { id: params.id, userId: session.user.id }
+  })
+
+  if (!persona) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  return NextResponse.json(persona)
+}
+
+export async function PUT(req: Request, { params }: Params) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const { title, persona } = await req.json()
+  const updated = await prisma.persona.updateMany({
+    where: { id: params.id, userId: session.user.id },
+    data: {
+      ...(title && { title }),
+      ...(persona && { data: persona })
+    }
+  })
+
+  if (updated.count === 0) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const result = await prisma.persona.findUnique({ where: { id: params.id } })
+  return NextResponse.json(result)
+}
+
+export async function DELETE(_req: Request, { params }: Params) {
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const deleted = await prisma.persona.deleteMany({
+    where: { id: params.id, userId: session.user.id }
+  })
+
+  if (deleted.count === 0) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({ success: true })
+}
+

--- a/apps/creator/app/api/personas/route.ts
+++ b/apps/creator/app/api/personas/route.ts
@@ -1,40 +1,40 @@
-import { promises as fs } from 'fs';
-import { join } from 'path';
-import { NextResponse } from 'next/server';
-
-const PERSONAS_DIR = join(process.cwd(), '..', '..', 'data', 'personas');
-
-async function readPersonas(): Promise<Record<string, unknown>[]> {
-  try {
-    await fs.mkdir(PERSONAS_DIR, { recursive: true });
-    const files = await fs.readdir(PERSONAS_DIR);
-    const personas: Record<string, unknown>[] = [];
-    for (const f of files) {
-      if (f.endsWith('.json')) {
-        const content = await fs.readFile(join(PERSONAS_DIR, f), 'utf8');
-        personas.push(JSON.parse(content));
-      }
-    }
-    return personas;
-  } catch {
-    return [];
-  }
-}
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions, prisma } from '@/lib/auth'
 
 export async function GET() {
-  const personas = await readPersonas();
-  return NextResponse.json(personas);
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return new NextResponse('Unauthorized', { status: 401 })
+  }
+
+  const personas = await prisma.persona.findMany({
+    where: { userId: session.user.id },
+    orderBy: { createdAt: 'desc' }
+  })
+
+  return NextResponse.json(personas)
 }
 
 export async function POST(req: Request) {
-  const { title, persona } = await req.json();
-  if (!title || !persona) {
-    return NextResponse.json({ error: 'Missing title or persona' }, { status: 400 });
+  const session = await getServerSession(authOptions)
+  if (!session?.user?.id) {
+    return new NextResponse('Unauthorized', { status: 401 })
   }
-  await fs.mkdir(PERSONAS_DIR, { recursive: true });
-  const iso = new Date().toISOString();
-  const datePart = iso.slice(0, 10).replace(/-/g, '');
-  const filePath = join(PERSONAS_DIR, `persona-${datePart}.json`);
-  await fs.writeFile(filePath, JSON.stringify({ title, persona, timestamp: iso }, null, 2), 'utf8');
-  return NextResponse.json({ success: true });
+
+  const { title, persona } = await req.json()
+  if (!title || !persona) {
+    return NextResponse.json({ error: 'Missing title or persona' }, { status: 400 })
+  }
+
+  const result = await prisma.persona.create({
+    data: {
+      title,
+      data: persona,
+      userId: session.user.id
+    }
+  })
+
+  return NextResponse.json(result)
 }
+

--- a/apps/creator/prisma/schema.prisma
+++ b/apps/creator/prisma/schema.prisma
@@ -16,6 +16,7 @@ model User {
   image         String?
   accounts      Account[]
   sessions      Session[]
+  personas      Persona[]
 }
 
 model Account {
@@ -50,4 +51,17 @@ model VerificationToken {
   expires    DateTime
 
   @@unique([identifier, token])
+}
+
+model Persona {
+  id        String   @id @default(cuid())
+  userId    String
+  title     String
+  data      Json
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
 }


### PR DESCRIPTION
## Summary
- switch persona endpoint to use Prisma database
- add dynamic routes for updating/deleting individual personas
- expand Prisma schema with `Persona` model linked to `User`

## Testing
- `npm run lint -w apps/creator`
- `npm run build -w apps/creator` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_685091445fb0832cb2c5870e0ac7004d