### PR TITLE
Add brand discovery interface

### DIFF
--- a/apps/creator/app/brand-discovery/page.tsx
+++ b/apps/creator/app/brand-discovery/page.tsx
@@ -1,0 +1,159 @@
+"use client"
+
+import { useEffect, useMemo, useState } from 'react'
+import BrandDiscoveryCard from '@/components/BrandDiscoveryCard'
+import { discoveryBrands, DiscoveryBrand } from '@/data/discoveryBrands'
+import { loadPersonasFromLocal, StoredPersona } from '@/lib/localPersonas'
+
+export default function BrandDiscoveryPage() {
+  const [search, setSearch] = useState('')
+  const [industry, setIndustry] = useState('')
+  const [value, setValue] = useState('')
+  const [vibe, setVibe] = useState('')
+  const [campaign, setCampaign] = useState('')
+  const [personas, setPersonas] = useState<StoredPersona[]>([])
+  const [personaIndex, setPersonaIndex] = useState(0)
+
+  useEffect(() => {
+    setPersonas(loadPersonasFromLocal())
+  }, [])
+
+  const industries = useMemo(
+    () => Array.from(new Set(discoveryBrands.map(b => b.industry))),
+    []
+  )
+  const values = useMemo(
+    () => Array.from(new Set(discoveryBrands.flatMap(b => b.values))),
+    []
+  )
+  const vibes = useMemo(
+    () => Array.from(new Set(discoveryBrands.flatMap(b => b.vibes))),
+    []
+  )
+  const campaigns = useMemo(
+    () => Array.from(new Set(discoveryBrands.flatMap(b => b.pastCampaigns))),
+    []
+  )
+
+  const filtered = useMemo(() => {
+    return discoveryBrands.filter(b => {
+      if (industry && b.industry !== industry) return false
+      if (value && !b.values.includes(value)) return false
+      if (vibe && !b.vibes.includes(vibe)) return false
+      if (campaign && !b.pastCampaigns.includes(campaign)) return false
+      const term = search.toLowerCase()
+      if (term && !b.name.toLowerCase().includes(term) && !b.industry.toLowerCase().includes(term)) {
+        return false
+      }
+      return true
+    })
+  }, [industry, value, vibe, campaign, search])
+
+  const suggested = useMemo(() => {
+    const persona = personas[personaIndex]?.persona
+    if (!persona) return [] as DiscoveryBrand[]
+    const keywords = [
+      persona.personality,
+      persona.brandFit ?? '',
+      ...(persona.interests || [])
+    ].join(' ').toLowerCase()
+    return discoveryBrands.filter(b => {
+      return (
+        keywords.includes(b.industry.toLowerCase()) ||
+        b.vibes.some(v => keywords.includes(v.toLowerCase())) ||
+        b.values.some(v => keywords.includes(v.toLowerCase()))
+      )
+    })
+  }, [personaIndex, personas])
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 space-y-6 max-w-5xl mx-auto">
+      <h1 className="text-2xl font-bold">Discover Brands</h1>
+
+      {personas.length > 0 && (
+        <div>
+          <label className="block text-sm font-semibold mb-1">Select Persona</label>
+          <select
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={personaIndex}
+            onChange={e => setPersonaIndex(parseInt(e.target.value, 10))}
+          >
+            {personas.map((p, idx) => (
+              <option key={idx} value={idx}>
+                {(p.persona as { name?: string }).name || `Persona ${idx + 1}`}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      <div className="grid md:grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <input
+            type="text"
+            placeholder="Search by name or industry"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+          />
+          <select
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={industry}
+            onChange={e => setIndustry(e.target.value)}
+          >
+            <option value="">All Industries</option>
+            {industries.map(i => (
+              <option key={i} value={i}>{i}</option>
+            ))}
+          </select>
+          <select
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={value}
+            onChange={e => setValue(e.target.value)}
+          >
+            <option value="">All Values</option>
+            {values.map(v => (
+              <option key={v} value={v}>{v}</option>
+            ))}
+          </select>
+          <select
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={vibe}
+            onChange={e => setVibe(e.target.value)}
+          >
+            <option value="">All Vibes</option>
+            {vibes.map(v => (
+              <option key={v} value={v}>{v}</option>
+            ))}
+          </select>
+          <select
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={campaign}
+            onChange={e => setCampaign(e.target.value)}
+          >
+            <option value="">Past Campaigns</option>
+            {campaigns.map(c => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </select>
+        </div>
+        {suggested.length > 0 && (
+          <div>
+            <h2 className="font-semibold mb-2">Suggested for You</h2>
+            <div className="space-y-2">
+              {suggested.map(b => (
+                <BrandDiscoveryCard key={b.id} brand={b} />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+        {filtered.map(b => (
+          <BrandDiscoveryCard key={b.id} brand={b} />
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/apps/creator/components/BrandDiscoveryCard.tsx
+++ b/apps/creator/components/BrandDiscoveryCard.tsx
@@ -1,0 +1,43 @@
+import Image from 'next/image'
+import { DiscoveryBrand } from '@/data/discoveryBrands'
+
+interface Props {
+  brand: DiscoveryBrand
+  onAction?: () => void
+}
+
+export default function BrandDiscoveryCard({ brand, onAction }: Props) {
+  return (
+    <div className="p-4 rounded-lg border border-white/10 bg-background space-y-2">
+      <div className="flex items-center space-x-3">
+        <Image
+          src={brand.logo}
+          alt={brand.name}
+          width={40}
+          height={40}
+          unoptimized
+          className="rounded-full"
+        />
+        <div>
+          <h3 className="font-semibold">{brand.name}</h3>
+          <p className="text-sm text-foreground/70">{brand.tagline}</p>
+        </div>
+      </div>
+      <p className="text-sm">Industry: {brand.industry}</p>
+      <div className="flex flex-wrap gap-1">
+        {brand.vibes.map((v) => (
+          <span key={v} className="px-2 py-0.5 text-xs bg-zinc-800 rounded">
+            {v}
+          </span>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={onAction}
+        className="mt-2 px-3 py-1 bg-indigo-600 text-white rounded"
+      >
+        View Brand
+      </button>
+    </div>
+  )
+}

--- a/apps/creator/data/discoveryBrands.ts
+++ b/apps/creator/data/discoveryBrands.ts
@@ -1,0 +1,63 @@
+export interface DiscoveryBrand {
+  id: string;
+  name: string;
+  logo: string;
+  tagline: string;
+  industry: string;
+  vibes: string[];
+  values: string[];
+  pastCampaigns: string[];
+}
+
+export const discoveryBrands: DiscoveryBrand[] = [
+  {
+    id: 'b1',
+    name: 'Glow Cosmetics',
+    logo: 'https://via.placeholder.com/80?text=Glow',
+    tagline: 'Shine naturally',
+    industry: 'Beauty',
+    vibes: ['vibrant', 'youthful'],
+    values: ['cruelty-free', 'sustainable'],
+    pastCampaigns: ['GlowSummer', 'SPFLaunch'],
+  },
+  {
+    id: 'b2',
+    name: 'FitFuel',
+    logo: 'https://via.placeholder.com/80?text=FitFuel',
+    tagline: 'Power your workouts',
+    industry: 'Fitness',
+    vibes: ['energetic', 'bold'],
+    values: ['vegan', 'health'],
+    pastCampaigns: ['ProteinBar2024'],
+  },
+  {
+    id: 'b3',
+    name: 'EcoHome',
+    logo: 'https://via.placeholder.com/80?text=EcoHome',
+    tagline: 'Zero-waste living',
+    industry: 'Home',
+    vibes: ['minimal', 'clean'],
+    values: ['eco-friendly'],
+    pastCampaigns: ['ZeroWasteKit'],
+  },
+  {
+    id: 'b4',
+    name: 'TechVerse',
+    logo: 'https://via.placeholder.com/80?text=TechVerse',
+    tagline: 'Future gadgets today',
+    industry: 'Technology',
+    vibes: ['futuristic', 'sleek'],
+    values: ['innovation'],
+    pastCampaigns: ['VRLaunch'],
+  },
+  {
+    id: 'b5',
+    name: 'FreshBite',
+    logo: 'https://via.placeholder.com/80?text=FreshBite',
+    tagline: 'Taste the freshness',
+    industry: 'Food',
+    vibes: ['fun', 'colorful'],
+    values: ['organic'],
+    pastCampaigns: ['SummerSalads'],
+  },
+];


### PR DESCRIPTION
## Summary
- add brand discovery brands dataset
- show BrandDiscoveryCard for each brand with logo, tagline and vibe tags
- implement brand discovery page with filters and "Suggested for You"

## Testing
- `npm run lint -w apps/creator` *(fails: Unexpected any)*
- `npm run build -w apps/creator` *(fails: Build failed because of webpack errors)*

------
https://chatgpt.com/codex/tasks/task_e_6850b4452ec0832c947bdbf9165087ee