### PR TITLE
Add live filtering to brand dashboard

### DIFF
--- a/apps/brand/components/FilterBar.tsx
+++ b/apps/brand/components/FilterBar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 type Props = {
   onFilter: (filters: Record<string, string>) => void;
@@ -17,7 +17,8 @@ export default function FilterBar({ onFilter, onSort }: Props) {
   const [maxEngagement, setMaxEngagement] = useState("");
   const [sort, setSort] = useState("");
 
-  const handleApply = () => {
+  // automatically push filter updates up to the parent
+  useEffect(() => {
     onFilter({
       platform,
       tone,
@@ -27,8 +28,11 @@ export default function FilterBar({ onFilter, onSort }: Props) {
       minEngagement,
       maxEngagement,
     });
+  }, [platform, tone, audience, minFollowers, maxFollowers, minEngagement, maxEngagement, onFilter]);
+
+  useEffect(() => {
     onSort?.(sort);
-  };
+  }, [sort, onSort]);
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-6 gap-4 mb-8">
@@ -104,13 +108,6 @@ export default function FilterBar({ onFilter, onSort }: Props) {
           <option value="engagement-desc">Engagement ↓</option>
           <option value="engagement-asc">Engagement ↑</option>
         </select>
-
-        <button
-          onClick={handleApply}
-          className="bg-Siora-accent hover:bg-Siora-accent-soft text-white px-4 py-2 rounded-lg font-semibold transition"
-        >
-          Apply Filters
-        </button>
       </div>
     </div>
   );

--- a/apps/brand/src/app/dashboard/page.tsx
+++ b/apps/brand/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { creators as mockCreators, type Creator } from "@/app/data/creators";
 
 export default function Dashboard() {
   const [creators, setCreators] = useState<Creator[]>([]);
+  const [query, setQuery] = useState("");
   const [platform, setPlatform] = useState("");
   const [vibe, setVibe] = useState("");
   const [format, setFormat] = useState("");
@@ -32,6 +33,16 @@ export default function Dashboard() {
   // apply filters whenever options change
   useEffect(() => {
     let result = creators;
+    if (query) {
+      const q = query.toLowerCase();
+      result = result.filter(
+        (c) =>
+          c.name.toLowerCase().includes(q) ||
+          c.handle.toLowerCase().includes(q) ||
+          c.summary.toLowerCase().includes(q) ||
+          c.tags.some((t) => t.toLowerCase().includes(q))
+      );
+    }
     if (platform) {
       result = result.filter((c) =>
         c.platform.toLowerCase().includes(platform.toLowerCase())
@@ -60,11 +71,17 @@ export default function Dashboard() {
       }
     }
     setFiltered(result);
-  }, [platform, vibe, format, minScore, maxScore, creators]);
+  }, [query, platform, vibe, format, minScore, maxScore, creators]);
 
   return (
     <div className="p-8 space-y-6">
       <h1 className="text-2xl font-semibold">Creator Personas</h1>
+      <input
+        className="p-2 w-full border rounded bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white border-gray-300 dark:border-Siora-border"
+        placeholder="Search creators"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+      />
       <div className="grid grid-cols-1 sm:grid-cols-5 gap-4">
         <select
           className="p-2 border rounded bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white border-gray-300 dark:border-Siora-border"


### PR DESCRIPTION
## Summary
- call filtering callbacks automatically in `FilterBar`
- support a search bar and real time filtering for creator personas

## Testing
- `npm run lint -w apps/brand`

------
https://chatgpt.com/codex/tasks/task_e_68515bc6051c832c8214016977607191