### PR TITLE
Add creator collabs dashboard

### DIFF
--- a/apps/creator/app/collabs/page.tsx
+++ b/apps/creator/app/collabs/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useState } from "react";
+import collabs from "@/app/data/collabs";
+
+const statusOptions = [
+  { value: "all", label: "All" },
+  { value: "active", label: "Active" },
+  { value: "pending payment", label: "Pending Payment" },
+  { value: "completed", label: "Completed" },
+];
+
+export default function CollabsPage() {
+  const [status, setStatus] = useState<string>("all");
+
+  const filtered = collabs.filter(
+    (c) => status === "all" || c.status === status
+  );
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 space-y-6">
+      <h1 className="text-2xl font-bold">My Collaborations</h1>
+
+      <select
+        value={status}
+        onChange={(e) => setStatus(e.target.value)}
+        className="p-2 rounded-md border bg-background border-white/10"
+      >
+        {statusOptions.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+
+      <div className="space-y-4">
+        {filtered.map((c) => (
+          <div
+            key={c.id}
+            className="border border-white/10 p-4 rounded-lg space-y-1"
+          >
+            <h2 className="text-lg font-semibold">{c.brand}</h2>
+            <p className="text-sm">{c.campaign}</p>
+            <p className="text-sm">Earnings: ${c.earnings}</p>
+            <p className="text-sm capitalize">Status: {c.status}</p>
+            {c.rating && (
+              <div className="flex gap-0.5 text-yellow-400">
+                {Array.from({ length: 5 }).map((_, i) => (
+                  <span key={i}>{i < (c.rating ?? 0) ? "\u2605" : "\u2606"}</span>
+                ))}
+              </div>
+            )}
+            {c.review && (
+              <p className="text-sm italic text-foreground/80">{c.review}</p>
+            )}
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/apps/creator/app/dashboard/page.tsx
+++ b/apps/creator/app/dashboard/page.tsx
@@ -57,6 +57,9 @@ export default function DashboardPage() {
         <Link href="/applications" className="underline">
           My Applications
         </Link>
+        <Link href="/collabs" className="underline">
+          Collabs
+        </Link>
       </nav>
       <PerformanceMetrics />
       {items.length === 0 ? (

--- a/apps/creator/app/data/collabs.ts
+++ b/apps/creator/app/data/collabs.ts
@@ -1,0 +1,39 @@
+export interface Collab {
+  id: string;
+  brand: string;
+  campaign: string;
+  status: 'active' | 'pending payment' | 'completed';
+  earnings: number;
+  rating?: number;
+  review?: string;
+}
+
+const collabs: Collab[] = [
+  {
+    id: '1',
+    brand: 'Glow Cosmetics',
+    campaign: 'Summer Glow Launch',
+    status: 'active',
+    earnings: 500,
+  },
+  {
+    id: '2',
+    brand: 'FitFuel',
+    campaign: 'Protein Bar Campaign',
+    status: 'pending payment',
+    earnings: 800,
+    rating: 5,
+    review: 'Great communication and easy to work with.'
+  },
+  {
+    id: '3',
+    brand: 'EcoHome',
+    campaign: 'Green Living Tips',
+    status: 'completed',
+    earnings: 350,
+    rating: 4,
+    review: 'Overall positive experience with some minor delays.'
+  }
+];
+
+export default collabs;


### PR DESCRIPTION
## Summary
- create mock collab data
- build `/collabs` page for creators
- link to the new page from creator dashboard

## Testing
- `npm run lint -w apps/creator` *(fails: next not found)*
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518bbb8048832c99b1afe77e6a0147