### PR TITLE
Add persona refinement endpoint and UI

### DIFF
--- a/apps/creator/app/api/refinePersona/route.ts
+++ b/apps/creator/app/api/refinePersona/route.ts
@@ -1,0 +1,62 @@
+import type { PersonaProfile } from "@/types/persona";
+
+export async function POST(req: Request) {
+  try {
+    const { persona, updates } = await req.json();
+
+    if (!persona || typeof persona !== "object" || typeof updates !== "string") {
+      return new Response(
+        JSON.stringify({ error: "Invalid input" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const messages = [
+      {
+        role: "system",
+        content: [
+          "You refine influencer personas.",
+          "Given the existing persona and new creator information, rewrite the persona using the same structure.",
+          "Respond ONLY with JSON matching the PersonaProfile TypeScript interface: { name: string; personality: string; interests: string[]; summary: string; postingFrequency?: string; toneConfidence?: number; brandFit?: string; growthSuggestions?: string }"
+        ].join("\n"),
+      },
+      {
+        role: "user",
+        content: `Existing persona: ${JSON.stringify(persona)}\nNew data: ${updates}`,
+      },
+    ];
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({ model: "gpt-4", messages, temperature: 0.7 }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return new Response(
+        JSON.stringify({ error: "OpenAI error", details: errorText }),
+        { status: response.status, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const data = await response.json();
+    const content = data.choices?.[0]?.message?.content ?? "{}";
+    const refined: PersonaProfile = JSON.parse(content);
+
+    return new Response(JSON.stringify(refined), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    console.error("Unexpected error:", error);
+    return new Response(
+      JSON.stringify({ error: "Unexpected error", details: message }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+}

--- a/apps/creator/app/refine/page.tsx
+++ b/apps/creator/app/refine/page.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import PersonaCard from "@/components/PersonaCard";
+import { loadPersonasFromLocal, savePersonaToLocal, StoredPersona } from "@/lib/localPersonas";
+import type { PersonaProfile } from "@/types/persona";
+
+export default function RefinePersonaPage() {
+  const [personas, setPersonas] = useState<StoredPersona[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [updates, setUpdates] = useState("");
+  const [result, setResult] = useState<PersonaProfile | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    setPersonas(loadPersonasFromLocal());
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!personas[selectedIndex]) return;
+
+    setLoading(true);
+    setError("");
+    setResult(null);
+
+    try {
+      const res = await fetch("/api/refinePersona", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ persona: personas[selectedIndex].persona, updates }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Request failed");
+      setResult(data as PersonaProfile);
+      savePersonaToLocal(data as PersonaProfile);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Something went wrong";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (personas.length === 0) {
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-background text-foreground p-6">
+        <p>No saved personas found. Generate one first.</p>
+      </main>
+    );
+  }
+
+  const current = personas[selectedIndex].persona as PersonaProfile;
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 space-y-6 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold">Refine Persona</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 border border-white/10 p-4 rounded-md">
+        <div>
+          <label className="block text-sm font-semibold mb-1">Select Persona</label>
+          <select
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={selectedIndex}
+            onChange={(e) => setSelectedIndex(parseInt(e.target.value, 10))}
+          >
+            {personas.map((p, idx) => (
+              <option key={idx} value={idx}>
+                {(p.persona as { name?: string }).name || `Persona ${idx + 1}`}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-semibold mb-1">New creator info</label>
+          <textarea
+            className="w-full p-2 rounded-md bg-zinc-800 text-white h-32 resize-none"
+            value={updates}
+            onChange={(e) => setUpdates(e.target.value)}
+            placeholder="What's changed or new?"
+          />
+        </div>
+        <button
+          type="submit"
+          className="bg-indigo-600 hover:bg-indigo-500 transition-colors duration-200 text-white px-4 py-2 rounded-md disabled:opacity-50"
+          disabled={loading || !updates.trim()}
+        >
+          {loading ? "Refining..." : "Refine Persona"}
+        </button>
+        {error && <p className="text-red-500">{error}</p>}
+      </form>
+
+      {result && (
+        <div className="grid gap-6 md:grid-cols-2">
+          <div>
+            <h2 className="text-lg font-semibold mb-2">Before</h2>
+            <PersonaCard profile={current} />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold mb-2">After</h2>
+            <PersonaCard profile={result} />
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- create `/api/refinePersona` OpenAI endpoint to refine a persona
- add `/refine` page that lets a user input new info and see Before vs After persona cards

## Testing
- `npm run lint -w apps/creator`

------
https://chatgpt.com/codex/tasks/task_e_68509d3e1438832c9a81a6dc2ebbea66