### PR TITLE
Add magic link auth with NextAuth

### DIFF
--- a/apps/creator/README.md
+++ b/apps/creator/README.md
@@ -31,6 +31,11 @@ Update `.env.local` with the following variables:
 npm run dev:creator
 ```
 
+## Authentication
+
+Magic link sign-in is handled with [NextAuth.js](https://next-auth.js.org/).
+Configure `EMAIL_SERVER` and `EMAIL_FROM` then visit `/signin` to request your login link.
+
 ## Useful commands
 
 - `npm run dev:creator` – start the dev server

--- a/apps/creator/app/signin/page.tsx
+++ b/apps/creator/app/signin/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+import { signIn } from "next-auth/react";
+import { useState } from "react";
+
+export default function SignInPage() {
+  const [email, setEmail] = useState("");
+  const [sent, setSent] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+    const res = await signIn("email", { email, redirect: false });
+    if (res?.error) {
+      setError(res.error);
+    } else {
+      setSent(true);
+    }
+  };
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center bg-background text-foreground p-6">
+      {sent ? (
+        <p>Check your email for the login link.</p>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4 max-w-sm w-full">
+          <h1 className="text-xl font-semibold text-center">Sign in</h1>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            placeholder="you@example.com"
+            className="w-full p-2 rounded-md border bg-background"
+          />
+          <button
+            type="submit"
+            className="w-full bg-indigo-600 hover:bg-indigo-500 transition-colors text-white py-2 rounded-md"
+          >
+            Send Magic Link
+          </button>
+          {error && <p className="text-red-500 text-sm text-center">{error}</p>}
+        </form>
+      )}
+    </main>
+  );
+}

--- a/apps/creator/lib/auth.ts
+++ b/apps/creator/lib/auth.ts
@@ -13,8 +13,19 @@ export const authOptions: NextAuthOptions = {
       from: process.env.EMAIL_FROM,
     }),
   ],
+  pages: {
+    signIn: "/signin",
+  },
   session: {
     strategy: "database",
+  },
+  callbacks: {
+    async session({ session, user }) {
+      if (session.user) {
+        (session.user as { id?: string }).id = user.id;
+      }
+      return session;
+    },
   },
 };
 

--- a/apps/creator/types/next-auth.d.ts
+++ b/apps/creator/types/next-auth.d.ts
@@ -1,0 +1,7 @@
+import NextAuth, { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session extends DefaultSession {
+    user?: DefaultSession["user"] & { id: string };
+  }
+}


### PR DESCRIPTION
## Summary
- add a `/signin` page for requesting email magic links
- extend NextAuth config to use the new sign-in page and expose `user.id`
- augment session type with user id
- document how to sign in with a magic link

## Testing
- `npm run lint -w apps/creator`
- `npm run build -w apps/creator` *(fails: Cannot find module '../lightningcss.linux-x64-gnu.node')*

------
https://chatgpt.com/codex/tasks/task_e_6850998430a8832c89e61cd5aec9eb61