### PR TITLE
Add creator notes and collab status

### DIFF
--- a/apps/brand/app/creator/[id]/notes/page.tsx
+++ b/apps/brand/app/creator/[id]/notes/page.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { useEffect } from "react";
+import { useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import creators from "@/app/data/mock_creators_200.json";
+import { useCreatorMeta } from "@/lib/creatorMeta";
+
+export default function CreatorNotesPage({ params }: { params: { id: string } }) {
+  const { data: session, status } = useSession();
+  const user = session?.user?.email ?? null;
+  const router = useRouter();
+  const { notes, updateNote, status: collab, updateStatus } = useCreatorMeta(user);
+
+  useEffect(() => {
+    if (status === "unauthenticated") router.replace("/signin");
+  }, [status, router]);
+
+  if (status === "loading") return null;
+
+  const creator = creators.find((c) => c.id.toString() === params.id);
+  if (!creator) return <p className="p-6">Creator not found</p>;
+
+  const note = notes[creator.id] || "";
+  const collabStatus = collab[creator.id] || "not_contacted";
+
+  return (
+    <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
+      <div className="max-w-xl mx-auto space-y-6">
+        <h1 className="text-3xl font-bold">
+          Notes for {creator.name}{" "}
+          <span className="text-Siora-accent">@{creator.handle.replace(/^@/, "")}</span>
+        </h1>
+        <textarea
+          value={note}
+          onChange={(e) => updateNote(creator.id, e.target.value)}
+          placeholder="Add your notes"
+          className="w-full h-40 p-3 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
+        />
+        <div>
+          <label className="block mb-1">Collab Status</label>
+          <select
+            value={collabStatus}
+            onChange={(e) => updateStatus(creator.id, e.target.value as any)}
+            className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
+          >
+            <option value="not_contacted">Not contacted</option>
+            <option value="contacted">Contacted</option>
+            <option value="negotiating">Negotiating</option>
+            <option value="closed">Closed</option>
+          </select>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/apps/brand/app/shortlist/page.tsx
+++ b/apps/brand/app/shortlist/page.tsx
@@ -6,12 +6,15 @@ import creators from "@/app/data/mock_creators_200.json";
 import CreatorCard from "@/components/CreatorCard";
 import { useSession } from "next-auth/react";
 import { useShortlist } from "@/lib/shortlist";
+import Link from "next/link";
+import { useCreatorMeta } from "@/lib/creatorMeta";
 
 export default function ShortlistPage() {
   const { data: session, status } = useSession();
   const user = session?.user?.email ?? null;
   const router = useRouter();
   const { ids, toggle } = useShortlist(user);
+  const { status: collabStatus } = useCreatorMeta(user);
 
   useEffect(() => {
     if (status === "unauthenticated") router.replace("/signin");
@@ -30,7 +33,13 @@ export default function ShortlistPage() {
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             {saved.map((c) => (
-              <CreatorCard key={c.id} creator={c} onShortlist={toggle} shortlisted={true} />
+              <CreatorCard key={c.id} creator={c} onShortlist={toggle} shortlisted={true}>
+                <div className="mt-2 flex flex-wrap items-center gap-2 text-sm">
+                  <Link href={`/creator/${c.id}/profile`} className="text-Siora-accent underline">Profile</Link>
+                  <Link href={`/creator/${c.id}/notes`} className="text-Siora-accent underline">Notes</Link>
+                  <span className="text-zinc-400 ml-auto">Status: {collabStatus[c.id] ?? "not_contacted"}</span>
+                </div>
+              </CreatorCard>
             ))}
           </div>
         )}

--- a/apps/brand/components/CreatorCard.tsx
+++ b/apps/brand/components/CreatorCard.tsx
@@ -5,12 +5,15 @@ import { motion } from "framer-motion";
 import type { Creator } from "@/app/data/creators";
 import { useState } from "react";
 
+import { ReactNode } from "react";
+
 type Props = {
   creator: Creator;
   onShortlist?: (id: string) => void;
   shortlisted?: boolean;
+  children?: ReactNode;
 };
-export default function CreatorCard({ creator, onShortlist, shortlisted }: Props) {
+export default function CreatorCard({ creator, onShortlist, shortlisted, children }: Props) {
   const [loading, setLoading] = useState(false);
 
   const handleContact = async () => {
@@ -83,6 +86,7 @@ export default function CreatorCard({ creator, onShortlist, shortlisted }: Props
           {shortlisted ? 'Remove' : 'Shortlist'}
         </button>
       )}
+      {children}
     </motion.div>
   );
 }

--- a/apps/brand/lib/creatorMeta.ts
+++ b/apps/brand/lib/creatorMeta.ts
@@ -1,0 +1,43 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export type CollabStatus = "not_contacted" | "contacted" | "negotiating" | "closed";
+
+export function useCreatorMeta(user: string | null) {
+  const notesKey = user ? `notes:${user}` : "notes";
+  const statusKey = user ? `status:${user}` : "status";
+  const [notes, setNotes] = useState<Record<string, string>>({});
+  const [status, setStatus] = useState<Record<string, CollabStatus>>({});
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const storedNotes = localStorage.getItem(notesKey);
+      if (storedNotes) setNotes(JSON.parse(storedNotes));
+    } catch {}
+    try {
+      const storedStatus = localStorage.getItem(statusKey);
+      if (storedStatus) setStatus(JSON.parse(storedStatus));
+    } catch {}
+  }, [notesKey, statusKey]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(notesKey, JSON.stringify(notes));
+  }, [notes, notesKey]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    localStorage.setItem(statusKey, JSON.stringify(status));
+  }, [status, statusKey]);
+
+  const updateNote = (id: string, note: string) => {
+    setNotes((prev) => ({ ...prev, [id]: note }));
+  };
+
+  const updateStatus = (id: string, s: CollabStatus) => {
+    setStatus((prev) => ({ ...prev, [id]: s }));
+  };
+
+  return { notes, status, updateNote, updateStatus };
+}


### PR DESCRIPTION
## Summary
- tweak `CreatorCard` to support additional actions
- show quick links for profiles and notes with status on shortlist page
- save notes & collab status in browser local storage
- add a creator notes page for editing notes and status

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm run build:brand` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68515e984c08832c8d28aa400da74c9a