### PR TITLE
Add brand login and shortlist

### DIFF
--- a/apps/brand/README.md
+++ b/apps/brand/README.md
@@ -28,6 +28,6 @@ This app does not require any environment variables by default.
 
 ## Dashboard
 
-Visit `/dashboard` in the brand app to search saved creator personas. You can filter by niche, tone and platform. Matches are shown using the `CreatorCard` component.
+Visit `/signin` to log in. After signing in, head to `/brands` to search creator personas. Results can be filtered by tone, platform and vibe. Each profile can be saved to your personal shortlist which is stored in your browser.
 
-Visit `/personas` to search personas by tone, platform or vibe.
+`/dashboard` and `/personas` remain available for exploring personas without authentication.

--- a/apps/brand/app/brands/page.tsx
+++ b/apps/brand/app/brands/page.tsx
@@ -1,15 +1,30 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import personas from "@/app/data/mock_creators_200.json";
 import PersonaCard from "@/components/PersonaCard";
+import { useAuth } from "@/lib/auth";
+import { useShortlist } from "@/lib/shortlist";
 
 type Persona = (typeof personas)[number];
 
 export default function BrandsDashboard() {
+  const { user } = useAuth();
+  const router = useRouter();
+  const { toggle, inShortlist } = useShortlist(user);
+
   const [tone, setTone] = useState("");
   const [platform, setPlatform] = useState("");
   const [vibe, setVibe] = useState("");
+
+  useEffect(() => {
+    if (!user) router.replace('/signin');
+  }, [user, router]);
+
+  if (!user) {
+    return null;
+  }
 
   const filtered = personas.filter((p: Persona) => {
     const matchTone = !tone || p.tone.toLowerCase().includes(tone.toLowerCase());
@@ -53,7 +68,12 @@ export default function BrandsDashboard() {
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             {filtered.map((p: Persona) => (
-              <PersonaCard key={p.id} persona={p} />
+              <PersonaCard
+                key={p.id}
+                persona={p}
+                onToggle={toggle}
+                inShortlist={inShortlist(p.id)}
+              />
             ))}
           </div>
         )}

--- a/apps/brand/app/layout.tsx
+++ b/apps/brand/app/layout.tsx
@@ -1,11 +1,14 @@
 import './globals.css';
 import type { ReactNode } from 'react';
+import { AuthProvider } from '@/lib/auth';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body className="bg-white text-black dark:bg-Siora-dark dark:text-white font-sans antialiased min-h-screen">
-        <main className="max-w-7xl mx-auto px-6 sm:px-8 py-10">{children}</main>
+        <AuthProvider>
+          <main className="max-w-7xl mx-auto px-6 sm:px-8 py-10">{children}</main>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/apps/brand/app/signin/page.tsx
+++ b/apps/brand/app/signin/page.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "@/lib/auth";
+
+export default function SignInPage() {
+  const { signIn } = useAuth();
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+
+  const handle = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email) return;
+    signIn(email);
+    router.push("/brands");
+  };
+
+  return (
+    <main className="min-h-screen flex items-center justify-center">
+      <form onSubmit={handle} className="space-y-4 bg-Siora-mid p-6 rounded-xl">
+        <h1 className="text-xl font-bold text-white">Brand Sign In</h1>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="email"
+          className="w-full p-2 rounded text-black"
+        />
+        <button
+          type="submit"
+          className="bg-Siora-accent text-white px-4 py-2 rounded w-full"
+        >
+          Sign In
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/apps/brand/components/PersonaCard.tsx
+++ b/apps/brand/components/PersonaCard.tsx
@@ -4,7 +4,13 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 import type { Creator } from "@/app/data/creators";
 
-export default function PersonaCard({ persona }: { persona: Creator }) {
+type Props = {
+  persona: Creator;
+  onToggle?: (id: string) => void;
+  inShortlist?: boolean;
+};
+
+export default function PersonaCard({ persona, onToggle, inShortlist }: Props) {
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -33,6 +39,14 @@ export default function PersonaCard({ persona }: { persona: Creator }) {
       >
         View Persona
       </Link>
+      {onToggle && (
+        <button
+          onClick={() => onToggle(persona.id)}
+          className="ml-4 text-sm text-Siora-accent underline"
+        >
+          {inShortlist ? "Remove" : "Save"}
+        </button>
+      )}
     </motion.div>
   );
 }

--- a/apps/brand/lib/auth.tsx
+++ b/apps/brand/lib/auth.tsx
@@ -1,0 +1,46 @@
+"use client";
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+
+interface AuthContextValue {
+  user: string | null;
+  signIn: (email: string) => void;
+  signOut: () => void;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = localStorage.getItem("brandUser");
+    if (stored) setUser(stored);
+  }, []);
+
+  const signIn = (email: string) => {
+    setUser(email);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("brandUser", email);
+    }
+  };
+
+  const signOut = () => {
+    setUser(null);
+    if (typeof window !== "undefined") {
+      localStorage.removeItem("brandUser");
+    }
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, signIn, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/apps/brand/lib/shortlist.ts
+++ b/apps/brand/lib/shortlist.ts
@@ -1,0 +1,33 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export function useShortlist(user: string | null) {
+  const key = user ? `shortlist:${user}` : "shortlist";
+  const [ids, setIds] = useState<string[]>([]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = localStorage.getItem(key);
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) setIds(parsed);
+      } catch {}
+    }
+  }, [key]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(key, JSON.stringify(ids));
+  }, [ids, key]);
+
+  const toggle = (id: string) => {
+    setIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    );
+  };
+
+  const inShortlist = (id: string) => ids.includes(id);
+
+  return { ids, toggle, inShortlist };
+}


### PR DESCRIPTION
## Summary
- add brand AuthProvider and shortlist hooks
- gate `/brands` behind sign in and add save/remove functionality
- add sign-in page for brands
- document the new `/signin` and `/brands` flow

## Testing
- `npm run lint -w apps/brand`

------
https://chatgpt.com/codex/tasks/task_e_68509b226c04832ca312c4469ad9351c