### PR TITLE
Add brand campaign goal matching dashboard

### DIFF
--- a/apps/brand/app/api/goal-match/route.ts
+++ b/apps/brand/app/api/goal-match/route.ts
@@ -1,0 +1,108 @@
+import creators from '@/app/data/mock_creators_200.json';
+import { NextResponse } from 'next/server';
+
+interface GoalRequest {
+  goals?: string;
+  tone?: string;
+  platform?: string;
+  audience?: string;
+}
+
+function scoreCreator(c: (typeof creators)[number], req: GoalRequest) {
+  let score = 0;
+  const reasons: string[] = [];
+  if (req.tone) {
+    const match = c.tone?.toLowerCase().includes(req.tone.toLowerCase());
+    if (match) {
+      score += 25;
+      reasons.push('Tone match');
+    }
+  }
+  if (req.platform) {
+    const match = c.platform.toLowerCase().includes(req.platform.toLowerCase());
+    if (match) {
+      score += 25;
+      reasons.push('Platform match');
+    }
+  }
+  if (req.goals) {
+    const words = req.goals.toLowerCase().split(/[,\s]+/);
+    const text = [c.niche, ...(c.tags||[])].join(' ').toLowerCase();
+    const match = words.some(w => text.includes(w));
+    if (match) {
+      score += 25;
+      reasons.push('Goal alignment');
+    }
+  }
+  if (req.audience) {
+    const words = req.audience.toLowerCase().split(/[,\s]+/);
+    const text = c.summary.toLowerCase();
+    const match = words.some(w => text.includes(w));
+    if (match) {
+      score += 25;
+      reasons.push('Audience overlap');
+    }
+  }
+  return { score, reasons };
+}
+
+export async function POST(req: Request) {
+  try {
+    const body: GoalRequest = await req.json();
+    const scored = creators.map(c => {
+      const { score, reasons } = scoreCreator(c, body);
+      return { creator: c, score, reasons };
+    });
+    scored.sort((a,b) => b.score - a.score);
+    const top = scored.slice(0,5);
+
+    let explanations: Record<string,string> = {};
+    try {
+      const messages = [
+        {
+          role: 'system',
+          content: [
+            'You help brands understand why creators match their campaign.',
+            'For each creator, provide one friendly sentence explaining the fit.',
+            'Respond ONLY with JSON array like [{ id: "1", reason: "..." }].'
+          ].join('\n')
+        },
+        {
+          role: 'user',
+          content: `Campaign goals: ${body.goals || ''}; Tone: ${body.tone || ''}; Platform: ${body.platform || ''}; Audience: ${body.audience || ''}. Creators: ${top.map(t => `${t.creator.id}:${t.creator.name}`).join(', ')}`
+        }
+      ];
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
+        },
+        body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.7 })
+      });
+      if (res.ok) {
+        const data = await res.json();
+        const content = data.choices?.[0]?.message?.content || '[]';
+        const arr = JSON.parse(content);
+        if (Array.isArray(arr)) {
+          for (const item of arr) {
+            if (item && item.id) explanations[item.id] = item.reason || '';
+          }
+        }
+      }
+    } catch (err) {
+      console.error('gpt explain error', err);
+    }
+
+    const results = top.map(t => ({
+      creator: t.creator,
+      score: t.score,
+      reason: explanations[t.creator.id] || t.reasons.join('; ')
+    }));
+
+    return NextResponse.json({ matches: results });
+  } catch (err) {
+    console.error('goal match error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/apps/brand/app/goal-dashboard/page.tsx
+++ b/apps/brand/app/goal-dashboard/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+import type { Creator } from "@/app/data/creators";
+
+interface Match {
+  creator: Creator;
+  score: number;
+  reason: string;
+}
+
+export default function GoalDashboard() {
+  const [goals, setGoals] = useState("");
+  const [tone, setTone] = useState("");
+  const [platform, setPlatform] = useState("");
+  const [audience, setAudience] = useState("");
+  const [matches, setMatches] = useState<Match[]>([]);
+  const [sort, setSort] = useState<"score" | "name">("score");
+  const [loading, setLoading] = useState(false);
+
+  async function fetchMatches() {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/goal-match", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ goals, tone, platform, audience })
+      });
+      const data = await res.json();
+      if (Array.isArray(data.matches)) setMatches(data.matches as Match[]);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const sorted = [...matches].sort((a, b) => {
+    return sort === "score"
+      ? b.score - a.score
+      : a.creator.name.localeCompare(b.creator.name);
+  });
+
+  return (
+    <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
+      <div className="max-w-7xl mx-auto space-y-8">
+        <h1 className="text-4xl font-extrabold tracking-tight">Campaign Matcher</h1>
+        <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
+          <input value={goals} onChange={e => setGoals(e.target.value)} placeholder="Campaign goals" className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border" />
+          <input value={tone} onChange={e => setTone(e.target.value)} placeholder="Tone" className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border" />
+          <input value={platform} onChange={e => setPlatform(e.target.value)} placeholder="Platform" className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border" />
+          <input value={audience} onChange={e => setAudience(e.target.value)} placeholder="Audience" className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border" />
+        </div>
+        <button onClick={fetchMatches} className="bg-Siora-accent hover:bg-Siora-accent-soft text-white px-4 py-2 rounded-lg font-semibold">
+          {loading ? "Searching..." : "Find Matches"}
+        </button>
+
+        {matches.length > 0 && (
+          <div className="space-y-4">
+            <div className="flex gap-4">
+              <button onClick={() => setSort("score")} className="px-3 py-1 rounded border border-Siora-border">Sort by Score</button>
+              <button onClick={() => setSort("name")} className="px-3 py-1 rounded border border-Siora-border">Sort by Name</button>
+            </div>
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr>
+                  <th className="text-left p-2">Creator</th>
+                  <th className="text-left p-2">Score</th>
+                  <th className="text-left p-2">Reason</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sorted.map(m => (
+                  <tr key={m.creator.id} className="border-t border-Siora-border">
+                    <td className="p-2">{m.creator.name}</td>
+                    <td className="p-2">{Math.round(m.score)}</td>
+                    <td className="p-2">{m.reason}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `/api/goal-match` endpoint to score creators against campaign goals
- query GPT‑4 for a friendly explanation of each top match
- add `/goal-dashboard` page where brands can search and sort matches

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518bab4a44832c80a87553a9bbc86f