### PR TITLE
Add shortlist feature to brand dashboard

### DIFF
--- a/apps/brand/app/dashboard/page.tsx
+++ b/apps/brand/app/dashboard/page.tsx
@@ -4,6 +4,8 @@ import { useState } from "react";
 import creators from "@/app/data/mock_creators_200.json";
 import FilterBar from "@/components/FilterBar";
 import CreatorCard from "@/components/CreatorCard";
+import { useAuth } from "@/lib/auth";
+import { useShortlist } from "@/lib/shortlist";
 
 export default function Dashboard() {
   const [query, setQuery] = useState("");
@@ -11,6 +13,8 @@ export default function Dashboard() {
   const [sortBy, setSortBy] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const perPage = 12;
+  const { user } = useAuth();
+  const { toggle, inShortlist } = useShortlist(user);
 
   const filtered = creators
     .filter((c) => {
@@ -64,7 +68,12 @@ export default function Dashboard() {
 
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
           {paginated.map((c) => (
-            <CreatorCard key={c.id} creator={c} />
+            <CreatorCard
+              key={c.id}
+              creator={c}
+              onShortlist={toggle}
+              shortlisted={inShortlist(c.id)}
+            />
           ))}
         </div>
 

--- a/apps/brand/app/shortlist/page.tsx
+++ b/apps/brand/app/shortlist/page.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import creators from "@/app/data/mock_creators_200.json";
+import CreatorCard from "@/components/CreatorCard";
+import { useAuth } from "@/lib/auth";
+import { useShortlist } from "@/lib/shortlist";
+
+export default function ShortlistPage() {
+  const { user } = useAuth();
+  const router = useRouter();
+  const { ids, toggle } = useShortlist(user);
+
+  useEffect(() => {
+    if (!user) router.replace("/signin");
+  }, [user, router]);
+
+  if (!user) return null;
+
+  const saved = creators.filter((c) => ids.includes(c.id));
+
+  return (
+    <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
+      <div className="max-w-7xl mx-auto space-y-8">
+        <h1 className="text-4xl font-extrabold tracking-tight">My Shortlist</h1>
+        {saved.length === 0 ? (
+          <p className="text-center text-zinc-400 mt-10">No creators saved.</p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {saved.map((c) => (
+              <CreatorCard key={c.id} creator={c} onShortlist={toggle} shortlisted={true} />
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/brand/components/CreatorCard.tsx
+++ b/apps/brand/components/CreatorCard.tsx
@@ -5,7 +5,12 @@ import { motion } from "framer-motion";
 import type { Creator } from "@/app/data/creators";
 import { useState } from "react";
 
-export default function CreatorCard({ creator }: { creator: Creator }) {
+type Props = {
+  creator: Creator;
+  onShortlist?: (id: string) => void;
+  shortlisted?: boolean;
+};
+export default function CreatorCard({ creator, onShortlist, shortlisted }: Props) {
   const [loading, setLoading] = useState(false);
 
   const handleContact = async () => {
@@ -70,6 +75,14 @@ export default function CreatorCard({ creator }: { creator: Creator }) {
       >
         {loading ? 'Contacting...' : 'Contact'}
       </button>
+      {onShortlist && (
+        <button
+          onClick={() => onShortlist(creator.id)}
+          className="ml-4 text-sm mt-4 text-Siora-accent underline"
+        >
+          {shortlisted ? 'Remove' : 'Shortlist'}
+        </button>
+      )}
     </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- add shortlist support to `CreatorCard`
- integrate shortlist hook in brand dashboard
- show shortlisted creators on `/shortlist` page

## Testing
- `npm run lint -w apps/brand`

------
https://chatgpt.com/codex/tasks/task_e_6850a111f0a8832c88bb9c062b045ab3