### PR TITLE
Add advanced creator filters

### DIFF
--- a/apps/brand/components/AdvancedFilterBar.tsx
+++ b/apps/brand/components/AdvancedFilterBar.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { creators } from "@/app/data/creators";
+import TagInput from "./TagInput";
+
+export type Filters = {
+  platforms: string[];
+  tones: string[];
+  vibes: string[];
+  niches: string[];
+  formats: string[];
+  values: string[];
+  minEngagement: number;
+  maxEngagement: number;
+  minCollabs: number;
+};
+
+interface Props {
+  onFilter: (f: Filters) => void;
+}
+
+export default function AdvancedFilterBar({ onFilter }: Props) {
+  const unique = <T extends string>(arr: (T | undefined)[]) =>
+    Array.from(new Set(arr.filter(Boolean))) as T[];
+
+  const platforms = unique(creators.map((c) => c.platform));
+  const tones = unique(creators.map((c) => c.tone));
+  const vibes = unique(creators.map((c) => c.vibe));
+  const niches = unique(creators.map((c) => c.niche));
+  const formats = unique(creators.flatMap((c) => c.formats || []));
+
+  const [platformsSel, setPlatformsSel] = useState<string[]>([]);
+  const [tonesSel, setTonesSel] = useState<string[]>([]);
+  const [vibesSel, setVibesSel] = useState<string[]>([]);
+  const [nichesSel, setNichesSel] = useState<string[]>([]);
+  const [formatsSel, setFormatsSel] = useState<string[]>([]);
+  const [values, setValues] = useState<string[]>([]);
+  const [minER, setMinER] = useState(0);
+  const [maxER, setMaxER] = useState(10);
+  const [minCollabs, setMinCollabs] = useState(0);
+
+  useEffect(() => {
+    onFilter({
+      platforms: platformsSel,
+      tones: tonesSel,
+      vibes: vibesSel,
+      niches: nichesSel,
+      formats: formatsSel,
+      values,
+      minEngagement: minER,
+      maxEngagement: maxER,
+      minCollabs,
+    });
+  }, [platformsSel, tonesSel, vibesSel, nichesSel, formatsSel, values, minER, maxER, minCollabs, onFilter]);
+
+  const toggle = (value: string, list: string[], set: (v: string[]) => void) => {
+    set(list.includes(value) ? list.filter((v) => v !== value) : [...list, value]);
+  };
+
+  return (
+    <div className="space-y-4 p-4 bg-Siora-light rounded-lg text-white">
+      <div className="flex flex-wrap gap-4">
+        {platforms.map((p) => (
+          <label key={p} className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={platformsSel.includes(p)}
+              onChange={() => toggle(p, platformsSel, setPlatformsSel)}
+            />
+            {p}
+          </label>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-4">
+        {niches.map((n) => (
+          <label key={n} className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={nichesSel.includes(n)}
+              onChange={() => toggle(n, nichesSel, setNichesSel)}
+            />
+            {n}
+          </label>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-4">
+        {tones.map((t) => (
+          <label key={t} className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={tonesSel.includes(t)}
+              onChange={() => toggle(t, tonesSel, setTonesSel)}
+            />
+            {t}
+          </label>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-4">
+        {vibes.map((v) => (
+          <label key={v} className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={vibesSel.includes(v)}
+              onChange={() => toggle(v || "", vibesSel, setVibesSel)}
+            />
+            {v}
+          </label>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-4">
+        {formats.map((f) => (
+          <label key={f} className="flex items-center gap-1">
+            <input
+              type="checkbox"
+              checked={formatsSel.includes(f)}
+              onChange={() => toggle(f, formatsSel, setFormatsSel)}
+            />
+            {f}
+          </label>
+        ))}
+      </div>
+
+      <TagInput tags={values} onChange={setValues} placeholder="Add values" />
+
+      <div className="flex items-center gap-2">
+        <label>ER % {minER}+</label>
+        <input
+          type="range"
+          min={0}
+          max={10}
+          step={0.1}
+          value={minER}
+          onChange={(e) => setMinER(parseFloat(e.target.value))}
+        />
+        <label className="ml-4">Max {maxER}</label>
+        <input
+          type="range"
+          min={0}
+          max={10}
+          step={0.1}
+          value={maxER}
+          onChange={(e) => setMaxER(parseFloat(e.target.value))}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <label>Min Collabs {minCollabs}</label>
+        <input
+          type="range"
+          min={0}
+          max={10}
+          step={1}
+          value={minCollabs}
+          onChange={(e) => setMinCollabs(parseInt(e.target.value))}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/brand/components/TagInput.tsx
+++ b/apps/brand/components/TagInput.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+
+interface TagInputProps {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  placeholder?: string;
+}
+
+export default function TagInput({ tags, onChange, placeholder }: TagInputProps) {
+  const [value, setValue] = useState('');
+
+  const addTag = () => {
+    const tag = value.trim();
+    if (tag && !tags.includes(tag)) {
+      onChange([...tags, tag]);
+    }
+    setValue('');
+  };
+
+  const removeTag = (t: string) => {
+    onChange(tags.filter((tag) => tag !== t));
+  };
+
+  return (
+    <div className="p-2 border rounded bg-gray-100 dark:bg-Siora-light text-gray-900 dark:text-white border-gray-300 dark:border-Siora-border flex flex-wrap gap-1">
+      {tags.map((tag) => (
+        <span key={tag} className="bg-indigo-600 text-white rounded px-2 py-0.5 flex items-center gap-1 text-xs">
+          {tag}
+          <button type="button" onClick={() => removeTag(tag)} className="ml-1">×</button>
+        </span>
+      ))}
+      <input
+        className="flex-1 bg-transparent outline-none"
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            addTag();
+          }
+        }}
+        placeholder={placeholder}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce `TagInput` component for entering value tags
- add `AdvancedFilterBar` with checkboxes and sliders for detailed filtering
- update dashboard to use advanced filters and richer creator dataset

## Testing
- `npm run lint -w apps/brand` *(fails: `next` not found)*
- `npm install` *(fails: unsupported URL type "workspace:")*

------
https://chatgpt.com/codex/tasks/task_e_68518f721dfc832c912e7432ca7ba02b