### PR TITLE
Add performance tab to brand creator profile

### DIFF
--- a/apps/brand/app/api/performance/[id]/route.ts
+++ b/apps/brand/app/api/performance/[id]/route.ts
@@ -1,0 +1,18 @@
+import data from '@/app/data/performanceData.json';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const record = (data as Record<string, any>)[params.id];
+  if (!record) {
+    return new Response(JSON.stringify({ error: 'Not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  return new Response(JSON.stringify(record), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/apps/brand/app/creator/[id]/profile.tsx
+++ b/apps/brand/app/creator/[id]/profile.tsx
@@ -1,5 +1,6 @@
 import creators from "@/app/data/mock_creators_200.json";
 import { notFound } from "next/navigation";
+import PerformanceTab from "@/components/PerformanceTab";
 
 type Props = {
   params: {
@@ -55,6 +56,8 @@ export default function CreatorProfile({ params }: Props) {
               </div>
             </div>
           )}
+
+          <PerformanceTab creatorId={creator.id.toString()} />
         </div>
       </div>
     </main>

--- a/apps/brand/app/data/performanceData.json
+++ b/apps/brand/app/data/performanceData.json
@@ -1,0 +1,5 @@
+{
+  "1": {"followers": 120000, "engagementRate": 3.8, "avgViews": 5500, "growth": 0.04},
+  "2": {"followers": 45000, "engagementRate": 6.2, "avgViews": 15000, "growth": 0.02},
+  "3": {"followers": 82000, "engagementRate": 4.7, "avgViews": 9000, "growth": -0.01}
+}

--- a/apps/brand/components/PerformanceTab.tsx
+++ b/apps/brand/components/PerformanceTab.tsx
@@ -1,0 +1,60 @@
+"use client";
+import { useEffect, useState } from "react";
+
+type Props = {
+  creatorId: string;
+};
+
+interface PerfData {
+  followers: number;
+  engagementRate: number;
+  avgViews: number;
+  growth: number;
+}
+
+export default function PerformanceTab({ creatorId }: Props) {
+  const [data, setData] = useState<PerfData | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/performance/${creatorId}`);
+        if (res.ok) {
+          const d = await res.json();
+          setData(d);
+        }
+      } catch (err) {
+        console.error("performance fetch", err);
+      }
+    }
+    load();
+  }, [creatorId]);
+
+  if (!data) {
+    return <p className="text-sm text-zinc-400">Loading performance...</p>;
+  }
+
+  const trendUp = data.growth >= 0;
+  const trendPercent = Math.round(Math.abs(data.growth * 100));
+
+  return (
+    <div className="mt-6 space-y-2 text-sm text-zinc-300">
+      <div>
+        <strong>Followers:</strong> {data.followers.toLocaleString()}
+      </div>
+      <div>
+        <strong>Engagement Rate:</strong> {data.engagementRate}%
+      </div>
+      <div>
+        <strong>Avg Views:</strong> {data.avgViews.toLocaleString()}
+      </div>
+      <div className="flex items-center gap-1">
+        <strong>Growth:</strong>
+        <span className={trendUp ? "text-green-400" : "text-red-400"}>
+          {trendUp ? "▲" : "▼"}
+        </span>
+        <span>{trendPercent}%</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add mocked performance data API
- display followers, engagement, avg views and growth
- fetch data in new `PerformanceTab` component
- embed performance tab in brand creator profile

## Testing
- `npx turbo lint` *(fails: command not found or missing workspaces)*

------
https://chatgpt.com/codex/tasks/task_e_685192458318832c90c43bdda61c924e