### PR TITLE
Add chat sidebar for inbox page

### DIFF
--- a/apps/brand/app/inbox/page.tsx
+++ b/apps/brand/app/inbox/page.tsx
@@ -2,9 +2,11 @@
 
 import { useState, useMemo, useEffect } from "react";
 import { creators } from "@/app/data/creators";
+import type { Creator } from "@/app/data/creators";
 import { useShortlist } from "@/lib/shortlist";
 import { useBrandUser } from "@/lib/brandUser";
 import SavedCreatorCard from "@/components/SavedCreatorCard";
+import ChatSidebar from "@/components/ChatSidebar";
 
 interface Application {
   id: string;
@@ -24,6 +26,8 @@ export default function InboxPage() {
 
   const [tab, setTab] = useState<'shortlist' | 'applications'>('shortlist');
   const [applications, setApplications] = useState<Application[]>([]);
+
+  const [chatCreator, setChatCreator] = useState<Creator | null>(null);
 
   const [niche, setNiche] = useState("");
   const [vibe, setVibe] = useState("");
@@ -218,6 +222,7 @@ export default function InboxPage() {
                     creator={creator}
                     score={Math.round(score)}
                     reason={reason}
+                    onClick={() => setChatCreator(creator)}
                   />
                 ))}
               </div>
@@ -257,6 +262,9 @@ export default function InboxPage() {
           </div>
         )}
       </div>
+      {chatCreator && (
+        <ChatSidebar creator={chatCreator} onClose={() => setChatCreator(null)} />
+      )}
     </main>
   );
 }

--- a/apps/brand/components/ChatSidebar.tsx
+++ b/apps/brand/components/ChatSidebar.tsx
@@ -1,0 +1,75 @@
+"use client";
+import { useEffect, useState } from "react";
+import type { Creator } from "@/app/data/creators";
+import { ChatPanel, ChatMessage } from "shared-ui";
+
+interface Message extends ChatMessage {
+  creatorId: string;
+  campaign?: string;
+}
+
+interface Props {
+  creator: Creator | null;
+  onClose: () => void;
+}
+
+export default function ChatSidebar({ creator, onClose }: Props) {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [sending, setSending] = useState(false);
+
+  useEffect(() => {
+    if (!creator) return;
+    async function load() {
+      try {
+        const res = await fetch(`/api/messages?creatorId=${creator.id}`);
+        if (res.ok) {
+          const data = await res.json();
+          const sorted = (data.messages as Message[]).sort(
+            (a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
+          );
+          setMessages(sorted);
+        }
+      } catch (err) {
+        console.error('failed to load messages', err);
+      }
+    }
+    load();
+  }, [creator]);
+
+  const send = async (text: string) => {
+    if (!creator) return;
+    setSending(true);
+    try {
+      const res = await fetch('/api/messages', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ creatorId: creator.id, sender: 'brand', text }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setMessages((prev) => [...prev, data.message]);
+      }
+    } finally {
+      setSending(false);
+    }
+  };
+
+  if (!creator) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end bg-black/50">
+      <div className="w-full max-w-md bg-Siora-mid border-l border-Siora-border p-4 flex flex-col">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-white">Chat with {creator.name}</h2>
+          <button onClick={onClose} className="text-white">✕</button>
+        </div>
+        <ChatPanel
+          messages={messages}
+          currentUser="brand"
+          onSend={send}
+          sending={sending}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/brand/components/SavedCreatorCard.tsx
+++ b/apps/brand/components/SavedCreatorCard.tsx
@@ -7,16 +7,18 @@ interface Props {
   creator: Creator;
   score?: number;
   reason?: string;
+  onClick?: () => void;
 }
 
-export default function SavedCreatorCard({ creator, score, reason }: Props) {
+export default function SavedCreatorCard({ creator, score, reason, onClick }: Props) {
   return (
     <motion.div
       initial={{ opacity: 0, y: 20 }}
       animate={{ opacity: 1, y: 0 }}
       whileHover={{ y: -6 }}
       transition={{ duration: 0.3 }}
-      className="bg-white dark:bg-Siora-mid border border-gray-300 dark:border-Siora-border rounded-2xl p-6 shadow-Siora-hover"
+      onClick={onClick}
+      className="bg-white dark:bg-Siora-mid border border-gray-300 dark:border-Siora-border rounded-2xl p-6 shadow-Siora-hover cursor-pointer"
     >
       <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-1">
         {creator.name}


### PR DESCRIPTION
## Summary
- tweak SavedCreatorCard so it can be clicked
- add ChatSidebar component for on-page messaging
- integrate chat sidebar on the brand inbox page

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm run build:brand` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685197103b28832c87e316b6eeadd166