### PR TITLE
Add brand onboard API route

### DIFF
--- a/apps/brand/app/api/brand-onboard/route.ts
+++ b/apps/brand/app/api/brand-onboard/route.ts
@@ -1,0 +1,68 @@
+export async function POST(req: Request) {
+  try {
+    const { name, goals, campaignFocus, targetAudience, idealCreators } = await req.json();
+
+    if (!name || typeof name !== "string") {
+      return new Response(
+        JSON.stringify({ error: "Brand name is required" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const details = [
+      `Name: ${name}`,
+      goals ? `Goals: ${goals}` : undefined,
+      campaignFocus ? `Campaign focus: ${campaignFocus}` : undefined,
+      targetAudience ? `Target audience: ${targetAudience}` : undefined,
+      idealCreators ? `Ideal creators: ${idealCreators}` : undefined,
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    const messages = [
+      {
+        role: "system",
+        content: [
+          "You assist brands in preparing influencer outreach.",
+          "Craft a concise mission blurb, list three short creator-fit traits, recommend the best platform and content formats, and write a short outreach pitch.",
+          "Respond ONLY with JSON matching this TypeScript interface:",
+          "{ mission: string; creatorTraits: string[]; platformFormat: string; pitch: string }",
+        ].join("\n"),
+      },
+      { role: "user", content: details },
+    ];
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({ model: "gpt-4", messages, temperature: 0.7 }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return new Response(
+        JSON.stringify({ error: "OpenAI error", details: errorText }),
+        { status: response.status, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const data = await response.json();
+    const content = data.choices?.[0]?.message?.content ?? "{}";
+    const result = JSON.parse(content);
+
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    console.error("Unexpected error:", error);
+    return new Response(
+      JSON.stringify({ error: "Unexpected error", details: message }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+}

--- a/apps/brand/types/onboard.ts
+++ b/apps/brand/types/onboard.ts
@@ -1,0 +1,6 @@
+export type BrandOnboardResult = {
+  mission: string;
+  creatorTraits: string[];
+  platformFormat: string;
+  pitch: string;
+};


### PR DESCRIPTION
## Summary
- add API to suggest brand profile details
- export `BrandOnboardResult` type for results

## Testing
- `npm run lint -w apps/brand`

------
https://chatgpt.com/codex/tasks/task_e_6850a37db620832cb88214dac2120d25