### PR TITLE
Enable shortlist export to PDF

### DIFF
--- a/apps/brand/app/api/export-shortlist/pdf.css
+++ b/apps/brand/app/api/export-shortlist/pdf.css
@@ -1,0 +1,25 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #fafafa;
+  color: #333;
+  line-height: 1.6;
+  padding: 20px;
+}
+h1, h2, h3, h4, h5 {
+  font-weight: bold;
+  margin-top: 1.2em;
+}
+pre {
+  background: #f0f0f0;
+  padding: 10px;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+code {
+  font-family: "Courier New", monospace;
+}
+
+img {
+  border-radius: 6px;
+  margin-bottom: 4px;
+}

--- a/apps/brand/app/api/export-shortlist/route.ts
+++ b/apps/brand/app/api/export-shortlist/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server'
+import markdownpdf from 'markdown-pdf'
+import path from 'path'
+
+export async function POST(req: Request) {
+  try {
+    const { markdown } = await req.json()
+    if (!markdown || typeof markdown !== 'string') {
+      return NextResponse.json({ error: 'Markdown string required' }, { status: 400 })
+    }
+
+    const cssPath = path.join(process.cwd(), 'apps', 'brand', 'app', 'api', 'export-shortlist', 'pdf.css')
+
+    const buffer: Buffer = await new Promise((resolve, reject) => {
+      markdownpdf({ cssPath })
+        .from.string(markdown)
+        .to.buffer((err, buff) => {
+          if (err) reject(err)
+          else resolve(buff)
+        })
+    })
+
+    return new NextResponse(buffer, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': 'attachment; filename="shortlist.pdf"',
+      },
+    })
+  } catch (err) {
+    console.error('PDF export failed', err)
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+}

--- a/apps/brand/package.json
+++ b/apps/brand/package.json
@@ -15,6 +15,7 @@
     "react-markdown": "^10.1.0",
     "framer-motion": "^12.6.3",
     "jspdf": "^3.0.1",
+    "markdown-pdf": "^11.0.0",
     "fuse.js": "^7.1.0",
     "next-auth": "^4.24.11",
     "@next-auth/prisma-adapter": "^1.0.7",


### PR DESCRIPTION
## Summary
- add server route `/api/export-shortlist` for Markdown → PDF
- provide matching `pdf.css`
- let brands export shortlist as a PDF
- include `markdown-pdf` in brand dependencies

## Testing
- `npm run lint -w apps/brand` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685161f07f9c832cbdcf416d9c5cd974