### PR TITLE
Add performance metrics component

### DIFF
--- a/apps/creator/app/dashboard/page.tsx
+++ b/apps/creator/app/dashboard/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import PersonaCard from "@/components/PersonaCard";
+import PerformanceMetrics from "@/components/PerformanceMetrics";
 import type { PersonaProfile } from "@/types/persona";
 
 interface PersonaRecord {
@@ -57,6 +58,7 @@ export default function DashboardPage() {
           My Applications
         </Link>
       </nav>
+      <PerformanceMetrics />
       {items.length === 0 ? (
         <p className="text-foreground/60">{loading ? "Loading..." : "No personas found."}</p>
       ) : (

--- a/apps/creator/components/PerformanceMetrics.tsx
+++ b/apps/creator/components/PerformanceMetrics.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+
+const mockData = {
+  followers: {
+    instagram: 12000,
+    tiktok: 15000,
+    youtube: 8000,
+  },
+  avgViews: 5000,
+  engagementRate: 4.8,
+  recentTopContent: [
+    { title: "How to style activewear", views: 12000 },
+    { title: "Daily workout routine", views: 11000 },
+    { title: "Healthy meal prep ideas", views: 10500 },
+  ],
+};
+
+export default function PerformanceMetrics() {
+  const { followers, avgViews, engagementRate, recentTopContent } = mockData;
+  return (
+    <div className="border border-white/10 bg-background p-4 rounded-xl shadow-sm space-y-4">
+      <h2 className="text-lg font-bold">Performance Metrics</h2>
+      <div>
+        <h3 className="font-semibold text-sm mb-1">Total Followers</h3>
+        <ul className="text-sm space-y-1">
+          {Object.entries(followers).map(([platform, count]) => (
+            <li key={platform} className="flex justify-between">
+              <span className="capitalize">{platform}</span>
+              <span>{count.toLocaleString()}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="text-sm space-y-1">
+        <p>
+          <span className="font-semibold">Avg Views per Post:</span>{" "}
+          {avgViews.toLocaleString()}
+        </p>
+        <p>
+          <span className="font-semibold">Engagement Rate:</span>{" "}
+          {engagementRate}%
+        </p>
+      </div>
+      <div>
+        <h3 className="font-semibold text-sm mb-1">Recent Top Content</h3>
+        <ul className="list-disc list-inside text-sm space-y-1">
+          {recentTopContent.map((post, i) => (
+            <li key={i}>
+              {post.title} - {post.views.toLocaleString()} views
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `PerformanceMetrics` component showing follower and engagement stats
- display `PerformanceMetrics` on the creator dashboard page

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851896a7fc8832cafcc0a6cbae6dd53