### PR TITLE
Add creator/brand badge system

### DIFF
--- a/apps/brand/app/data/creators.ts
+++ b/apps/brand/app/data/creators.ts
@@ -13,6 +13,9 @@ export type Creator = {
   formats?: string[];
   fitScore?: number;
   markdown?: string;
+  verified?: boolean;
+  completedCollabs?: number;
+  avgResponseMinutes?: number;
 };
 
 export const creators = [
@@ -50,7 +53,10 @@ I'm Sophie — I share skincare rituals, cozy routines, and self-care tips to he
 - Clean beauty
 - Wellness supplements
 - Cozy fashion brands
-    `
+    `,
+    verified: true,
+    completedCollabs: 4,
+    avgResponseMinutes: 30,
   },
   {
     id: "2",
@@ -87,7 +93,10 @@ Tech explainer meets crypto nerd. My YouTube channel covers AI, gadgets, and dec
 - AI-powered tools
 - Tech startups
 - Secure wallet brands
-    `
+    `,
+    verified: true,
+    completedCollabs: 3,
+    avgResponseMinutes: 45,
   },
   {
     id: "3",
@@ -123,7 +132,10 @@ I teach aesthetic plant care, budget-friendly home decor, and cozy vibes — all
 ## 🌍 Followers
 - Mostly Brazil, but US & Spain growing!
 - Strong LGBTQ+ & design community
-    `
+    `,
+    verified: false,
+    completedCollabs: 2,
+    avgResponseMinutes: 90,
   }
 ];
 

--- a/apps/brand/components/CreatorCard.tsx
+++ b/apps/brand/components/CreatorCard.tsx
@@ -4,6 +4,8 @@ import Link from "next/link";
 import { motion } from "framer-motion";
 import type { Creator } from "@/app/data/creators";
 import { useState } from "react";
+import { Badge } from "shared-ui";
+import { getCreatorBadges } from "shared-utils";
 
 import { ReactNode } from "react";
 
@@ -15,6 +17,11 @@ type Props = {
 };
 export default function CreatorCard({ creator, onShortlist, shortlisted, children }: Props) {
   const [loading, setLoading] = useState(false);
+  const badges = getCreatorBadges({
+    verified: creator.verified,
+    completedCollabs: creator.completedCollabs,
+    avgResponseMinutes: creator.avgResponseMinutes,
+  });
 
   const handleContact = async () => {
     setLoading(true);
@@ -49,11 +56,14 @@ export default function CreatorCard({ creator, onShortlist, shortlisted, childre
       transition={{ duration: 0.3 }}
       className="group bg-white dark:bg-Siora-mid border border-gray-300 dark:border-Siora-border rounded-2xl p-6 shadow-Siora-hover"
     >
-      <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1 flex items-center gap-2">
         {creator.name}{" "}
         <span className="text-Siora-accent group-hover:text-Siora-accent-soft">
           @{creator.handle}
         </span>
+        {badges.map((b) => (
+          <Badge key={b.id} label={b.label} />
+        ))}
       </h2>
       <p className="text-sm text-gray-500 dark:text-zinc-400 mb-2">
         {creator.niche} • {creator.platform}

--- a/apps/creator/app/campaigns/page.tsx
+++ b/apps/creator/app/campaigns/page.tsx
@@ -1,9 +1,13 @@
 "use client";
 import { useEffect, useState } from "react";
 import Toast from "@/components/Toast";
+import { discoveryBrands } from "@/data/discoveryBrands";
+import { Badge } from "shared-ui";
+import { getBrandBadges } from "shared-utils";
 
 interface Campaign {
   id: string;
+  brand: string;
   name: string;
   description: string;
   deliverables: string;
@@ -50,27 +54,39 @@ export default function CampaignsPage() {
     <main className="min-h-screen bg-background text-foreground p-6 space-y-6">
       <h1 className="text-2xl font-bold">Brand Campaigns</h1>
       <div className="space-y-4">
-        {campaigns.map((c) => (
-          <div
-            key={c.id}
-            className="border border-white/10 p-4 rounded-lg space-y-2"
-          >
-            <h2 className="text-lg font-semibold">{c.name}</h2>
-            <p className="text-sm">{c.description}</p>
-            <p className="text-sm text-foreground/80">
-              Deliverables: {c.deliverables}
-            </p>
-            <p className="text-sm text-foreground/80">
-              Deadline: {new Date(c.deadline).toLocaleDateString()}
-            </p>
-            <button
-              onClick={() => apply(c.id)}
-              className="text-indigo-600 underline"
+        {campaigns.map((c) => {
+          const brandInfo = discoveryBrands.find((b) => b.name === c.brand);
+          const badges = getBrandBadges({
+            verified: brandInfo?.verified,
+            pastCampaigns: brandInfo?.pastCampaigns.length,
+          });
+          return (
+            <div
+              key={c.id}
+              className="border border-white/10 p-4 rounded-lg space-y-2"
             >
-              Apply
-            </button>
-          </div>
-        ))}
+              <h2 className="text-lg font-semibold flex items-center gap-2">
+                {c.name}
+                {badges.map((b) => (
+                  <Badge key={b.id} label={b.label} />
+                ))}
+              </h2>
+              <p className="text-sm">{c.description}</p>
+              <p className="text-sm text-foreground/80">
+                Deliverables: {c.deliverables}
+              </p>
+              <p className="text-sm text-foreground/80">
+                Deadline: {new Date(c.deadline).toLocaleDateString()}
+              </p>
+              <button
+                onClick={() => apply(c.id)}
+                className="text-indigo-600 underline"
+              >
+                Apply
+              </button>
+            </div>
+          );
+        })}
       </div>
       {toast && <Toast message={toast} onClose={() => setToast("")} />}
     </main>

--- a/apps/creator/app/data/messages.ts
+++ b/apps/creator/app/data/messages.ts
@@ -1,0 +1,28 @@
+export interface Message {
+  id: string;
+  creatorId: string;
+  sender: 'brand' | 'creator';
+  text: string;
+  campaign: string;
+  timestamp: string;
+}
+
+export const messages: Message[] = [
+  {
+    id: 'msg1',
+    creatorId: '1',
+    sender: 'brand',
+    text: 'Welcome to the campaign!',
+    campaign: '1',
+    timestamp: '2024-05-01T12:10:00.000Z'
+  },
+  {
+    id: 'msg2',
+    creatorId: '1',
+    sender: 'creator',
+    text: 'Thanks, excited to work together!',
+    campaign: '1',
+    timestamp: '2024-05-01T12:12:00.000Z'
+  }
+];
+export default messages;

--- a/apps/creator/components/BrandDiscoveryCard.tsx
+++ b/apps/creator/components/BrandDiscoveryCard.tsx
@@ -1,5 +1,7 @@
 import Image from 'next/image'
 import { DiscoveryBrand } from '@/data/discoveryBrands'
+import { Badge } from 'shared-ui'
+import { getBrandBadges } from 'shared-utils'
 
 interface Props {
   brand: DiscoveryBrand
@@ -7,6 +9,11 @@ interface Props {
 }
 
 export default function BrandDiscoveryCard({ brand, onAction }: Props) {
+  const badges = getBrandBadges({
+    verified: brand.verified,
+    pastCampaigns: brand.pastCampaigns.length,
+  })
+
   return (
     <div className="p-4 rounded-lg border border-white/10 bg-background space-y-2">
       <div className="flex items-center space-x-3">
@@ -19,7 +26,12 @@ export default function BrandDiscoveryCard({ brand, onAction }: Props) {
           className="rounded-full"
         />
         <div>
-          <h3 className="font-semibold">{brand.name}</h3>
+          <h3 className="font-semibold flex items-center gap-2">
+            {brand.name}
+            {badges.map((b) => (
+              <Badge key={b.id} label={b.label} />
+            ))}
+          </h3>
           <p className="text-sm text-foreground/70">{brand.tagline}</p>
         </div>
       </div>

--- a/apps/creator/components/PersonaCard.tsx
+++ b/apps/creator/components/PersonaCard.tsx
@@ -1,9 +1,22 @@
 import { PersonaProfile } from '../types/persona'
+import { Badge } from 'shared-ui'
+import { getCreatorBadges } from 'shared-utils'
 
 export default function PersonaCard({ profile }: { profile: PersonaProfile }) {
+  const badges = getCreatorBadges({
+    verified: profile.verified,
+    completedCollabs: profile.completedCollabs,
+    avgResponseMinutes: profile.avgResponseMinutes,
+  })
+
   return (
     <div className="border border-white/10 bg-background text-foreground p-4 sm:p-6 rounded-xl shadow-sm space-y-2">
-      <h2 className="text-xl font-bold">{profile.name}</h2>
+      <div className="flex items-center gap-2">
+        <h2 className="text-xl font-bold">{profile.name}</h2>
+        {badges.map((b) => (
+          <Badge key={b.id} label={b.label} />
+        ))}
+      </div>
       <p className="italic">{profile.personality}</p>
       <div className="flex flex-wrap gap-2">
         {profile.interests.map((tag, i) => (

--- a/apps/creator/data/discoveryBrands.ts
+++ b/apps/creator/data/discoveryBrands.ts
@@ -7,6 +7,7 @@ export interface DiscoveryBrand {
   vibes: string[];
   values: string[];
   pastCampaigns: string[];
+  verified?: boolean;
 }
 
 export const discoveryBrands: DiscoveryBrand[] = [
@@ -18,7 +19,8 @@ export const discoveryBrands: DiscoveryBrand[] = [
     industry: 'Beauty',
     vibes: ['vibrant', 'youthful'],
     values: ['cruelty-free', 'sustainable'],
-    pastCampaigns: ['GlowSummer', 'SPFLaunch'],
+    pastCampaigns: ['GlowSummer', 'SPFLaunch', 'HolidayGlow'],
+    verified: true,
   },
   {
     id: 'b2',
@@ -29,6 +31,7 @@ export const discoveryBrands: DiscoveryBrand[] = [
     vibes: ['energetic', 'bold'],
     values: ['vegan', 'health'],
     pastCampaigns: ['ProteinBar2024'],
+    verified: true,
   },
   {
     id: 'b3',

--- a/apps/creator/types/persona.ts
+++ b/apps/creator/types/persona.ts
@@ -7,6 +7,9 @@ export type PersonaProfile = {
   toneConfidence?: number
   brandFit?: string
   growthSuggestions?: string
+  verified?: boolean
+  completedCollabs?: number
+  avgResponseMinutes?: number
 }
 
 export interface FullPersona extends PersonaProfile {

--- a/db/campaigns.json
+++ b/db/campaigns.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "1",
+    "brand": "Glow Cosmetics",
     "name": "Summer Glow Launch",
     "description": "Seeking beauty creators to promote our new dewy foundation line.",
     "deliverables": "1 IG Reel and 3 Story frames highlighting product benefits",
@@ -8,6 +9,7 @@
   },
   {
     "id": "2",
+    "brand": "FitFuel",
     "name": "Fall Fitness Push",
     "description": "Looking for energetic influencers to showcase our workout gear.",
     "deliverables": "2 posts wearing gear, 1 short testimonial video",
@@ -15,6 +17,7 @@
   },
   {
     "id": "3",
+    "brand": "EcoHome",
     "name": "Green Living Tips",
     "description": "Creators passionate about sustainability to share our eco products.",
     "deliverables": "Blog article or video review and 5 social shares",

--- a/packages/shared-ui/src/Badge.tsx
+++ b/packages/shared-ui/src/Badge.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export interface BadgeProps {
+  label: string;
+  className?: string;
+}
+
+export function Badge({ label, className }: BadgeProps) {
+  return (
+    <span
+      className={
+        'inline-block text-xs font-medium bg-indigo-100 text-indigo-800 dark:bg-indigo-800 dark:text-indigo-100 rounded-full px-2 py-0.5 ' +
+        (className || '')
+      }
+    >
+      {label}
+    </span>
+  );
+}
+
+export default Badge;

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -1,1 +1,2 @@
 export * from './ChatPanel';
+export * from './Badge';

--- a/packages/shared-utils/src/badges.ts
+++ b/packages/shared-utils/src/badges.ts
@@ -1,0 +1,40 @@
+export interface Badge {
+  id: string;
+  label: string;
+}
+
+export interface CreatorBadgeData {
+  verified?: boolean;
+  completedCollabs?: number;
+  avgResponseMinutes?: number;
+}
+
+export function getCreatorBadges(data: CreatorBadgeData): Badge[] {
+  const badges: Badge[] = [];
+  if (data.verified) {
+    badges.push({ id: 'verified', label: 'Verified Creator' });
+  }
+  if ((data.completedCollabs ?? 0) >= 3) {
+    badges.push({ id: 'collabs3', label: 'Completed 3+ Collabs' });
+  }
+  if (data.avgResponseMinutes != null && data.avgResponseMinutes <= 60) {
+    badges.push({ id: 'fast-responder', label: 'Fast Responder' });
+  }
+  return badges;
+}
+
+export interface BrandBadgeData {
+  verified?: boolean;
+  pastCampaigns?: number;
+}
+
+export function getBrandBadges(data: BrandBadgeData): Badge[] {
+  const badges: Badge[] = [];
+  if (data.verified) {
+    badges.push({ id: 'verified-brand', label: 'Verified Brand' });
+  }
+  if ((data.pastCampaigns ?? 0) >= 3) {
+    badges.push({ id: 'campaigns3', label: 'Ran 3+ Campaigns' });
+  }
+  return badges;
+}

--- a/packages/shared-utils/src/index.ts
+++ b/packages/shared-utils/src/index.ts
@@ -3,3 +3,4 @@ export * from './generateSmartPitch';
 export * from './matchScore';
 export * from './creatorRanking';
 export * from './campaignFitScore';
+export * from './badges';


### PR DESCRIPTION
## Summary
- create Badge UI component
- compute creator and brand badges
- update datasets to track verification and collab metrics
- display badges on personas, creators, brands and campaign listings
- include sample message data

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518bc35cf4832cb8682d6d791dee68