### PR TITLE
Add lead magnet generator

### DIFF
--- a/apps/creator/app/api/leadMagnet/route.ts
+++ b/apps/creator/app/api/leadMagnet/route.ts
@@ -1,10 +1,15 @@
 export async function POST(req: Request) {
   try {
-    const { niche, persona } = await req.json();
+    const { niche, audience } = await req.json();
 
-    if (!niche || typeof niche !== 'string' || !persona || typeof persona !== 'string') {
+    if (
+      !niche ||
+      typeof niche !== 'string' ||
+      !audience ||
+      typeof audience !== 'string'
+    ) {
       return new Response(
-        JSON.stringify({ error: 'Provide both niche and persona strings.' }),
+        JSON.stringify({ error: 'Provide both niche and audience strings.' }),
         { status: 400, headers: { 'Content-Type': 'application/json' } }
       );
     }
@@ -14,10 +19,11 @@ export async function POST(req: Request) {
         role: 'system',
         content: [
           'You generate concise ideas for downloadable resources that creators can offer as lead magnets to grow their email list.',
-          'Respond ONLY with JSON in the form { "idea": string } describing one resource idea.'
+          'Each idea should include a short title, a one-sentence description, a clear benefit statement, and a compelling call-to-action.',
+          'Respond ONLY with JSON in the form { "title": string; "description": string; "benefit": string; "cta": string }.'
         ].join('\n')
       },
-      { role: 'user', content: `Niche: ${niche}\nPersona: ${persona}` }
+      { role: 'user', content: `Niche: ${niche}\nAudience: ${audience}` }
     ];
 
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
@@ -39,7 +45,12 @@ export async function POST(req: Request) {
 
     const data = await response.json();
     const content = data.choices?.[0]?.message?.content ?? '{}';
-    const result = JSON.parse(content) as { idea: string };
+    const result = JSON.parse(content) as {
+      title: string;
+      description: string;
+      benefit: string;
+      cta: string;
+    };
 
     return new Response(JSON.stringify(result), {
       status: 200,

--- a/apps/creator/app/lead-magnet/page.tsx
+++ b/apps/creator/app/lead-magnet/page.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import type { LeadMagnetIdea } from "@/types/leadMagnet";
+
+export default function LeadMagnetPage() {
+  const [niche, setNiche] = useState("");
+  const [audience, setAudience] = useState("");
+  const [idea, setIdea] = useState<LeadMagnetIdea | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!niche.trim() || !audience.trim()) return;
+    setLoading(true);
+    setIdea(null);
+    setError("");
+    try {
+      const res = await fetch("/api/leadMagnet", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ niche, audience }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Request failed");
+      setIdea(data as LeadMagnetIdea);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 space-y-6 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold">Lead Magnet Idea Generator</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 border border-white/10 p-4 rounded-md">
+        <div>
+          <label className="block text-sm font-semibold mb-1">Your niche</label>
+          <input
+            type="text"
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={niche}
+            onChange={(e) => setNiche(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-semibold mb-1">Describe your audience</label>
+          <input
+            type="text"
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={audience}
+            onChange={(e) => setAudience(e.target.value)}
+            required
+          />
+        </div>
+        <button
+          type="submit"
+          className="bg-indigo-600 hover:bg-indigo-500 transition-colors duration-200 text-white px-4 py-2 rounded-md disabled:opacity-50"
+          disabled={loading || !niche.trim() || !audience.trim()}
+        >
+          {loading ? "Generating..." : "Generate"}
+        </button>
+      </form>
+      {error && <p className="text-red-500">{error}</p>}
+      {idea && (
+        <div className="space-y-2 border border-white/10 p-4 rounded-md">
+          <h2 className="text-lg font-semibold">{idea.title}</h2>
+          <p className="text-sm text-foreground/80">{idea.description}</p>
+          <p className="text-sm">Benefit: {idea.benefit}</p>
+          <p className="text-sm font-semibold">CTA: {idea.cta}</p>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/creator/app/tools/page.tsx
+++ b/apps/creator/app/tools/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import type { LeadMagnetIdea } from "@/types/leadMagnet";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 
@@ -45,7 +46,7 @@ export default function ToolsPage() {
   // Lead Magnet Idea state
   const [magnetNiche, setMagnetNiche] = useState("");
   const [magnetPersona, setMagnetPersona] = useState("");
-  const [magnetIdea, setMagnetIdea] = useState("");
+  const [magnetIdea, setMagnetIdea] = useState<LeadMagnetIdea | null>(null);
   const [magnetLoading, setMagnetLoading] = useState(false);
   const [magnetError, setMagnetError] = useState("");
 
@@ -119,17 +120,17 @@ export default function ToolsPage() {
     e.preventDefault();
     if (!magnetNiche.trim() || !magnetPersona.trim()) return;
     setMagnetLoading(true);
-    setMagnetIdea("");
+    setMagnetIdea(null);
     setMagnetError("");
     try {
       const res = await fetch("/api/leadMagnet", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ niche: magnetNiche, persona: magnetPersona }),
+        body: JSON.stringify({ niche: magnetNiche, audience: magnetPersona }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Request failed");
-      setMagnetIdea(data.idea as string);
+      setMagnetIdea(data as LeadMagnetIdea);
     } catch (err) {
       setMagnetError(err instanceof Error ? err.message : "Something went wrong");
     } finally {
@@ -238,7 +239,12 @@ export default function ToolsPage() {
       </button>
       {magnetError && <p className="text-red-500 text-sm">{magnetError}</p>}
       {magnetIdea && (
-        <p className="text-sm text-zinc-300 border-t border-white/10 pt-2">{magnetIdea}</p>
+        <div className="text-sm text-zinc-300 border-t border-white/10 pt-2 space-y-1">
+          <p className="font-semibold">{magnetIdea.title}</p>
+          <p>{magnetIdea.description}</p>
+          <p>Benefit: {magnetIdea.benefit}</p>
+          <p className="font-semibold">CTA: {magnetIdea.cta}</p>
+        </div>
       )}
     </form>
   );

--- a/apps/creator/types/leadMagnet.ts
+++ b/apps/creator/types/leadMagnet.ts
@@ -1,0 +1,6 @@
+export type LeadMagnetIdea = {
+  title: string;
+  description: string;
+  benefit: string;
+  cta: string;
+};


### PR DESCRIPTION
## Summary
- introduce `LeadMagnetIdea` type
- update `/api/leadMagnet` to return structured lead magnet ideas
- update tools page to handle new lead magnet response
- add dedicated Lead Magnet page for creators

## Testing
- `npm run lint -w apps/creator`

------
https://chatgpt.com/codex/tasks/task_e_6850a385a124832c922c9fbc60a869af