### PR TITLE
Add collab request modal

### DIFF
--- a/apps/brand/app/matches/page.tsx
+++ b/apps/brand/app/matches/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState, useMemo } from "react";
+import CollabRequestModal from "@/components/CollabRequestModal";
 import creators from "@/app/data/mock_creators_200.json";
 import { useShortlist } from "@/lib/shortlist";
 import { useSession } from "next-auth/react";
@@ -12,6 +13,8 @@ export default function MatchesPage() {
   const user = session?.user?.email ?? null;
   const { toggle, inShortlist } = useShortlist(user);
   const [brand, setBrand] = useState<BrandProfile | null>(null);
+  const [showModal, setShowModal] = useState(false);
+  const [selectedCreator, setSelectedCreator] = useState<string | null>(null);
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -43,7 +46,8 @@ export default function MatchesPage() {
   }, [brand]);
 
   const requestCollab = (name: string) => {
-    alert(`Collab request for ${name}`);
+    setSelectedCreator(name);
+    setShowModal(true);
   };
 
   if (!brand) {
@@ -55,6 +59,7 @@ export default function MatchesPage() {
   }
 
   return (
+    <>
     <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
       <div className="max-w-4xl mx-auto space-y-6">
         <h1 className="text-4xl font-extrabold">Your Top Matches</h1>
@@ -85,5 +90,11 @@ export default function MatchesPage() {
         </div>
       </div>
     </main>
+    <CollabRequestModal
+      open={showModal}
+      onClose={() => setShowModal(false)}
+      creator={selectedCreator}
+    />
+    </>
   );
 }

--- a/apps/brand/components/CollabRequestModal.tsx
+++ b/apps/brand/components/CollabRequestModal.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { useState } from "react";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  creator: string | null;
+};
+
+export default function CollabRequestModal({ open, onClose, creator }: Props) {
+  const [message, setMessage] = useState("");
+  const [budget, setBudget] = useState("");
+
+  if (!open) return null;
+
+  const handleSend = () => {
+    // In a real app this would POST to an API.
+    console.log({ creator, message, budget });
+    onClose();
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-Siora-mid border border-Siora-border rounded-xl p-6 w-96 space-y-4 shadow-Siora-hover">
+        <h2 className="text-xl font-semibold">
+          Request Collaboration with {creator}
+        </h2>
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Short message"
+          className="w-full h-24 p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
+        />
+        <input
+          value={budget}
+          onChange={(e) => setBudget(e.target.value)}
+          placeholder="Budget range (e.g. $500-$1000)"
+          className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
+        />
+        <div className="flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="px-3 py-1 text-sm rounded border border-Siora-border text-white"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSend}
+            className="px-3 py-1 text-sm rounded bg-Siora-accent text-white"
+          >
+            Send
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `CollabRequestModal` component to gather a short message and budget range
- show modal from matches page when clicking **Request Collab**

## Testing
- `npm run lint -w apps/brand` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515e89c14c832cad340046f8edefb1