### PR TITLE
Add performance metrics page

### DIFF
--- a/apps/creator/app/dashboard/page.tsx
+++ b/apps/creator/app/dashboard/page.tsx
@@ -60,6 +60,9 @@ export default function DashboardPage() {
         <Link href="/collabs" className="underline">
           Collabs
         </Link>
+        <Link href="/performance" className="underline">
+          Performance
+        </Link>
       </nav>
       <PerformanceMetrics />
       {items.length === 0 ? (

--- a/apps/creator/app/performance/page.tsx
+++ b/apps/creator/app/performance/page.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { savePerformance, loadPerformance } from "@/lib/localPerformance";
+import type { PerformanceData } from "@/types/performance";
+
+export default function PerformancePage() {
+  const [metrics, setMetrics] = useState<PerformanceData>({
+    followerCount: 0,
+    engagementRate: 0,
+    avgViews: 0,
+    growthTrend: "",
+  });
+
+  useEffect(() => {
+    const stored = loadPerformance();
+    if (stored) setMetrics(stored);
+  }, []);
+
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const { name, value } = e.target;
+    setMetrics((prev) => ({
+      ...prev,
+      [name]: name === "growthTrend" ? value : Number(value),
+    }));
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    savePerformance(metrics);
+    alert("Saved performance metrics");
+  };
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 space-y-6 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold">Update Performance</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 border border-white/10 p-4 rounded-md">
+        <div>
+          <label className="block text-sm font-semibold mb-1" htmlFor="followerCount">Follower Count</label>
+          <input
+            id="followerCount"
+            name="followerCount"
+            type="number"
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={metrics.followerCount}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-semibold mb-1" htmlFor="engagementRate">Engagement Rate (%)</label>
+          <input
+            id="engagementRate"
+            name="engagementRate"
+            type="number"
+            step="0.1"
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={metrics.engagementRate}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-semibold mb-1" htmlFor="avgViews">Avg Views per Post</label>
+          <input
+            id="avgViews"
+            name="avgViews"
+            type="number"
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={metrics.avgViews}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-semibold mb-1" htmlFor="growthTrend">Growth Trend</label>
+          <input
+            id="growthTrend"
+            name="growthTrend"
+            type="text"
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={metrics.growthTrend}
+            onChange={handleChange}
+            placeholder="rising, steady, declining"
+          />
+        </div>
+        <button type="submit" className="bg-indigo-600 hover:bg-indigo-500 transition-colors duration-200 text-white px-4 py-2 rounded-md">
+          Save Metrics
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/apps/creator/components/PerformanceMetrics.tsx
+++ b/apps/creator/components/PerformanceMetrics.tsx
@@ -1,56 +1,39 @@
-import React from "react";
-
-const mockData = {
-  followers: {
-    instagram: 12000,
-    tiktok: 15000,
-    youtube: 8000,
-  },
-  avgViews: 5000,
-  engagementRate: 4.8,
-  recentTopContent: [
-    { title: "How to style activewear", views: 12000 },
-    { title: "Daily workout routine", views: 11000 },
-    { title: "Healthy meal prep ideas", views: 10500 },
-  ],
-};
+"use client";
+import { useEffect, useState } from "react";
+import { loadPerformance } from "@/lib/localPerformance";
+import type { PerformanceData } from "@/types/performance";
 
 export default function PerformanceMetrics() {
-  const { followers, avgViews, engagementRate, recentTopContent } = mockData;
+  const [data, setData] = useState<PerformanceData | null>(null);
+
+  useEffect(() => {
+    setData(loadPerformance());
+  }, []);
+
+  if (!data) {
+    return (
+      <div className="border border-white/10 bg-background p-4 rounded-xl shadow-sm space-y-2">
+        <h2 className="text-lg font-bold">Performance Metrics</h2>
+        <p className="text-sm text-foreground/60">No metrics saved.</p>
+      </div>
+    );
+  }
+
   return (
-    <div className="border border-white/10 bg-background p-4 rounded-xl shadow-sm space-y-4">
+    <div className="border border-white/10 bg-background p-4 rounded-xl shadow-sm space-y-2">
       <h2 className="text-lg font-bold">Performance Metrics</h2>
-      <div>
-        <h3 className="font-semibold text-sm mb-1">Total Followers</h3>
-        <ul className="text-sm space-y-1">
-          {Object.entries(followers).map(([platform, count]) => (
-            <li key={platform} className="flex justify-between">
-              <span className="capitalize">{platform}</span>
-              <span>{count.toLocaleString()}</span>
-            </li>
-          ))}
-        </ul>
-      </div>
-      <div className="text-sm space-y-1">
-        <p>
-          <span className="font-semibold">Avg Views per Post:</span>{" "}
-          {avgViews.toLocaleString()}
-        </p>
-        <p>
-          <span className="font-semibold">Engagement Rate:</span>{" "}
-          {engagementRate}%
-        </p>
-      </div>
-      <div>
-        <h3 className="font-semibold text-sm mb-1">Recent Top Content</h3>
-        <ul className="list-disc list-inside text-sm space-y-1">
-          {recentTopContent.map((post, i) => (
-            <li key={i}>
-              {post.title} - {post.views.toLocaleString()} views
-            </li>
-          ))}
-        </ul>
-      </div>
+      <p className="text-sm">
+        <span className="font-semibold">Follower Count:</span> {data.followerCount.toLocaleString()}
+      </p>
+      <p className="text-sm">
+        <span className="font-semibold">Avg Views per Post:</span> {data.avgViews.toLocaleString()}
+      </p>
+      <p className="text-sm">
+        <span className="font-semibold">Engagement Rate:</span> {data.engagementRate}%
+      </p>
+      <p className="text-sm">
+        <span className="font-semibold">Growth Trend:</span> {data.growthTrend || "N/A"}
+      </p>
     </div>
   );
 }

--- a/apps/creator/lib/localPerformance.ts
+++ b/apps/creator/lib/localPerformance.ts
@@ -1,0 +1,23 @@
+import type { PerformanceData } from "@/types/performance";
+
+const STORAGE_KEY = "performanceMetrics";
+
+export function savePerformance(data: PerformanceData) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch (err) {
+    console.error("Failed to save performance metrics", err);
+  }
+}
+
+export function loadPerformance(): PerformanceData | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) return JSON.parse(stored) as PerformanceData;
+  } catch (err) {
+    console.error("Failed to load performance metrics", err);
+  }
+  return null;
+}

--- a/apps/creator/types/performance.ts
+++ b/apps/creator/types/performance.ts
@@ -1,0 +1,6 @@
+export type PerformanceData = {
+  followerCount: number;
+  engagementRate: number;
+  avgViews: number;
+  growthTrend: string;
+};


### PR DESCRIPTION
## Summary
- add `/performance` page with form for follower count, engagement rate, avg views per post and growth trend
- save the metrics locally and show them on the dashboard
- update the dashboard navigation

## Testing
- `npx turbo run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519235dbec832ca5d9a62fe025348b