### PR TITLE
Add persona editing capability

### DIFF
--- a/apps/creator/app/dashboard/page.tsx
+++ b/apps/creator/app/dashboard/page.tsx
@@ -57,8 +57,8 @@ export default function DashboardPage() {
                 <Link href={`/persona/${item.id}`} className="text-indigo-600 underline">
                   View
                 </Link>
-                <Link href={`/persona/${item.id}?edit=1`} className="text-indigo-600 underline">
-                  Edit
+                <Link href={`/persona/${item.id}/edit`} className="text-indigo-600 underline">
+                  Edit Persona
                 </Link>
                 <button onClick={() => handleDelete(item.id)} className="text-red-600 underline">
                   Delete


### PR DESCRIPTION
## Summary
- allow editing personas from dashboard
- track persona inputs on save so they can be reused
- add edit page with wizard prefilled from stored inputs

## Testing
- `npm run lint` *(fails: Found `pipeline` field instead of `tasks` in turbo.json)*

------
https://chatgpt.com/codex/tasks/task_e_6850a133539c832c9b016d8a16f93f1a