### PR TITLE
Rank inbox creators by match score

### DIFF
--- a/apps/brand/app/inbox/page.tsx
+++ b/apps/brand/app/inbox/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { creators } from "@/app/data/creators";
 import { useShortlist } from "@/lib/shortlist";
 import { useBrandUser } from "@/lib/brandUser";
 import SavedCreatorCard from "@/components/SavedCreatorCard";
+import type { BrandProfile, CreatorPersona } from "shared-utils";
+import { matchScore } from "shared-utils";
 
 export default function InboxPage() {
   const { user } = useBrandUser();
@@ -14,6 +16,30 @@ export default function InboxPage() {
   const [vibe, setVibe] = useState("");
   const [minER, setMinER] = useState("");
   const [maxER, setMaxER] = useState("");
+
+  const [brand, setBrand] = useState<BrandProfile & { platforms?: string[] } | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = localStorage.getItem("brandPrefs");
+    if (stored) {
+      try {
+        setBrand(JSON.parse(stored));
+      } catch {
+        setBrand(null);
+      }
+    } else {
+      setBrand({
+        targetAgeRange: { min: 18, max: 30 },
+        niches: ["Beauty & Lifestyle"],
+        tone: "Warm & Aspirational",
+        values: ["wellness", "selfcare"],
+        desiredFormats: ["UGC reels"],
+        categories: ["Clean beauty"],
+        platforms: ["Instagram"],
+      });
+    }
+  }, []);
 
   const savedCreators = creators.filter((c) => ids.includes(c.id));
 
@@ -27,6 +53,28 @@ export default function InboxPage() {
     const maxOk = maxER ? c.engagementRate <= parseFloat(maxER) : true;
     return nicheOk && vibeOk && minOk && maxOk;
   });
+
+  const scored = useMemo(() => {
+    return filtered
+      .map((c) => {
+        const persona: CreatorPersona = {
+          niches: [c.niche],
+          tone: c.tone,
+          platforms: [c.platform],
+          vibe: c.vibe,
+          formats: c.formats,
+        };
+        let score = 0;
+        let reason = '';
+        if (brand) {
+          const result = matchScore(persona, brand);
+          score = result.score;
+          reason = result.reasons.slice(0, 3).join(', ');
+        }
+        return { creator: c, score, reason };
+      })
+      .sort((a, b) => b.score - a.score);
+  }, [filtered, brand]);
 
   return (
     <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
@@ -88,12 +136,17 @@ export default function InboxPage() {
           </div>
         </div>
 
-        {filtered.length === 0 ? (
+        {scored.length === 0 ? (
           <p className="text-center text-zinc-400">No creators saved.</p>
         ) : (
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            {filtered.map((c) => (
-              <SavedCreatorCard key={c.id} creator={c} />
+            {scored.map(({ creator, score, reason }) => (
+              <SavedCreatorCard
+                key={creator.id}
+                creator={creator}
+                score={Math.round(score)}
+                reason={reason}
+              />
             ))}
           </div>
         )}

--- a/apps/brand/components/SavedCreatorCard.tsx
+++ b/apps/brand/components/SavedCreatorCard.tsx
@@ -5,9 +5,11 @@ import type { Creator } from "@/app/data/creators";
 
 interface Props {
   creator: Creator;
+  score?: number;
+  reason?: string;
 }
 
-export default function SavedCreatorCard({ creator }: Props) {
+export default function SavedCreatorCard({ creator, score, reason }: Props) {
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
@@ -19,6 +21,16 @@ export default function SavedCreatorCard({ creator }: Props) {
       <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
         {creator.name}
       </h3>
+      {typeof score === "number" && (
+        <p className="text-sm text-gray-500 dark:text-zinc-400">
+          Match Score: {score}/100
+        </p>
+      )}
+      {reason && (
+        <p className="text-sm text-gray-500 dark:text-zinc-400 mb-1">
+          {reason}
+        </p>
+      )}
       <p className="text-sm text-gray-500 dark:text-zinc-400 mb-1">
         {creator.platform}
       </p>


### PR DESCRIPTION
## Summary
- compute best matches for brands on inbox page
- show match score and short reason on each saved creator card

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851949061a4832c8608def9028050d3