### PR TITLE
Fix framer-motion type resolution

### DIFF
--- a/apps/brand/tsconfig.json
+++ b/apps/brand/tsconfig.json
@@ -13,7 +13,6 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "types": ["node"],
     "target": "ES2017",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,


### PR DESCRIPTION
## Summary
- remove `types` field from Brand app's tsconfig so TypeScript can locate framer-motion's bundled types

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515efc8bb0832cba77859cc2100238