### PR TITLE
Add mock performance metrics per creator

### DIFF
--- a/apps/brand/app/api/performance/[id]/route.ts
+++ b/apps/brand/app/api/performance/[id]/route.ts
@@ -1,4 +1,4 @@
-import data from '@/app/data/performanceData.json';
+import data from '@/app/data/performanceMetrics.json';
 
 export async function GET(
   _req: Request,

--- a/apps/brand/app/data/performanceData.json
+++ b/apps/brand/app/data/performanceData.json
@@ -1,5 +1,0 @@
-{
-  "1": {"followers": 120000, "engagementRate": 3.8, "avgViews": 5500, "growth": 0.04},
-  "2": {"followers": 45000, "engagementRate": 6.2, "avgViews": 15000, "growth": 0.02},
-  "3": {"followers": 82000, "engagementRate": 4.7, "avgViews": 9000, "growth": -0.01}
-}

--- a/apps/brand/app/data/performanceMetrics.json
+++ b/apps/brand/app/data/performanceMetrics.json
@@ -1,0 +1,29 @@
+{
+  "1": {
+    "avgReach": 5500,
+    "engagementRate": 3.8,
+    "followerGrowth": 4.0,
+    "topPosts": [
+      {"type": "Reel", "title": "Glow routine", "link": "https://example.com/post1", "stats": "8k views"},
+      {"type": "Story", "title": "Skincare Q&A", "link": "https://example.com/post2", "stats": "5k views"}
+    ]
+  },
+  "2": {
+    "avgReach": 15000,
+    "engagementRate": 6.2,
+    "followerGrowth": 2.0,
+    "topPosts": [
+      {"type": "Video", "title": "AI Gadgets Review", "link": "https://example.com/post3", "stats": "20k views"},
+      {"type": "Short", "title": "Crypto Basics", "link": "https://example.com/post4", "stats": "15k views"}
+    ]
+  },
+  "3": {
+    "avgReach": 9000,
+    "engagementRate": 4.7,
+    "followerGrowth": -1.0,
+    "topPosts": [
+      {"type": "Reel", "title": "Plant Shelf Tour", "link": "https://example.com/post5", "stats": "11k views"},
+      {"type": "Tutorial", "title": "Potting Basics", "link": "https://example.com/post6", "stats": "8k views"}
+    ]
+  }
+}

--- a/apps/brand/components/PerformanceTab.tsx
+++ b/apps/brand/components/PerformanceTab.tsx
@@ -5,11 +5,18 @@ type Props = {
   creatorId: string;
 };
 
+interface TopPost {
+  type: string;
+  title: string;
+  link: string;
+  stats: string;
+}
+
 interface PerfData {
-  followers: number;
+  avgReach: number;
   engagementRate: number;
-  avgViews: number;
-  growth: number;
+  followerGrowth: number;
+  topPosts: TopPost[];
 }
 
 export default function PerformanceTab({ creatorId }: Props) {
@@ -34,27 +41,38 @@ export default function PerformanceTab({ creatorId }: Props) {
     return <p className="text-sm text-zinc-400">Loading performance...</p>;
   }
 
-  const trendUp = data.growth >= 0;
-  const trendPercent = Math.round(Math.abs(data.growth * 100));
+  const trendUp = data.followerGrowth >= 0;
+  const trendPercent = Math.round(Math.abs(data.followerGrowth));
 
   return (
     <div className="mt-6 space-y-2 text-sm text-zinc-300">
       <div>
-        <strong>Followers:</strong> {data.followers.toLocaleString()}
+        <strong>Avg Reach:</strong> {data.avgReach.toLocaleString()}
       </div>
       <div>
         <strong>Engagement Rate:</strong> {data.engagementRate}%
       </div>
-      <div>
-        <strong>Avg Views:</strong> {data.avgViews.toLocaleString()}
-      </div>
       <div className="flex items-center gap-1">
-        <strong>Growth:</strong>
+        <strong>Follower Growth:</strong>
         <span className={trendUp ? "text-green-400" : "text-red-400"}>
           {trendUp ? "▲" : "▼"}
         </span>
         <span>{trendPercent}%</span>
       </div>
+      {data.topPosts && (
+        <div>
+          <strong>Top Posts:</strong>
+          <ul className="list-disc list-inside space-y-1 mt-1">
+            {data.topPosts.map((p) => (
+              <li key={p.link}>
+                <a href={p.link} target="_blank" rel="noreferrer" className="underline">
+                  {p.title}
+                </a>{" "}- {p.stats}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- refactor performance API to read new `performanceMetrics.json`
- extend `PerformanceTab` to display avg reach, follower growth and top posts
- mock performance metrics for three sample creators

## Testing
- `npx turbo run lint` *(fails: command not found / missing dependencies)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6851972775c8832cb956eb30579240c4