### PR TITLE
Add inbox saved creators page

### DIFF
--- a/apps/brand/components/SavedCreatorCard.tsx
+++ b/apps/brand/components/SavedCreatorCard.tsx
@@ -1,0 +1,48 @@
+"use client";
+import Link from "next/link";
+import { motion } from "framer-motion";
+import type { Creator } from "@/app/data/creators";
+
+interface Props {
+  creator: Creator;
+}
+
+export default function SavedCreatorCard({ creator }: Props) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      whileHover={{ y: -6 }}
+      transition={{ duration: 0.3 }}
+      className="bg-white dark:bg-Siora-mid border border-gray-300 dark:border-Siora-border rounded-2xl p-6 shadow-Siora-hover"
+    >
+      <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
+        {creator.name}
+      </h3>
+      <p className="text-sm text-gray-500 dark:text-zinc-400 mb-1">
+        {creator.platform}
+      </p>
+      <p className="text-sm text-gray-700 dark:text-zinc-300 mb-2">
+        {creator.summary}
+      </p>
+      {creator.tags && (
+        <div className="flex flex-wrap gap-1 mb-4">
+          {creator.tags.map((t) => (
+            <span
+              key={t}
+              className="bg-gray-100 dark:bg-Siora-light text-gray-700 dark:text-zinc-300 rounded px-2 py-1 text-xs"
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+      )}
+      <Link
+        href={`/dashboard/persona/${creator.handle.replace(/^@/, "")}`}
+        className="text-sm text-Siora-accent underline"
+      >
+        View Profile
+      </Link>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
## Summary
- overhaul brand inbox page to show saved creators
- add simple filtering by niche, ER and vibe
- add `SavedCreatorCard` component for concise profile info

## Testing
- `pnpm -r install` *(fails: shared-utils@workspace:* missing)*
- `npx next lint` *(fails: Unsupported URL Type "workspace:")*

------
https://chatgpt.com/codex/tasks/task_e_68519330fe9c832c98ec7b8151aee782