### PR TITLE
Add campaigns page with API and toast

### DIFF
--- a/apps/creator/app/api/campaigns/route.ts
+++ b/apps/creator/app/api/campaigns/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import path from 'path';
+import { promises as fs } from 'fs';
+
+const dbPath = path.join(process.cwd(), '..', '..', 'db', 'campaigns.json');
+
+export async function GET() {
+  try {
+    const file = await fs.readFile(dbPath, 'utf8');
+    const data = JSON.parse(file);
+    const list = Array.isArray(data) ? data : [];
+    const now = Date.now();
+    const active = list.filter((c: { deadline?: string }) =>
+      !c.deadline || Date.parse(c.deadline) > now
+    );
+    return NextResponse.json(active);
+  } catch {
+    return NextResponse.json([]);
+  }
+}

--- a/apps/creator/app/campaigns/page.tsx
+++ b/apps/creator/app/campaigns/page.tsx
@@ -1,23 +1,78 @@
 "use client";
-import Link from "next/link";
-import campaigns from "@/app/data/campaigns";
+import { useEffect, useState } from "react";
+import Toast from "@/components/Toast";
+
+interface Campaign {
+  id: string;
+  name: string;
+  description: string;
+  deliverables: string;
+  deadline: string;
+}
 
 export default function CampaignsPage() {
+  const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+  const [toast, setToast] = useState("");
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch("/api/campaigns");
+        if (res.ok) {
+          const data = await res.json();
+          if (Array.isArray(data)) setCampaigns(data as Campaign[]);
+        }
+      } catch (err) {
+        console.error("Failed to load campaigns", err);
+      }
+    }
+    load();
+  }, []);
+
+  async function apply(id: string) {
+    try {
+      await fetch("/api/campaign-applications", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          campaignId: id,
+          pitch: "Excited to collaborate!",
+          personaSummary: "",
+        }),
+      });
+      setToast("Application submitted!");
+    } catch {
+      setToast("Failed to apply");
+    }
+  }
+
   return (
     <main className="min-h-screen bg-background text-foreground p-6 space-y-6">
       <h1 className="text-2xl font-bold">Brand Campaigns</h1>
       <div className="space-y-4">
         {campaigns.map((c) => (
-          <div key={c.id} className="border border-white/10 p-4 rounded-lg space-y-2">
-            <h2 className="text-lg font-semibold">{c.title}</h2>
-            <p className="text-sm text-foreground/80">{c.brand}</p>
+          <div
+            key={c.id}
+            className="border border-white/10 p-4 rounded-lg space-y-2"
+          >
+            <h2 className="text-lg font-semibold">{c.name}</h2>
             <p className="text-sm">{c.description}</p>
-            <Link href={`/campaigns/${c.id}/apply`} className="text-indigo-600 underline">
+            <p className="text-sm text-foreground/80">
+              Deliverables: {c.deliverables}
+            </p>
+            <p className="text-sm text-foreground/80">
+              Deadline: {new Date(c.deadline).toLocaleDateString()}
+            </p>
+            <button
+              onClick={() => apply(c.id)}
+              className="text-indigo-600 underline"
+            >
               Apply
-            </Link>
+            </button>
           </div>
         ))}
       </div>
+      {toast && <Toast message={toast} onClose={() => setToast("")} />}
     </main>
   );
 }

--- a/apps/creator/components/Toast.tsx
+++ b/apps/creator/components/Toast.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { useEffect } from 'react';
+
+export default function Toast({ message, onClose }: { message: string; onClose: () => void }) {
+  useEffect(() => {
+    const t = setTimeout(onClose, 3000);
+    return () => clearTimeout(t);
+  }, [onClose]);
+
+  return (
+    <div className="fixed bottom-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow">
+      {message}
+    </div>
+  );
+}

--- a/db/campaigns.json
+++ b/db/campaigns.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "1",
+    "name": "Summer Glow Launch",
+    "description": "Seeking beauty creators to promote our new dewy foundation line.",
+    "deliverables": "1 IG Reel and 3 Story frames highlighting product benefits",
+    "deadline": "2025-12-31"
+  },
+  {
+    "id": "2",
+    "name": "Fall Fitness Push",
+    "description": "Looking for energetic influencers to showcase our workout gear.",
+    "deliverables": "2 posts wearing gear, 1 short testimonial video",
+    "deadline": "2025-11-15"
+  },
+  {
+    "id": "3",
+    "name": "Green Living Tips",
+    "description": "Creators passionate about sustainability to share our eco products.",
+    "deliverables": "Blog article or video review and 5 social shares",
+    "deadline": "2025-10-01"
+  }
+]


### PR DESCRIPTION
## Summary
- add `Toast` component for simple notifications
- create `/api/campaigns` endpoint
- load campaigns on the creator campaigns page and allow applying
- store sample campaigns in `db/campaigns.json`

## Testing
- `npm run lint -w apps/creator` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851620e354c832c89c6181e34f2e167