### PR TITLE
Add inbox page for saved creators

### DIFF
--- a/apps/brand/app/inbox/page.tsx
+++ b/apps/brand/app/inbox/page.tsx
@@ -1,0 +1,85 @@
+"use client";
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import creators from "@/app/data/creators";
+import SavedCreatorCard from "@/components/SavedCreatorCard";
+import { useBrandUser } from "@/lib/brandUser";
+import { useShortlist } from "@/lib/shortlist";
+
+export default function InboxPage() {
+  const { user } = useBrandUser();
+  const router = useRouter();
+  const { ids } = useShortlist(user?.email ?? null);
+
+  const [niche, setNiche] = useState("");
+  const [minER, setMinER] = useState("");
+  const [vibe, setVibe] = useState("");
+
+  useEffect(() => {
+    if (!user) router.replace("/signin");
+  }, [user, router]);
+
+  if (!user) return null;
+
+  const niches = Array.from(new Set(creators.map((c) => c.niche)));
+  const vibes = Array.from(new Set(creators.map((c) => c.vibe).filter(Boolean)));
+
+  const saved = creators.filter((c) => ids.includes(c.id));
+  const filtered = saved.filter((c) => {
+    const erMatch = !minER || c.engagementRate >= parseFloat(minER);
+    const nicheMatch = !niche || c.niche === niche;
+    const vibeMatch = !vibe || c.vibe === vibe;
+    return erMatch && nicheMatch && vibeMatch;
+  });
+
+  return (
+    <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
+      <div className="max-w-7xl mx-auto space-y-8">
+        <h1 className="text-4xl font-extrabold tracking-tight">Inbox</h1>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <select
+            value={niche}
+            onChange={(e) => setNiche(e.target.value)}
+            className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
+          >
+            <option value="">All Niches</option>
+            {niches.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+          <input
+            type="number"
+            step="0.1"
+            value={minER}
+            onChange={(e) => setMinER(e.target.value)}
+            placeholder="Min ER%"
+            className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
+          />
+          <select
+            value={vibe}
+            onChange={(e) => setVibe(e.target.value)}
+            className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
+          >
+            <option value="">All Vibes</option>
+            {vibes.map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </div>
+        {filtered.length === 0 ? (
+          <p className="text-center text-zinc-400 mt-10">No saved creators found.</p>
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+            {filtered.map((c) => (
+              <SavedCreatorCard key={c.id} creator={c} />
+            ))}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/brand/components/SavedCreatorCard.tsx
+++ b/apps/brand/components/SavedCreatorCard.tsx
@@ -1,0 +1,41 @@
+"use client";
+import Link from "next/link";
+import type { Creator } from "@/app/data/creators";
+
+interface Props {
+  creator: Creator;
+}
+
+export default function SavedCreatorCard({ creator }: Props) {
+  return (
+    <div className="bg-white dark:bg-Siora-mid border border-gray-300 dark:border-Siora-border rounded-2xl p-6 shadow-Siora-hover flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          {creator.name}
+        </h2>
+        <span className="text-sm text-gray-500 dark:text-zinc-400">
+          {creator.platform}
+        </span>
+      </div>
+      <p className="text-sm text-gray-700 dark:text-zinc-300">{creator.summary}</p>
+      {creator.tags && (
+        <div className="flex flex-wrap gap-2 mt-1">
+          {creator.tags.map((tag) => (
+            <span
+              key={tag}
+              className="text-xs bg-gray-100 dark:bg-Siora-light text-gray-700 dark:text-zinc-300 px-2 py-1 rounded-full"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+      <Link
+        href={`/creator/${creator.id}/profile`}
+        className="mt-3 inline-block bg-Siora-accent hover:bg-Siora-accent-soft text-white px-3 py-1 rounded shadow"
+      >
+        View Profile
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `SavedCreatorCard` component for listing saved creators
- implement `/inbox` brand dashboard page with filters and dummy data

## Testing
- `npm ls` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68519224ed94832c9b76a9dcf25b3979