### PR TITLE
Add pitch email API endpoint

### DIFF
--- a/apps/creator/app/api/pitch/route.ts
+++ b/apps/creator/app/api/pitch/route.ts
@@ -9,9 +9,17 @@ export async function POST(req: Request) {
         { status: 400, headers: { "Content-Type": "application/json" } }
       );
     }
-    if (!persona || typeof persona !== "object") {
+    if (
+      !persona ||
+      typeof persona !== "object" ||
+      !persona.name ||
+      !persona.vibe ||
+      !persona.goal ||
+      !persona.audience ||
+      !Array.isArray(persona.dreamBrands)
+    ) {
       return new Response(
-        JSON.stringify({ error: "Persona data is required" }),
+        JSON.stringify({ error: "Incomplete persona data" }),
         { status: 400, headers: { "Content-Type": "application/json" } }
       );
     }
@@ -20,10 +28,11 @@ export async function POST(req: Request) {
       {
         role: "system",
         content: [
-          "You craft short brand collaboration pitches for creators.",
-          "Given the creator persona and target brand, explain briefly why the fit makes sense and then provide a copy-paste pitch email.",
+          "You write short, persuasive outreach emails for creators who want to work with brands.",
+          "Use a confident, friendly and professional tone.",
+          "Always personalize the email using the brand name when it is provided.",
           "Respond ONLY with JSON that matches this TypeScript interface:",
-          "{ reasoning: string; pitch: string }",
+          "{ pitch: string }",
         ].join(" \n"),
       },
       {

--- a/apps/creator/app/pitch/page.tsx
+++ b/apps/creator/app/pitch/page.tsx
@@ -95,8 +95,12 @@ export default function PitchPage() {
 
       {result && (
         <div className="space-y-4 border border-white/10 p-4 rounded-md">
-          <h2 className="text-lg font-semibold">Why You&apos;re a Fit</h2>
-          <p className="text-sm text-foreground/80">{result.reasoning}</p>
+          {result.reasoning && (
+            <>
+              <h2 className="text-lg font-semibold">Why You&apos;re a Fit</h2>
+              <p className="text-sm text-foreground/80">{result.reasoning}</p>
+            </>
+          )}
           <h2 className="text-lg font-semibold">Pitch</h2>
           <pre className="whitespace-pre-wrap bg-zinc-800 text-white p-3 rounded-md text-sm">{result.pitch}</pre>
           <button

--- a/apps/creator/types/pitch.ts
+++ b/apps/creator/types/pitch.ts
@@ -1,4 +1,4 @@
 export type PitchResult = {
-  reasoning: string;
   pitch: string;
+  reasoning?: string;
 };


### PR DESCRIPTION
## Summary
- update `/api/pitch` endpoint to generate a short brand pitch email
- make reasoning optional in `PitchResult`
- handle optional reasoning display on the Pitch page

## Testing
- `npm run lint -w apps/creator`

------
https://chatgpt.com/codex/tasks/task_e_6851548cbbcc832c9809854d513def4e