### PR TITLE
Add grouped message storage

### DIFF
--- a/apps/brand/app/api/messages/route.ts
+++ b/apps/brand/app/api/messages/route.ts
@@ -1,41 +1,43 @@
 import { NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { randomUUID } from 'crypto';
-
 interface Message {
-  id: string;
-  creatorId: string;
-  sender: 'brand' | 'creator';
-  text: string;
-  campaign?: string;
+  senderId: string;
+  receiverId: string;
+  message: string;
   timestamp: string;
+  read: boolean;
 }
+
+type MessageDB = Record<string, Message[]>;
 
 const DB_PATH = path.join(process.cwd(), '..', '..', 'db', 'messages.json');
 
-async function readData(): Promise<Message[]> {
+async function readData(): Promise<MessageDB> {
   try {
     const file = await fs.readFile(DB_PATH, 'utf8');
     const data = JSON.parse(file);
-    return Array.isArray(data) ? data : [];
+    return data && typeof data === 'object' ? data as MessageDB : {};
   } catch {
-    return [];
+    return {};
   }
 }
 
-async function writeData(data: Message[]) {
+async function writeData(data: MessageDB) {
   await fs.writeFile(DB_PATH, JSON.stringify(data, null, 2));
 }
 
 export async function GET(req: Request) {
   try {
     const { searchParams } = new URL(req.url);
+    const brandId = searchParams.get('brandId');
     const creatorId = searchParams.get('creatorId');
-    const campaign = searchParams.get('campaign');
+    if (!brandId || !creatorId) {
+      return NextResponse.json({ error: 'brandId and creatorId required' }, { status: 400 });
+    }
     const data = await readData();
-    let messages = creatorId ? data.filter(m => m.creatorId === creatorId) : data;
-    if (campaign) messages = messages.filter(m => m.campaign === campaign);
+    const key = `${brandId}_${creatorId}`;
+    const messages = data[key] ?? [];
     return NextResponse.json({ messages });
   } catch (err) {
     console.error('messages GET error', err);
@@ -45,22 +47,24 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { creatorId, sender, text, campaign } = await req.json();
-    if (!creatorId || !sender || !text) {
+    const { brandId, creatorId, senderId, receiverId, message } = await req.json();
+    if (!brandId || !creatorId || !senderId || !receiverId || !message) {
       return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
     }
     const data = await readData();
-    const message: Message = {
-      id: randomUUID(),
-      creatorId,
-      sender,
-      text,
-      campaign,
+    const key = `${brandId}_${creatorId}`;
+    const entry = data[key] ?? [];
+    const newMessage: Message = {
+      senderId,
+      receiverId,
+      message,
       timestamp: new Date().toISOString(),
+      read: false,
     };
-    data.push(message);
+    entry.push(newMessage);
+    data[key] = entry;
     await writeData(data);
-    return NextResponse.json({ message });
+    return NextResponse.json({ message: newMessage });
   } catch (err) {
     console.error('messages POST error', err);
     return NextResponse.json({ error: 'Server error' }, { status: 500 });

--- a/apps/creator/app/api/messages/route.ts
+++ b/apps/creator/app/api/messages/route.ts
@@ -1,41 +1,43 @@
 import { NextResponse } from 'next/server';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { randomUUID } from 'crypto';
-
 interface Message {
-  id: string;
-  creatorId: string;
-  sender: 'brand' | 'creator';
-  text: string;
-  campaign?: string;
+  senderId: string;
+  receiverId: string;
+  message: string;
   timestamp: string;
+  read: boolean;
 }
+
+type MessageDB = Record<string, Message[]>;
 
 const DB_PATH = path.join(process.cwd(), '..', '..', 'db', 'messages.json');
 
-async function readData(): Promise<Message[]> {
+async function readData(): Promise<MessageDB> {
   try {
     const file = await fs.readFile(DB_PATH, 'utf8');
     const data = JSON.parse(file);
-    return Array.isArray(data) ? data : [];
+    return data && typeof data === 'object' ? data as MessageDB : {};
   } catch {
-    return [];
+    return {};
   }
 }
 
-async function writeData(data: Message[]) {
+async function writeData(data: MessageDB) {
   await fs.writeFile(DB_PATH, JSON.stringify(data, null, 2));
 }
 
 export async function GET(req: Request) {
   try {
     const { searchParams } = new URL(req.url);
+    const brandId = searchParams.get('brandId');
     const creatorId = searchParams.get('creatorId');
-    const campaign = searchParams.get('campaign');
+    if (!brandId || !creatorId) {
+      return NextResponse.json({ error: 'brandId and creatorId required' }, { status: 400 });
+    }
     const data = await readData();
-    let messages = creatorId ? data.filter(m => m.creatorId === creatorId) : data;
-    if (campaign) messages = messages.filter(m => m.campaign === campaign);
+    const key = `${brandId}_${creatorId}`;
+    const messages = data[key] ?? [];
     return NextResponse.json({ messages });
   } catch (err) {
     console.error('messages GET error', err);
@@ -45,22 +47,24 @@ export async function GET(req: Request) {
 
 export async function POST(req: Request) {
   try {
-    const { creatorId, sender, text, campaign } = await req.json();
-    if (!creatorId || !sender || !text) {
+    const { brandId, creatorId, senderId, receiverId, message } = await req.json();
+    if (!brandId || !creatorId || !senderId || !receiverId || !message) {
       return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
     }
     const data = await readData();
-    const message: Message = {
-      id: randomUUID(),
-      creatorId,
-      sender,
-      text,
-      campaign,
+    const key = `${brandId}_${creatorId}`;
+    const entry = data[key] ?? [];
+    const newMessage: Message = {
+      senderId,
+      receiverId,
+      message,
       timestamp: new Date().toISOString(),
+      read: false,
     };
-    data.push(message);
+    entry.push(newMessage);
+    data[key] = entry;
     await writeData(data);
-    return NextResponse.json({ message });
+    return NextResponse.json({ message: newMessage });
   } catch (err) {
     console.error('messages POST error', err);
     return NextResponse.json({ error: 'Server error' }, { status: 500 });

--- a/db/messages.json
+++ b/db/messages.json
@@ -1,18 +1,18 @@
-[
-  {
-    "id": "msg1",
-    "creatorId": "1",
-    "sender": "brand",
-    "text": "Welcome to the campaign!",
-    "campaign": "1",
-    "timestamp": "2024-05-01T12:10:00.000Z"
-  },
-  {
-    "id": "msg2",
-    "creatorId": "1",
-    "sender": "creator",
-    "text": "Thanks, excited to work together!",
-    "campaign": "1",
-    "timestamp": "2024-05-01T12:12:00.000Z"
-  }
-]
+{
+  "brand1_1": [
+    {
+      "senderId": "brand1",
+      "receiverId": "1",
+      "message": "Welcome to the campaign!",
+      "timestamp": "2024-05-01T12:10:00.000Z",
+      "read": true
+    },
+    {
+      "senderId": "1",
+      "receiverId": "brand1",
+      "message": "Thanks, excited to work together!",
+      "timestamp": "2024-05-01T12:12:00.000Z",
+      "read": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- introduce per-conversation message model in messages.json
- store messages by `brandId_creatorId` pair
- update brand and creator message API routes to handle new model

## Testing
- `npx --yes turbo run lint` *(fails: command exited with code 127)*

------
https://chatgpt.com/codex/tasks/task_e_68519705b494832cbca92d9616dc0b26