### PR TITLE
Add simple creator recommendation

### DIFF
--- a/apps/brand/app/api/campaign-match/route.ts
+++ b/apps/brand/app/api/campaign-match/route.ts
@@ -1,64 +1,78 @@
 import creators from '@/app/data/mock_creators_200.json';
-import Fuse from 'fuse.js';
 
 interface CampaignRequest {
   name?: string;
-  focus?: string;
+  niche?: string;
   platform?: string;
   tone?: string;
-  audience?: string;
   budget?: string;
 }
 
-type Persona = (typeof creators)[number];
+type Creator = (typeof creators)[number];
 
-type FuseResult = { item: Persona; score?: number };
+function scoreCreator(c: Creator, req: CampaignRequest) {
+  let score = 0;
+  const reasons: string[] = [];
+
+  if (req.platform) {
+    const match = c.platform.toLowerCase().includes(req.platform.toLowerCase());
+    if (match) {
+      score += 0.25;
+      reasons.push('Platform match');
+    }
+  }
+
+  if (req.tone) {
+    const match = c.tone.toLowerCase().includes(req.tone.toLowerCase());
+    if (match) {
+      score += 0.25;
+      reasons.push('Tone match');
+    }
+  }
+
+  if (req.niche) {
+    const norm = req.niche.toLowerCase();
+    const match =
+      c.niche.toLowerCase().includes(norm) ||
+      (c.tags || []).some((t) => t.toLowerCase().includes(norm));
+    if (match) {
+      score += 0.25;
+      reasons.push('Niche match');
+    }
+  }
+
+  if (req.budget) {
+    const num = parseInt(req.budget.replace(/[^0-9]/g, ''), 10);
+    if (!isNaN(num)) {
+      const maxFollowers = num * 100; // rough $10 CPM assumption
+      if (c.followers <= maxFollowers) {
+        score += 0.25;
+        reasons.push('Within budget');
+      }
+    }
+  }
+
+  return { score, reasons };
+}
 
 export async function POST(req: Request) {
   try {
-    const { focus, platform, tone, audience } = (await req.json()) as CampaignRequest;
+    const body = (await req.json()) as CampaignRequest;
 
-    const query = [focus, platform, tone, audience].filter(Boolean).join(' ');
-    const fuse = new Fuse(creators, {
-      keys: ['summary', 'niche', 'tags', 'platform', 'tone'],
-      threshold: 0.4,
-      includeScore: true,
+    const scored = creators.map((c) => {
+      const { score, reasons } = scoreCreator(c, body);
+      return { persona: c, score, reasons };
     });
 
-    const fuseResults: FuseResult[] = query
-      ? fuse.search(query)
-      : creators.map((c) => ({ item: c, score: 0 }));
+    scored.sort((a, b) => b.score - a.score);
 
-    const results = fuseResults.map(({ item, score }) => {
-      const reasons: string[] = [];
-      const normPlatform = platform?.toLowerCase() || '';
-      const normTone = tone?.toLowerCase() || '';
-      const normFocus = focus?.toLowerCase() || '';
-
-      if (platform && item.platform.toLowerCase().includes(normPlatform)) {
-        reasons.push('Platform match');
+    return new Response(
+      JSON.stringify({ results: scored.slice(0, 5) }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
       }
-      if (tone && item.tone.toLowerCase().includes(normTone)) {
-        reasons.push('Tone match');
-      }
-      if (
-        focus &&
-        (item.niche.toLowerCase().includes(normFocus) ||
-          item.tags?.some((t) => t.toLowerCase().includes(normFocus)))
-      ) {
-        reasons.push('Content focus match');
-      }
-
-      const matchScore = 1 - (score ?? 1);
-      return { persona: item, score: matchScore, reasons };
-    });
-
-    results.sort((a, b) => b.score - a.score);
-
-    return new Response(JSON.stringify({ results: results.slice(0, 5) }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    );
   } catch (err) {
     console.error('campaign match error', err);
     return new Response(JSON.stringify({ error: 'Server error' }), {

--- a/apps/brand/app/campaign/new/page.tsx
+++ b/apps/brand/app/campaign/new/page.tsx
@@ -12,10 +12,9 @@ interface MatchResult {
 
 export default function NewCampaignPage() {
   const [name, setName] = useState("");
-  const [focus, setFocus] = useState("");
+  const [niche, setNiche] = useState("");
   const [platform, setPlatform] = useState("");
   const [tone, setTone] = useState("");
-  const [audience, setAudience] = useState("");
   const [budget, setBudget] = useState("");
   const [results, setResults] = useState<MatchResult[]>([]);
   const [loading, setLoading] = useState(false);
@@ -26,7 +25,7 @@ export default function NewCampaignPage() {
       const res = await fetch("/api/campaign-match", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, focus, platform, tone, audience, budget }),
+        body: JSON.stringify({ name, niche, platform, tone, budget }),
       });
       const data = await res.json();
       setResults(data.results || []);
@@ -49,9 +48,9 @@ export default function NewCampaignPage() {
             className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
           />
           <input
-            value={focus}
-            onChange={(e) => setFocus(e.target.value)}
-            placeholder="Campaign focus"
+            value={niche}
+            onChange={(e) => setNiche(e.target.value)}
+            placeholder="Campaign niche"
             className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
           />
           <input
@@ -64,12 +63,6 @@ export default function NewCampaignPage() {
             value={tone}
             onChange={(e) => setTone(e.target.value)}
             placeholder="Desired tone"
-            className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
-          />
-          <input
-            value={audience}
-            onChange={(e) => setAudience(e.target.value)}
-            placeholder="Target audience"
             className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
           />
           <input


### PR DESCRIPTION
## Summary
- implement a basic matching function in `campaign-match` API
- update campaign page fields to use niche and budget
- show top creator matches using new API

## Testing
- `npx --yes turbo run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518f7a352c832cbd0ac37752f51645