### PR TITLE
Add shortlist button text updates

### DIFF
--- a/apps/brand/README.md
+++ b/apps/brand/README.md
@@ -28,7 +28,7 @@ This app does not require any environment variables by default.
 
 ## Dashboard
 
-Visit `/signin` to log in. After signing in, head to `/brands` to search creator personas. Results can be filtered by tone, platform and vibe. Each profile can be saved to your personal shortlist which is stored in your browser.
+Visit `/signin` to log in. After signing in, head to `/brands` to search creator personas. Results can be filtered by tone, platform and vibe. Each profile can be saved to your personal shortlist which is stored in your browser. View your selections any time at `/shortlist`.
 
 `/dashboard` and `/personas` remain available for exploring personas without authentication.
 

--- a/apps/brand/app/matches/page.tsx
+++ b/apps/brand/app/matches/page.tsx
@@ -71,7 +71,7 @@ export default function MatchesPage() {
                   onClick={() => toggle(creator.id)}
                   className="px-3 py-1 text-sm rounded bg-Siora-accent text-white"
                 >
-                  {inShortlist(creator.id) ? "Saved" : "Save"}
+                  {inShortlist(creator.id) ? "Remove from Shortlist" : "Save to Shortlist"}
                 </button>
                 <button
                   onClick={() => requestCollab(creator.name)}

--- a/apps/brand/components/CreatorCard.tsx
+++ b/apps/brand/components/CreatorCard.tsx
@@ -80,7 +80,7 @@ export default function CreatorCard({ creator, onShortlist, shortlisted }: Props
           onClick={() => onShortlist(creator.id)}
           className="ml-4 text-sm mt-4 text-Siora-accent underline"
         >
-          {shortlisted ? 'Remove' : 'Shortlist'}
+          {shortlisted ? 'Remove from Shortlist' : 'Save to Shortlist'}
         </button>
       )}
     </motion.div>

--- a/apps/brand/components/PersonaCard.tsx
+++ b/apps/brand/components/PersonaCard.tsx
@@ -44,7 +44,7 @@ export default function PersonaCard({ persona, onToggle, inShortlist }: Props) {
           onClick={() => onToggle(persona.id)}
           className="ml-4 text-sm text-Siora-accent underline"
         >
-          {inShortlist ? "Remove" : "Save"}
+          {inShortlist ? "Remove from Shortlist" : "Save to Shortlist"}
         </button>
       )}
     </motion.div>


### PR DESCRIPTION
## Summary
- update shortlist button labels in CreatorCard, PersonaCard and matches page
- clarify shortlist page in brand app README

## Testing
- `npm run lint -w apps/brand` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515e910648832c9602622342a1c138