### PR TITLE
Add dashboard filter UI

### DIFF
--- a/apps/brand/app/dashboard/page.tsx
+++ b/apps/brand/app/dashboard/page.tsx
@@ -19,15 +19,20 @@ export default function Dashboard() {
 
   const filtered = creators
     .filter((c) => {
-      const matchesQuery = `${c.name} ${c.handle} ${c.niche} ${c.tags.join(" ")} ${c.tone}`
+      const matchesQuery = `${c.name} ${c.handle} ${c.niche} ${c.tags.join(" ")} ${c.tone} ${c.summary}`
         .toLowerCase()
         .includes(query.toLowerCase());
 
       const matchesFilters =
-        (!filters.niche || c.niche.toLowerCase().includes(filters.niche.toLowerCase())) &&
         (!filters.platform || c.platform.toLowerCase().includes(filters.platform.toLowerCase())) &&
+        (!filters.tone || c.tone.toLowerCase().includes(filters.tone.toLowerCase())) &&
+        (!filters.audience ||
+          c.summary.toLowerCase().includes(filters.audience.toLowerCase()) ||
+          c.tags.some((t) => t.toLowerCase().includes(filters.audience.toLowerCase()))) &&
         (!filters.minFollowers || c.followers >= parseInt(filters.minFollowers)) &&
-        (!filters.maxFollowers || c.followers <= parseInt(filters.maxFollowers));
+        (!filters.maxFollowers || c.followers <= parseInt(filters.maxFollowers)) &&
+        (!filters.minEngagement || c.engagementRate >= parseFloat(filters.minEngagement)) &&
+        (!filters.maxEngagement || c.engagementRate <= parseFloat(filters.maxEngagement));
 
       return matchesQuery && matchesFilters;
     })

--- a/apps/brand/components/FilterBar.tsx
+++ b/apps/brand/components/FilterBar.tsx
@@ -4,38 +4,34 @@ import { useState } from "react";
 
 type Props = {
   onFilter: (filters: Record<string, string>) => void;
-  onSort: (sort: string) => void;
+  onSort?: (sort: string) => void;
 };
 
 export default function FilterBar({ onFilter, onSort }: Props) {
-  const [niche, setNiche] = useState("");
   const [platform, setPlatform] = useState("");
+  const [tone, setTone] = useState("");
+  const [audience, setAudience] = useState("");
   const [minFollowers, setMinFollowers] = useState("");
   const [maxFollowers, setMaxFollowers] = useState("");
+  const [minEngagement, setMinEngagement] = useState("");
+  const [maxEngagement, setMaxEngagement] = useState("");
   const [sort, setSort] = useState("");
 
   const handleApply = () => {
-    onFilter({ niche, platform, minFollowers, maxFollowers });
-    onSort(sort);
+    onFilter({
+      platform,
+      tone,
+      audience,
+      minFollowers,
+      maxFollowers,
+      minEngagement,
+      maxEngagement,
+    });
+    onSort?.(sort);
   };
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mb-8">
-      <select
-        value={niche}
-        onChange={(e) => setNiche(e.target.value)}
-        className="bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white p-2 rounded-lg border border-gray-300 dark:border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
-      >
-        <option value="">All Niches</option>
-        <option value="Beauty">Beauty</option>
-        <option value="Fitness">Fitness</option>
-        <option value="Tech">Tech</option>
-        <option value="Finance">Finance</option>
-        <option value="Travel">Travel</option>
-        <option value="Home & Plants">Home & Plants</option>
-        <option value="Gaming">Gaming</option>
-        <option value="Food">Food</option>
-      </select>
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4 mb-8">
 
       <select
         value={platform}
@@ -47,6 +43,20 @@ export default function FilterBar({ onFilter, onSort }: Props) {
         <option value="TikTok">TikTok</option>
         <option value="YouTube">YouTube</option>
       </select>
+
+      <input
+        value={tone}
+        onChange={(e) => setTone(e.target.value)}
+        placeholder="Tone"
+        className="bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white p-2 rounded-lg border border-gray-300 dark:border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
+      />
+
+      <input
+        value={audience}
+        onChange={(e) => setAudience(e.target.value)}
+        placeholder="Audience"
+        className="bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white p-2 rounded-lg border border-gray-300 dark:border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
+      />
 
       <input
         type="number"
@@ -61,6 +71,24 @@ export default function FilterBar({ onFilter, onSort }: Props) {
         placeholder="Max Followers"
         value={maxFollowers}
         onChange={(e) => setMaxFollowers(e.target.value)}
+        className="bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white p-2 rounded-lg border border-gray-300 dark:border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
+      />
+
+      <input
+        type="number"
+        step="0.1"
+        placeholder="Min ER%"
+        value={minEngagement}
+        onChange={(e) => setMinEngagement(e.target.value)}
+        className="bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white p-2 rounded-lg border border-gray-300 dark:border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
+      />
+
+      <input
+        type="number"
+        step="0.1"
+        placeholder="Max ER%"
+        value={maxEngagement}
+        onChange={(e) => setMaxEngagement(e.target.value)}
         className="bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white p-2 rounded-lg border border-gray-300 dark:border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent transition"
       />
 


### PR DESCRIPTION
## Summary
- add filter fields for tone, audience, followers and engagement range
- update dashboard logic to filter by new fields

## Testing
- `npm run lint -w apps/brand`
- `npm run build -w apps/brand` *(fails: Can't resolve '../../creator/app/generated/prisma')*

------
https://chatgpt.com/codex/tasks/task_e_685157c5dac8832ca9d20ddacb4cb9fb