### PR TITLE
Add campaign application management page

### DIFF
--- a/apps/brand/app/api/campaigns/[id]/applications/route.ts
+++ b/apps/brand/app/api/campaigns/[id]/applications/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import path from 'path';
+import { promises as fs } from 'fs';
+
+interface Application {
+  id: string;
+  userId: string;
+  campaignId: string;
+  pitch: string;
+  personaSummary: string;
+  timestamp: string;
+}
+
+const dbPath = path.join(process.cwd(), '..', '..', 'db', 'campaign_applications.json');
+
+async function readData(): Promise<Application[]> {
+  try {
+    const file = await fs.readFile(dbPath, 'utf8');
+    const data = JSON.parse(file);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  try {
+    const data = await readData();
+    const apps = data.filter(a => a.campaignId === params.id);
+    return NextResponse.json(apps);
+  } catch (err) {
+    console.error('failed to load applications', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/apps/brand/app/api/matches/route.ts
+++ b/apps/brand/app/api/matches/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+
+interface MatchEntry {
+  id: string;
+  campaignId: string;
+  creatorId: string;
+  timestamp: string;
+  applicationId?: string;
+}
+
+const dbPath = path.join(process.cwd(), '..', '..', 'db', 'matches.json');
+
+async function readData(): Promise<MatchEntry[]> {
+  try {
+    const file = await fs.readFile(dbPath, 'utf8');
+    const data = JSON.parse(file);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeData(data: MatchEntry[]) {
+  await fs.writeFile(dbPath, JSON.stringify(data, null, 2));
+}
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const campaignId = searchParams.get('campaignId');
+    const data = await readData();
+    const matches = campaignId ? data.filter(m => m.campaignId === campaignId) : data;
+    return NextResponse.json(matches);
+  } catch (err) {
+    console.error('matches GET error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { campaignId, creatorId, applicationId } = await req.json();
+    if (!campaignId || !creatorId) {
+      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+    }
+    const data = await readData();
+    const entry: MatchEntry = {
+      id: randomUUID(),
+      campaignId,
+      creatorId,
+      timestamp: new Date().toISOString(),
+      applicationId,
+    };
+    data.push(entry);
+    await writeData(data);
+    return NextResponse.json(entry);
+  } catch (err) {
+    console.error('matches POST error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/apps/brand/app/campaigns/[id]/applications/page.tsx
+++ b/apps/brand/app/campaigns/[id]/applications/page.tsx
@@ -1,0 +1,96 @@
+"use client";
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import Toast from '@/components/Toast';
+import { creators } from '@/app/data/creators';
+
+interface Application {
+  id: string;
+  userId: string;
+  campaignId: string;
+  personaSummary: string;
+  timestamp: string;
+}
+
+export default function ApplicationsPage() {
+  const params = useParams<{ id: string }>();
+  const campaignId = params.id;
+  const [apps, setApps] = useState<Application[]>([]);
+  const [toast, setToast] = useState('');
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/campaigns/${campaignId}/applications`);
+        if (res.ok) {
+          const data = await res.json();
+          if (Array.isArray(data)) setApps(data as Application[]);
+        }
+      } catch (err) {
+        console.error('failed to load applications', err);
+      }
+    }
+    if (campaignId) load();
+  }, [campaignId]);
+
+  async function accept(application: Application) {
+    try {
+      await fetch('/api/matches', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          campaignId,
+          creatorId: application.userId,
+          applicationId: application.id,
+        }),
+      });
+      setApps((prev) => prev.filter((a) => a.id !== application.id));
+      setToast('Application accepted');
+    } catch {
+      setToast('Failed to accept');
+    }
+  }
+
+  function reject(id: string) {
+    setApps((prev) => prev.filter((a) => a.id !== id));
+    setToast('Application rejected');
+  }
+
+  return (
+    <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
+      <div className="max-w-4xl mx-auto space-y-6">
+        <h1 className="text-4xl font-extrabold">Campaign Applications</h1>
+        {apps.length === 0 ? (
+          <p className="text-center text-zinc-400">No applications yet.</p>
+        ) : (
+          <div className="space-y-4">
+            {apps.map((app) => {
+              const creator = creators.find((c) => c.id === app.userId);
+              return (
+                <div key={app.id} className="bg-Siora-mid border border-Siora-border rounded-xl p-6 shadow-Siora-hover">
+                  <h2 className="text-xl font-semibold">
+                    {creator ? (
+                      <Link href={`/dashboard/persona/${creator.handle.replace(/^@/, '')}`} className="text-Siora-accent underline">
+                        {creator.name}
+                      </Link>
+                    ) : (
+                      app.userId
+                    )}
+                  </h2>
+                  <p className="text-sm text-zinc-300 mb-2">{app.personaSummary}</p>
+                  <p className="text-sm text-zinc-400 mb-4">{new Date(app.timestamp).toLocaleString()}</p>
+                  <div className="flex gap-4">
+                    <button onClick={() => accept(app)} className="px-3 py-1 text-sm rounded bg-green-600 text-white">Accept</button>
+                    <button onClick={() => reject(app.id)} className="px-3 py-1 text-sm rounded bg-red-600 text-white">Reject</button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+      {toast && <Toast message={toast} onClose={() => setToast('')} />}
+    </main>
+  );
+}

--- a/apps/brand/components/Toast.tsx
+++ b/apps/brand/components/Toast.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { useEffect } from 'react';
+
+export default function Toast({ message, onClose }: { message: string; onClose: () => void }) {
+  useEffect(() => {
+    const t = setTimeout(onClose, 3000);
+    return () => clearTimeout(t);
+  }, [onClose]);
+
+  return (
+    <div className="fixed bottom-4 right-4 bg-green-600 text-white px-4 py-2 rounded shadow">
+      {message}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create API to list campaign applications
- store matches in a new API
- build page to manage applications for a campaign
- add Toast component for brand app

## Testing
- `npx turbo run lint` *(fails: Workspace 'packages/shared-ui' not found in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6851896325a8832caa88099fe413d01c