### PR TITLE
Add public persona route

### DIFF
--- a/apps/creator/app/p/[id]/page.tsx
+++ b/apps/creator/app/p/[id]/page.tsx
@@ -1,0 +1,76 @@
+import PersonaCard from '@/components/PersonaCard';
+import InsightsSidebar from '@/components/InsightsSidebar';
+import CopyLinkButton from '@/components/CopyLinkButton';
+import { prisma } from '@/lib/auth';
+import type { PersonaProfile } from '@/types/persona';
+
+interface PageParams {
+  params: { id: string };
+}
+
+const computeBrandFit = (interests: string[]): string => {
+  const lower = interests.map((i) => i.toLowerCase());
+  const fitness = ['fitness', 'workout', 'health', 'wellness'];
+  const fashion = ['fashion', 'style', 'beauty', 'clothing'];
+  if (lower.some((i) => fitness.some((k) => i.includes(k)))) return 'fitness';
+  if (lower.some((i) => fashion.some((k) => i.includes(k)))) return 'fashion';
+  return 'business';
+};
+
+const computePostingFrequency = (fit: string): string => {
+  switch (fit) {
+    case 'fitness':
+      return '5 posts/week';
+    case 'fashion':
+      return '3 posts/week';
+    case 'business':
+      return '2 posts/week';
+    default:
+      return '3 posts/week';
+  }
+};
+
+const computeGrowthSuggestions = (fit: string): string => {
+  switch (fit) {
+    case 'fitness':
+      return 'Share workout tips daily and track progress with before/after posts.';
+    case 'fashion':
+      return 'Post seasonal lookbooks and tag the brands you wear.';
+    case 'business':
+      return 'Publish case studies and network on LinkedIn.';
+    default:
+      return 'Collaborate with peers and experiment with short-form video.';
+  }
+};
+
+const ensureInsights = (p: PersonaProfile): PersonaProfile => {
+  const fit = p.brandFit ?? computeBrandFit(p.interests ?? []);
+  return {
+    ...p,
+    brandFit: fit,
+    postingFrequency: p.postingFrequency ?? computePostingFrequency(fit),
+    growthSuggestions: p.growthSuggestions ?? computeGrowthSuggestions(fit),
+    toneConfidence: p.toneConfidence ?? 75,
+  };
+};
+
+export default async function PublicPersonaPage({ params }: PageParams) {
+  const persona = await prisma.persona.findUnique({ where: { id: params.id } });
+  if (!persona) {
+    return <main className="p-6">Persona not found.</main>;
+  }
+
+  const profile = ensureInsights(persona.data as PersonaProfile);
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 sm:p-10 space-y-6">
+      <div className="flex flex-col items-center gap-6 sm:gap-8 md:flex-row md:items-start">
+        <PersonaCard profile={profile} />
+        <InsightsSidebar profile={profile} />
+      </div>
+      <div>
+        <CopyLinkButton />
+      </div>
+    </main>
+  );
+}

--- a/apps/creator/app/persona/[id]/page.tsx
+++ b/apps/creator/app/persona/[id]/page.tsx
@@ -6,6 +6,7 @@ import { PDFDownloadLink } from "@react-pdf/renderer";
 import PersonaCard from "@/components/PersonaCard";
 import InsightsSidebar from "@/components/InsightsSidebar";
 import PersonaPDF from "@/components/PersonaPDF";
+import CopyLinkButton from "@/components/CopyLinkButton";
 import type { PersonaProfile } from "@/types/persona";
 
 export default function PersonaPage() {
@@ -78,12 +79,6 @@ export default function PersonaPage() {
     }
   }, [idParam]);
 
-  const handleCopy = () => {
-    if (typeof window === "undefined") return;
-    navigator.clipboard.writeText(window.location.href).catch((err) => {
-      console.error("Failed to copy", err);
-    });
-  };
 
   const toMarkdown = (p: PersonaProfile): string => {
     return `# ${p.name}\n\n` +
@@ -142,13 +137,7 @@ export default function PersonaPage() {
                 </button>
               )}
             </PDFDownloadLink>
-            <button
-              type="button"
-              onClick={handleCopy}
-              className="bg-indigo-600 hover:bg-indigo-500 transition-colors duration-200 text-white font-semibold py-2 px-4 rounded-md"
-            >
-              Copy link
-            </button>
+            <CopyLinkButton />
           </div>
         </>
       ) : (

--- a/apps/creator/components/CopyLinkButton.tsx
+++ b/apps/creator/components/CopyLinkButton.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+export default function CopyLinkButton() {
+  const handleCopy = () => {
+    if (typeof window === 'undefined') return;
+    navigator.clipboard.writeText(window.location.href).catch((err) => {
+      console.error('Failed to copy', err);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="bg-indigo-600 hover:bg-indigo-500 transition-colors duration-200 text-white font-semibold py-2 px-4 rounded-md"
+    >
+      Copy link
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- render personas server-side at `/p/[id]`
- share links via new `CopyLinkButton`
- refactor persona page to use the new copy button

## Testing
- `npm run lint` *(fails: Found `pipeline` field instead of `tasks`)*

------
https://chatgpt.com/codex/tasks/task_e_685099a21edc832cbaf3b47fe2e623b6