### PR TITLE
Add campaign-based messaging

### DIFF
--- a/apps/brand/app/campaigns/[id]/applications/page.tsx
+++ b/apps/brand/app/campaigns/[id]/applications/page.tsx
@@ -47,6 +47,7 @@ export default function ApplicationsPage() {
       });
       setApps((prev) => prev.filter((a) => a.id !== application.id));
       setToast('Application accepted');
+      window.location.href = `/campaigns/${campaignId}/messages/${application.userId}`;
     } catch {
       setToast('Failed to accept');
     }

--- a/apps/brand/app/campaigns/[id]/messages/[creatorId]/page.tsx
+++ b/apps/brand/app/campaigns/[id]/messages/[creatorId]/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import creators from "@/app/data/mock_creators_200.json";
+import { ChatPanel, ChatMessage } from "shared-ui";
+
+interface Message extends ChatMessage {
+  creatorId: string;
+  campaign?: string;
+}
+
+export default function CampaignChatPage({ params }: { params: { creatorId: string; id: string } }) {
+  const creator = creators.find((c) => c.id === params.creatorId);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [sending, setSending] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/messages?creatorId=${params.creatorId}&campaign=${params.id}`);
+        if (res.ok) {
+          const data = await res.json();
+          setMessages(data.messages);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    load();
+  }, [params.creatorId, params.id]);
+
+  const send = async (text: string) => {
+    if (!text.trim()) return;
+    setSending(true);
+    try {
+      const res = await fetch('/api/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ creatorId: params.creatorId, sender: 'brand', text, campaign: params.id }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setMessages((prev) => [...prev, data.message]);
+      }
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen p-6">
+      <div className="max-w-xl mx-auto flex flex-col space-y-4">
+        <h1 className="text-2xl font-bold">Chat with {creator?.name ?? params.creatorId}</h1>
+        <ChatPanel
+          messages={messages}
+          currentUser="brand"
+          onSend={send}
+          sending={sending}
+        />
+      </div>
+    </main>
+  );
+}

--- a/apps/brand/app/campaigns/[id]/messages/page.tsx
+++ b/apps/brand/app/campaigns/[id]/messages/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useParams } from "next/navigation";
+import creators from "@/app/data/mock_creators_200.json";
+
+interface Match {
+  id: string;
+  campaignId: string;
+  creatorId: string;
+  timestamp: string;
+}
+
+export default function CampaignMessagesPage() {
+  const params = useParams<{ id: string }>();
+  const campaignId = params.id;
+  const [matches, setMatches] = useState<Match[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/matches?campaignId=${campaignId}`);
+        if (res.ok) {
+          const data = await res.json();
+          if (Array.isArray(data)) setMatches(data as Match[]);
+        }
+      } catch (err) {
+        console.error("failed to load matches", err);
+      }
+    }
+    if (campaignId) load();
+  }, [campaignId]);
+
+  return (
+    <main className="min-h-screen p-6">
+      <div className="max-w-xl mx-auto space-y-4">
+        <h1 className="text-2xl font-bold">Campaign Threads</h1>
+        <ul className="space-y-2">
+          {matches.map((m) => {
+            const creator = creators.find((c) => c.id === m.creatorId);
+            return (
+              <li key={m.id}>
+                <Link
+                  href={`/campaigns/${campaignId}/messages/${m.creatorId}`}
+                  className="text-Siora-accent underline"
+                >
+                  {creator ? creator.name : m.creatorId}
+                </Link>
+              </li>
+            );
+          })}
+          {matches.length === 0 && (
+            <li className="text-zinc-400">No matches yet.</li>
+          )}
+        </ul>
+      </div>
+    </main>
+  );
+}

--- a/apps/creator/app/api/matches/route.ts
+++ b/apps/creator/app/api/matches/route.ts
@@ -1,0 +1,64 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+
+interface MatchEntry {
+  id: string;
+  campaignId: string;
+  creatorId: string;
+  timestamp: string;
+  applicationId?: string;
+}
+
+const dbPath = path.join(process.cwd(), '..', '..', 'db', 'matches.json');
+
+async function readData(): Promise<MatchEntry[]> {
+  try {
+    const file = await fs.readFile(dbPath, 'utf8');
+    const data = JSON.parse(file);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeData(data: MatchEntry[]) {
+  await fs.writeFile(dbPath, JSON.stringify(data, null, 2));
+}
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const campaignId = searchParams.get('campaignId');
+    const data = await readData();
+    const matches = campaignId ? data.filter(m => m.campaignId === campaignId) : data;
+    return NextResponse.json(matches);
+  } catch (err) {
+    console.error('matches GET error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { campaignId, creatorId, applicationId } = await req.json();
+    if (!campaignId || !creatorId) {
+      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+    }
+    const data = await readData();
+    const entry: MatchEntry = {
+      id: randomUUID(),
+      campaignId,
+      creatorId,
+      timestamp: new Date().toISOString(),
+      applicationId,
+    };
+    data.push(entry);
+    await writeData(data);
+    return NextResponse.json(entry);
+  } catch (err) {
+    console.error('matches POST error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/apps/creator/app/campaigns/[id]/messages/page.tsx
+++ b/apps/creator/app/campaigns/[id]/messages/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import campaigns from "@/app/data/campaigns";
+import { ChatPanel, ChatMessage } from "shared-ui";
+
+interface Message extends ChatMessage {
+  creatorId: string;
+  campaign?: string;
+}
+
+const creatorId = "1"; // demo user
+
+export default function CreatorCampaignChat() {
+  const params = useParams<{ id: string }>();
+  const campaign = campaigns.find((c) => c.id === params.id);
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [sending, setSending] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/messages?creatorId=${creatorId}&campaign=${params.id}`);
+        if (res.ok) {
+          const data = await res.json();
+          setMessages(data.messages);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    if (params.id) load();
+  }, [params.id]);
+
+  const send = async (text: string) => {
+    if (!text.trim()) return;
+    setSending(true);
+    try {
+      const res = await fetch('/api/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ creatorId, sender: 'creator', text, campaign: params.id }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setMessages((prev) => [...prev, data.message]);
+      }
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen p-6">
+      <div className="max-w-xl mx-auto flex flex-col space-y-4">
+        <h1 className="text-2xl font-bold">Chat about {campaign?.title ?? params.id}</h1>
+        <ChatPanel
+          messages={messages}
+          currentUser="creator"
+          onSend={send}
+          sending={sending}
+        />
+      </div>
+    </main>
+  );
+}

--- a/db/matches.json
+++ b/db/matches.json
@@ -1,1 +1,9 @@
-[]
+[
+  {
+    "id": "match1",
+    "campaignId": "1",
+    "creatorId": "1",
+    "timestamp": "2024-05-01T12:00:00.000Z",
+    "applicationId": "app1"
+  }
+]

--- a/db/messages.json
+++ b/db/messages.json
@@ -1,1 +1,18 @@
-[]
+[
+  {
+    "id": "msg1",
+    "creatorId": "1",
+    "sender": "brand",
+    "text": "Welcome to the campaign!",
+    "campaign": "1",
+    "timestamp": "2024-05-01T12:10:00.000Z"
+  },
+  {
+    "id": "msg2",
+    "creatorId": "1",
+    "sender": "creator",
+    "text": "Thanks, excited to work together!",
+    "campaign": "1",
+    "timestamp": "2024-05-01T12:12:00.000Z"
+  }
+]


### PR DESCRIPTION
## Summary
- create messages route for campaigns and copy matches API for creator app
- add campaign chat pages for brand and creator
- list campaign threads for brands
- redirect brand to new campaign chat when accepting an application
- seed example matches and messages in the local database

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518bb34b28832c8e8e3c41d1e76f92