### PR TITLE
Add Creator Explore page

### DIFF
--- a/apps/creator/app/api/campaigns/[id]/route.ts
+++ b/apps/creator/app/api/campaigns/[id]/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import path from 'path';
+import { promises as fs } from 'fs';
+
+const dbPath = path.join(process.cwd(), '..', '..', 'db', 'campaigns.json');
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const file = await fs.readFile(dbPath, 'utf8');
+    const data = JSON.parse(file);
+    const list = Array.isArray(data) ? data : [];
+    const campaign = list.find((c: { id: string }) => c.id === params.id);
+    if (!campaign) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return NextResponse.json(campaign);
+  } catch {
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/apps/creator/app/data/campaigns.ts
+++ b/apps/creator/app/data/campaigns.ts
@@ -3,26 +3,50 @@ export type Campaign = {
   brand: string;
   title: string;
   description: string;
+  platform: string;
+  niche: string;
+  budgetMin: number;
+  budgetMax: number;
+  deliverables?: string;
+  deadline?: string;
 };
 
 const campaigns: Campaign[] = [
   {
     id: '1',
-    brand: 'Glowify Cosmetics',
-    title: 'Summer Glow Launch',
-    description: 'Seeking beauty creators to promote our new dewy foundation line.',
+    brand: 'GlowUp Cosmetics',
+    title: 'Spring Skincare Launch',
+    description: 'Instagram Reels and Stories demoing the new skincare line',
+    platform: 'Instagram',
+    niche: 'Beauty',
+    budgetMin: 500,
+    budgetMax: 1000,
+    deliverables: '1 IG Reel and 3 Story frames highlighting product benefits',
+    deadline: '2025-12-31',
   },
   {
     id: '2',
-    brand: 'FitGear',
-    title: 'Fall Fitness Push',
-    description: 'Looking for energetic influencers to showcase our workout gear.',
+    brand: 'Plantify',
+    title: 'Urban Jungle Challenge',
+    description: 'TikTok video showing a plant makeover or styling tip',
+    platform: 'TikTok',
+    niche: 'Home & Plants',
+    budgetMin: 300,
+    budgetMax: 800,
+    deliverables: '2 posts showcasing plants, 1 short testimonial video',
+    deadline: '2025-11-15',
   },
   {
     id: '3',
-    brand: 'EcoHome',
-    title: 'Green Living Tips',
-    description: 'Creators passionate about sustainability to share our eco products.',
+    brand: 'Techify',
+    title: 'AI Gadget Review',
+    description: 'YouTube review of our latest AI gadget',
+    platform: 'YouTube',
+    niche: 'Tech',
+    budgetMin: 700,
+    budgetMax: 1500,
+    deliverables: 'Blog article or video review and 5 social shares',
+    deadline: '2025-10-01',
   },
 ];
 

--- a/apps/creator/app/explore/[id]/page.tsx
+++ b/apps/creator/app/explore/[id]/page.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import type { Campaign } from '@/app/data/campaigns';
+
+export default function CampaignDetail() {
+  const params = useParams<{ id: string }>();
+  const [campaign, setCampaign] = useState<Campaign | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      if (!params.id) return;
+      const res = await fetch(`/api/campaigns/${params.id}`);
+      if (res.ok) {
+        const data = await res.json();
+        setCampaign(data);
+      }
+    }
+    load();
+  }, [params.id]);
+
+  if (!campaign) return <p className="p-6">Loading...</p>;
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 space-y-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold">{campaign.title}</h1>
+      <p className="text-sm text-foreground/80">Brand: {campaign.brand}</p>
+      <p className="text-sm">Platform: {campaign.platform}</p>
+      <p className="text-sm">Niche: {campaign.niche}</p>
+      <p className="text-sm">Budget: ${campaign.budgetMin} - ${campaign.budgetMax}</p>
+      <p className="text-sm">Deliverables: {campaign.deliverables}</p>
+      <p className="text-sm">Deadline: {campaign.deadline}</p>
+      <Link
+        href={`/campaigns/${campaign.id}/apply`}
+        className="inline-block px-4 py-2 bg-indigo-600 text-white rounded"
+      >
+        Apply Now
+      </Link>
+    </main>
+  );
+}

--- a/apps/creator/app/explore/page.tsx
+++ b/apps/creator/app/explore/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+import { useEffect, useState, useMemo } from 'react';
+import type { Campaign } from '@/app/data/campaigns';
+import CampaignCard from '@/components/CampaignCard';
+
+export default function ExplorePage() {
+  const [campaigns, setCampaigns] = useState<Campaign[]>([]);
+  const [platform, setPlatform] = useState('');
+  const [niche, setNiche] = useState('');
+  const [payout, setPayout] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch('/api/campaigns');
+        const data = await res.json();
+        setCampaigns(Array.isArray(data) ? data : []);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  const filtered = useMemo(() => {
+    return campaigns.filter((c) => {
+      const matchPlatform = !platform || c.platform.toLowerCase().includes(platform.toLowerCase());
+      const matchNiche = !niche || c.niche.toLowerCase().includes(niche.toLowerCase());
+      const pay = parseInt(payout || '0', 10);
+      const matchPay = !payout || c.budgetMax >= pay;
+      return matchPlatform && matchNiche && matchPay;
+    });
+  }, [campaigns, platform, niche, payout]);
+
+  const platforms = useMemo(() => Array.from(new Set(campaigns.map(c => c.platform))), [campaigns]);
+  const niches = useMemo(() => Array.from(new Set(campaigns.map(c => c.niche))), [campaigns]);
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 space-y-6 max-w-5xl mx-auto">
+      <h1 className="text-2xl font-bold">Explore Campaigns</h1>
+      <div className="grid sm:grid-cols-3 gap-4">
+        <select className="w-full p-2 rounded-md bg-zinc-800 text-white" value={platform} onChange={e => setPlatform(e.target.value)}>
+          <option value="">All Platforms</option>
+          {platforms.map(p => <option key={p} value={p}>{p}</option>)}
+        </select>
+        <select className="w-full p-2 rounded-md bg-zinc-800 text-white" value={niche} onChange={e => setNiche(e.target.value)}>
+          <option value="">All Niches</option>
+          {niches.map(n => <option key={n} value={n}>{n}</option>)}
+        </select>
+        <input
+          type="number"
+          placeholder="Minimum Payout"
+          className="w-full p-2 rounded-md bg-zinc-800 text-white"
+          value={payout}
+          onChange={e => setPayout(e.target.value)}
+        />
+      </div>
+      {loading ? (
+        <p>Loading campaigns...</p>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+          {filtered.map(c => (
+            <CampaignCard key={c.id} campaign={c} />
+          ))}
+          {filtered.length === 0 && <p className="text-center text-zinc-400 col-span-full">No campaigns found.</p>}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/creator/components/CampaignCard.tsx
+++ b/apps/creator/components/CampaignCard.tsx
@@ -1,0 +1,24 @@
+import Link from 'next/link';
+import type { Campaign } from '@/app/data/campaigns';
+
+interface Props {
+  campaign: Campaign;
+}
+
+export default function CampaignCard({ campaign }: Props) {
+  return (
+    <div className="border border-white/10 bg-background p-4 rounded-lg space-y-2">
+      <h3 className="text-lg font-semibold">{campaign.title}</h3>
+      <p className="text-sm text-foreground/80">{campaign.brand}</p>
+      <p className="text-sm">Platform: {campaign.platform}</p>
+      <p className="text-sm">Niche: {campaign.niche}</p>
+      <p className="text-sm">Budget: ${campaign.budgetMin} - ${campaign.budgetMax}</p>
+      <Link
+        href={`/explore/${campaign.id}`}
+        className="mt-2 inline-block px-3 py-1 bg-indigo-600 text-white rounded"
+      >
+        View Brief
+      </Link>
+    </div>
+  );
+}

--- a/db/campaigns.json
+++ b/db/campaigns.json
@@ -1,26 +1,38 @@
 [
   {
     "id": "1",
-    "brand": "Glow Cosmetics",
-    "name": "Summer Glow Launch",
-    "description": "Seeking beauty creators to promote our new dewy foundation line.",
+    "brand": "GlowUp Cosmetics",
+    "title": "Spring Skincare Launch",
+    "description": "Instagram Reels and Stories demoing the new skincare line",
     "deliverables": "1 IG Reel and 3 Story frames highlighting product benefits",
-    "deadline": "2025-12-31"
+    "deadline": "2025-12-31",
+    "platform": "Instagram",
+    "niche": "Beauty",
+    "budgetMin": 500,
+    "budgetMax": 1000
   },
   {
     "id": "2",
-    "brand": "FitFuel",
-    "name": "Fall Fitness Push",
-    "description": "Looking for energetic influencers to showcase our workout gear.",
-    "deliverables": "2 posts wearing gear, 1 short testimonial video",
-    "deadline": "2025-11-15"
+    "brand": "Plantify",
+    "title": "Urban Jungle Challenge",
+    "description": "TikTok video showing a plant makeover or styling tip",
+    "deliverables": "2 posts showcasing plants, 1 short testimonial video",
+    "deadline": "2025-11-15",
+    "platform": "TikTok",
+    "niche": "Home & Plants",
+    "budgetMin": 300,
+    "budgetMax": 800
   },
   {
     "id": "3",
-    "brand": "EcoHome",
-    "name": "Green Living Tips",
-    "description": "Creators passionate about sustainability to share our eco products.",
+    "brand": "Techify",
+    "title": "AI Gadget Review",
+    "description": "YouTube review of our latest AI gadget",
     "deliverables": "Blog article or video review and 5 social shares",
-    "deadline": "2025-10-01"
+    "deadline": "2025-10-01",
+    "platform": "YouTube",
+    "niche": "Tech",
+    "budgetMin": 700,
+    "budgetMax": 1500
   }
 ]


### PR DESCRIPTION
## Summary
- extend campaign dataset with budget, platform and niche
- provide campaign detail API
- add Explore pages in creator app
- add simple campaign card component

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm run build` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518f8bec00832c994d65b399137ef5