### PR TITLE
Move fit score logic to shared utils

### DIFF
--- a/apps/brand/app/dashboard/recommended/page.tsx
+++ b/apps/brand/app/dashboard/recommended/page.tsx
@@ -1,9 +1,6 @@
 import { creators, type Creator } from "@/app/data/creators";
-import type {
-  BrandProfile,
-  CreatorPersona,
-} from "../../../../../packages/shared-utils/src/fitScoreEngine";
-import { getFitScore } from "../../../../../packages/shared-utils/src/fitScoreEngine";
+import type { BrandProfile, CreatorPersona } from "shared-utils";
+import { getFitScore } from "shared-utils";
 
 export const dynamic = "force-static";
 

--- a/apps/brand/package.json
+++ b/apps/brand/package.json
@@ -19,7 +19,8 @@
     "next-auth": "^4.24.11",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^6.9.0",
-    "prisma": "^6.9.0"
+    "prisma": "^6.9.0",
+    "shared-utils": "workspace:*"
   },
   "devDependencies": {
     "@tailwindcss/postcss7-compat": "^2.2.17",

--- a/apps/creator/package.json
+++ b/apps/creator/package.json
@@ -26,7 +26,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-markdown": "^10.1.0",
-    "stripe": "^18.2.1"
+    "stripe": "^18.2.1",
+    "shared-utils": "workspace:*"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.3",

--- a/tools/score_creators.mjs
+++ b/tools/score_creators.mjs
@@ -1,4 +1,4 @@
-import { rankCreators } from '../packages/shared-utils/src/creatorRanking.ts';
+import { rankCreators } from 'shared-utils';
 import creators from '../apps/brand/app/data/mock_creators_200.json' assert { type: 'json' };
 
 const brand = {


### PR DESCRIPTION
## Summary
- add `shared-utils` dependency to brand and creator apps
- import fit score utilities from `shared-utils`
- update scoring tool to import from package

## Testing
- `npm run lint` *(fails: ESLint setup prompts in homepage workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68515bd40210832c88f119c9b97bf781