### PR TITLE
Add brand inbox applications tab

### DIFF
--- a/apps/brand/app/api/applications/route.ts
+++ b/apps/brand/app/api/applications/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import path from 'path';
+import { promises as fs } from 'fs';
+
+interface ApplicationEntry {
+  id: string;
+  userId: string;
+  campaignId: string;
+  pitch: string;
+  personaSummary: string;
+  timestamp: string;
+  status?: 'pending' | 'accepted' | 'declined';
+}
+
+const dbPath = path.join(process.cwd(), '..', '..', 'db', 'campaign_applications.json');
+
+async function readData(): Promise<ApplicationEntry[]> {
+  try {
+    const file = await fs.readFile(dbPath, 'utf8');
+    const data = JSON.parse(file);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeData(data: ApplicationEntry[]) {
+  await fs.writeFile(dbPath, JSON.stringify(data, null, 2));
+}
+
+export async function GET() {
+  try {
+    const data = await readData();
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error('applications GET error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}
+
+export async function PUT(req: Request) {
+  try {
+    const { id, status } = await req.json();
+    if (!id || !status) {
+      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+    }
+    const data = await readData();
+    const app = data.find(a => a.id === id);
+    if (!app) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    app.status = status;
+    await writeData(data);
+    return NextResponse.json(app);
+  } catch (err) {
+    console.error('applications PUT error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/apps/brand/app/api/campaigns/[id]/applications/route.ts
+++ b/apps/brand/app/api/campaigns/[id]/applications/route.ts
@@ -9,6 +9,7 @@ interface Application {
   pitch: string;
   personaSummary: string;
   timestamp: string;
+  status?: 'pending' | 'accepted' | 'declined';
 }
 
 const dbPath = path.join(process.cwd(), '..', '..', 'db', 'campaign_applications.json');

--- a/apps/brand/app/inbox/page.tsx
+++ b/apps/brand/app/inbox/page.tsx
@@ -1,19 +1,48 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { creators } from "@/app/data/creators";
 import { useShortlist } from "@/lib/shortlist";
 import { useBrandUser } from "@/lib/brandUser";
 import SavedCreatorCard from "@/components/SavedCreatorCard";
 
+interface Application {
+  id: string;
+  userId: string;
+  campaignId: string;
+  personaSummary: string;
+  timestamp: string;
+  status?: 'pending' | 'accepted' | 'declined';
+}
+
 export default function InboxPage() {
   const { user } = useBrandUser();
   const { ids } = useShortlist(user?.email ?? null);
+
+  const [tab, setTab] = useState<'saved' | 'applications'>('saved');
 
   const [niche, setNiche] = useState("");
   const [vibe, setVibe] = useState("");
   const [minER, setMinER] = useState("");
   const [maxER, setMaxER] = useState("");
+
+  const [apps, setApps] = useState<Application[]>([]);
+
+  useEffect(() => {
+    if (tab !== 'applications') return;
+    async function load() {
+      try {
+        const res = await fetch('/api/applications');
+        if (res.ok) {
+          const data = await res.json();
+          if (Array.isArray(data)) setApps(data as Application[]);
+        }
+      } catch (err) {
+        console.error('failed to load applications', err);
+      }
+    }
+    load();
+  }, [tab]);
 
   const savedCreators = creators.filter((c) => ids.includes(c.id));
 
@@ -28,73 +57,137 @@ export default function InboxPage() {
     return nicheOk && vibeOk && minOk && maxOk;
   });
 
+  async function update(id: string, status: Application['status']) {
+    try {
+      await fetch('/api/applications', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id, status }),
+      });
+      setApps((prev) =>
+        prev.map((a) => (a.id === id ? { ...a, status } : a))
+      );
+    } catch (err) {
+      console.error('failed to update', err);
+    }
+  }
+
   return (
     <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
       <div className="max-w-5xl mx-auto space-y-8">
         <h1 className="text-3xl font-bold">Inbox</h1>
-
-        <div className="bg-Siora-mid p-4 rounded-xl shadow-Siora-hover space-y-4 sm:space-y-0 sm:flex sm:items-end sm:gap-4">
-          <div className="flex-1">
-            <label className="block text-sm mb-1">Niche</label>
-            <select
-              value={niche}
-              onChange={(e) => setNiche(e.target.value)}
-              className="w-full bg-Siora-light text-white border border-Siora-border p-2 rounded-md"
-            >
-              <option value="">All</option>
-              {niches.map((n) => (
-                <option key={n} value={n}>
-                  {n}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="flex-1">
-            <label className="block text-sm mb-1">Vibe</label>
-            <select
-              value={vibe}
-              onChange={(e) => setVibe(e.target.value)}
-              className="w-full bg-Siora-light text-white border border-Siora-border p-2 rounded-md"
-            >
-              <option value="">All</option>
-              {vibes.map((v) => (
-                <option key={v} value={v}>
-                  {v}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div className="flex-1">
-            <label className="block text-sm mb-1">Min ER%</label>
-            <input
-              type="number"
-              step="0.1"
-              value={minER}
-              onChange={(e) => setMinER(e.target.value)}
-              placeholder="Any"
-              className="w-full bg-Siora-light text-white border border-Siora-border p-2 rounded-md"
-            />
-          </div>
-          <div className="flex-1">
-            <label className="block text-sm mb-1">Max ER%</label>
-            <input
-              type="number"
-              step="0.1"
-              value={maxER}
-              onChange={(e) => setMaxER(e.target.value)}
-              placeholder="Any"
-              className="w-full bg-Siora-light text-white border border-Siora-border p-2 rounded-md"
-            />
-          </div>
+        <div className="flex gap-4">
+          <button
+            onClick={() => setTab('saved')}
+            className={`px-3 py-1 rounded border border-Siora-border ${tab === 'saved' ? 'bg-Siora-accent' : ''}`}
+          >
+            Saved Creators
+          </button>
+          <button
+            onClick={() => setTab('applications')}
+            className={`px-3 py-1 rounded border border-Siora-border ${tab === 'applications' ? 'bg-Siora-accent' : ''}`}
+          >
+            Applications
+          </button>
         </div>
 
-        {filtered.length === 0 ? (
-          <p className="text-center text-zinc-400">No creators saved.</p>
-        ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-            {filtered.map((c) => (
-              <SavedCreatorCard key={c.id} creator={c} />
-            ))}
+        {tab === 'saved' && (
+          <>
+            <div className="bg-Siora-mid p-4 rounded-xl shadow-Siora-hover space-y-4 sm:space-y-0 sm:flex sm:items-end sm:gap-4">
+              <div className="flex-1">
+                <label className="block text-sm mb-1">Niche</label>
+                <select
+                  value={niche}
+                  onChange={(e) => setNiche(e.target.value)}
+                  className="w-full bg-Siora-light text-white border border-Siora-border p-2 rounded-md"
+                >
+                  <option value="">All</option>
+                  {niches.map((n) => (
+                    <option key={n} value={n}>
+                      {n}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex-1">
+                <label className="block text-sm mb-1">Vibe</label>
+                <select
+                  value={vibe}
+                  onChange={(e) => setVibe(e.target.value)}
+                  className="w-full bg-Siora-light text-white border border-Siora-border p-2 rounded-md"
+                >
+                  <option value="">All</option>
+                  {vibes.map((v) => (
+                    <option key={v} value={v}>
+                      {v}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="flex-1">
+                <label className="block text-sm mb-1">Min ER%</label>
+                <input
+                  type="number"
+                  step="0.1"
+                  value={minER}
+                  onChange={(e) => setMinER(e.target.value)}
+                  placeholder="Any"
+                  className="w-full bg-Siora-light text-white border border-Siora-border p-2 rounded-md"
+                />
+              </div>
+              <div className="flex-1">
+                <label className="block text-sm mb-1">Max ER%</label>
+                <input
+                  type="number"
+                  step="0.1"
+                  value={maxER}
+                  onChange={(e) => setMaxER(e.target.value)}
+                  placeholder="Any"
+                  className="w-full bg-Siora-light text-white border border-Siora-border p-2 rounded-md"
+                />
+              </div>
+            </div>
+
+            {filtered.length === 0 ? (
+              <p className="text-center text-zinc-400">No creators saved.</p>
+            ) : (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+                {filtered.map((c) => (
+                  <SavedCreatorCard key={c.id} creator={c} />
+                ))}
+              </div>
+            )}
+          </>
+        )}
+
+        {tab === 'applications' && (
+          <div className="space-y-4">
+            {apps.map((app) => {
+              const creator = creators.find((c) => c.id === app.userId);
+              return (
+                <div key={app.id} className="bg-Siora-mid border border-Siora-border rounded-xl p-6 shadow-Siora-hover">
+                  <h2 className="text-xl font-semibold mb-1">
+                    {creator ? creator.name : app.userId}
+                  </h2>
+                  <p className="text-sm text-zinc-300 mb-2">{creator?.summary ?? app.personaSummary}</p>
+                  <div className="flex items-center gap-2">
+                    <label className="text-sm">Status:</label>
+                    <select
+                      value={app.status ?? 'pending'}
+                      onChange={(e) => update(app.id, e.target.value as Application['status'])}
+                      className="bg-Siora-light text-white border border-Siora-border p-1 rounded"
+                    >
+                      <option value="pending">Pending</option>
+                      <option value="accepted">Accepted</option>
+                      <option value="declined">Declined</option>
+                    </select>
+                  </div>
+                </div>
+              );
+            })}
+            {apps.length === 0 && (
+              <p className="text-center text-zinc-400">No applications.</p>
+            )}
           </div>
         )}
       </div>

--- a/apps/creator/app/api/campaign-applications/route.ts
+++ b/apps/creator/app/api/campaign-applications/route.ts
@@ -15,6 +15,7 @@ interface ApplicationEntry extends ApplicationRequest {
   id: string;
   userId: string;
   timestamp: string;
+  status?: 'pending' | 'accepted' | 'declined';
 }
 
 const dbPath = path.join(process.cwd(), '..', '..', 'db', 'campaign_applications.json');
@@ -58,6 +59,7 @@ export async function POST(req: Request) {
       pitch,
       personaSummary,
       timestamp: new Date().toISOString(),
+      status: 'pending',
     };
     data.push(entry);
     await fs.writeFile(dbPath, JSON.stringify(data, null, 2));

--- a/apps/creator/app/applications/page.tsx
+++ b/apps/creator/app/applications/page.tsx
@@ -8,6 +8,7 @@ interface Application {
   pitch: string;
   personaSummary: string;
   timestamp: string;
+  status?: 'pending' | 'accepted' | 'declined';
 }
 
 export default function ApplicationsPage() {
@@ -43,6 +44,7 @@ export default function ApplicationsPage() {
                 <h2 className="text-lg font-semibold">{c?.title ?? a.campaignId}</h2>
                 <p className="text-sm text-foreground/80">{c?.brand}</p>
                 <p className="text-sm">{a.pitch}</p>
+                <p className="text-sm">Status: {a.status ?? 'pending'}</p>
                 <p className="text-xs text-foreground/60">{new Date(a.timestamp).toLocaleString()}</p>
               </div>
             );


### PR DESCRIPTION
## Summary
- manage creator applications JSON with status field
- expose /brand/api/applications for listing and status updates
- track application status when creators apply
- show application tab on brand inbox page with dropdown to update status
- surface application status on creator side

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685194a08484832c952a7b00911c69bb