### PR TITLE
Add brand pitching feature

### DIFF
--- a/apps/creator/app/api/brand-pitch/route.ts
+++ b/apps/creator/app/api/brand-pitch/route.ts
@@ -1,0 +1,68 @@
+import type { PitchResult } from "@/types/pitch";
+
+export async function POST(req: Request) {
+  try {
+    const { persona, brand } = await req.json();
+    if (!brand || typeof brand !== "object" || !brand.name) {
+      return new Response(
+        JSON.stringify({ error: "Brand data is required" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    if (!persona || typeof persona !== "object") {
+      return new Response(
+        JSON.stringify({ error: "Persona data is required" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const messages = [
+      {
+        role: "system",
+        content: [
+          "You craft short outreach pitches for creators to approach brands.",
+          "Given the creator persona and brand campaign focus, explain briefly why the collaboration fits and provide a copy-paste pitch email.",
+          "Respond ONLY with JSON matching this TypeScript interface:",
+          "{ reasoning: string; pitch: string }",
+        ].join(" \n"),
+      },
+      {
+        role: "user",
+        content: `Persona: ${JSON.stringify(persona)}\nBrand: ${JSON.stringify(brand)}`,
+      },
+    ];
+
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({ model: "gpt-4", messages, temperature: 0.7 }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return new Response(
+        JSON.stringify({ error: "OpenAI error", details: errorText }),
+        { status: response.status, headers: { "Content-Type": "application/json" } }
+      );
+    }
+
+    const data = await response.json();
+    const content = data.choices?.[0]?.message?.content ?? "{}";
+    const pitch: PitchResult = JSON.parse(content);
+
+    return new Response(JSON.stringify(pitch), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Unexpected error";
+    console.error("Unexpected error:", error);
+    return new Response(
+      JSON.stringify({ error: "Unexpected error", details: message }),
+      { status: 500, headers: { "Content-Type": "application/json" } }
+    );
+  }
+}

--- a/apps/creator/app/brands/page.tsx
+++ b/apps/creator/app/brands/page.tsx
@@ -1,0 +1,74 @@
+"use client";
+import { useState, useEffect } from 'react';
+import { loadPersonasFromLocal, StoredPersona } from '@/lib/localPersonas';
+import { brands, type Brand } from '@/data/brands';
+import BrandCard from '@/components/BrandCard';
+import type { PitchResult } from '@/types/pitch';
+
+export default function BrandsPage() {
+  const [personas, setPersonas] = useState<StoredPersona[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [pitches, setPitches] = useState<Record<string, PitchResult | null>>({});
+  const [loadingId, setLoadingId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setPersonas(loadPersonasFromLocal());
+  }, []);
+
+  const handlePitch = async (brand: Brand) => {
+    if (!personas[selectedIndex]) return;
+    setLoadingId(brand.id);
+    try {
+      const res = await fetch('/api/brand-pitch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ persona: personas[selectedIndex].persona, brand }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setPitches((prev) => ({ ...prev, [brand.id]: data as PitchResult }));
+      }
+    } finally {
+      setLoadingId(null);
+    }
+  };
+
+  if (personas.length === 0) {
+    return (
+      <main className="min-h-screen flex items-center justify-center p-6 bg-background text-foreground">
+        <p>No saved personas found. Generate one first.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 space-y-6 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-bold">Brand Opportunities</h1>
+      <div>
+        <label className="block text-sm font-semibold mb-1">Select Persona</label>
+        <select
+          className="w-full p-2 rounded-md bg-zinc-800 text-white"
+          value={selectedIndex}
+          onChange={(e) => setSelectedIndex(parseInt(e.target.value, 10))}
+        >
+          {personas.map((p, idx) => (
+            <option key={idx} value={idx}>
+              {(p.persona as { name?: string }).name || `Persona ${idx + 1}`}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        {brands.map((brand) => (
+          <BrandCard
+            key={brand.id}
+            brand={brand}
+            pitch={pitches[brand.id]}
+            loading={loadingId === brand.id}
+            onPitch={() => handlePitch(brand)}
+          />
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/apps/creator/components/BrandCard.tsx
+++ b/apps/creator/components/BrandCard.tsx
@@ -1,0 +1,49 @@
+import { useState, useEffect } from 'react';
+import type { Brand } from '@/data/brands';
+import type { PitchResult } from '@/types/pitch';
+
+interface Props {
+  brand: Brand;
+  pitch?: PitchResult | null;
+  loading?: boolean;
+  onPitch: () => Promise<void>;
+}
+
+export default function BrandCard({ brand, pitch, loading, onPitch }: Props) {
+  const [text, setText] = useState('');
+  useEffect(() => {
+    setText(pitch?.pitch ?? '');
+  }, [pitch]);
+
+  return (
+    <div className="border border-white/10 bg-background p-4 rounded-xl space-y-3">
+      <h3 className="text-lg font-bold">{brand.name}</h3>
+      <p className="text-sm italic">Campaign: {brand.campaign}</p>
+      <p className="text-sm text-foreground/80">{brand.summary}</p>
+      <button
+        onClick={onPitch}
+        disabled={loading}
+        className="mt-2 px-3 py-1 bg-indigo-600 text-white rounded disabled:opacity-50"
+      >
+        {loading ? 'Generating...' : 'Pitch Brand'}
+      </button>
+      {pitch && (
+        <div className="space-y-2 mt-2">
+          <textarea
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            rows={4}
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+          />
+          <button
+            type="button"
+            onClick={() => navigator.clipboard.writeText(text)}
+            className="px-3 py-1 bg-green-600 text-white rounded"
+          >
+            Copy Message
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/creator/data/brands.ts
+++ b/apps/creator/data/brands.ts
@@ -1,0 +1,31 @@
+export interface Brand {
+  id: string;
+  name: string;
+  campaign: string;
+  niche: string;
+  summary: string;
+}
+
+export const brands: Brand[] = [
+  {
+    id: '1',
+    name: 'Glow Cosmetics',
+    campaign: 'Summer skincare launch',
+    niche: 'Beauty',
+    summary: 'Looking for skincare creators to promote our new SPF line.',
+  },
+  {
+    id: '2',
+    name: 'FitFuel',
+    campaign: 'Plant protein bars',
+    niche: 'Fitness',
+    summary: 'Seeking active lifestyle influencers to highlight our vegan protein bars.',
+  },
+  {
+    id: '3',
+    name: 'EcoHome',
+    campaign: 'Zero-waste home essentials',
+    niche: 'Home & Sustainability',
+    summary: 'Partnering with eco-conscious creators to showcase waste-free living tips.',
+  },
+];


### PR DESCRIPTION
## Summary
- add demo brand data
- add a brand card component with "Pitch Brand" button
- implement API route to generate creator pitches for brand campaigns
- create a page listing brands so creators can pitch them

## Testing
- `npm run lint -w apps/creator` *(fails: Unexpected any)*
- `npm run build -w apps/creator` *(fails: missing lightningcss native module)*

------
https://chatgpt.com/codex/tasks/task_e_6850ad96e19c832cbdc3d0fb9557b265