### PR TITLE
Add performance metrics section to creator view

### DIFF
--- a/apps/brand/app/creator/[id]/page.tsx
+++ b/apps/brand/app/creator/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { creators } from "@/app/data/creators";
 import { notFound } from "next/navigation";
+import PerformanceTab from "@/components/PerformanceTab";
 
 type Props = {
   params: {
@@ -54,6 +55,11 @@ export default function CreatorProfile({ params }: Props) {
             <p className="text-zinc-300">{creator.tone}</p>
           </div>
         )}
+
+        <div>
+          <h2 className="text-lg font-semibold mb-2">Performance</h2>
+          <PerformanceTab creatorId={creator.id} />
+        </div>
       </div>
     </main>
   );

--- a/apps/brand/app/data/performanceMetrics.json
+++ b/apps/brand/app/data/performanceMetrics.json
@@ -3,6 +3,7 @@
     "avgReach": 5500,
     "engagementRate": 3.8,
     "followerGrowth": 4.0,
+    "engagementBreakdown": {"likes": 60, "comments": 25, "shares": 15},
     "topPosts": [
       {"type": "Reel", "title": "Glow routine", "link": "https://example.com/post1", "stats": "8k views"},
       {"type": "Story", "title": "Skincare Q&A", "link": "https://example.com/post2", "stats": "5k views"}
@@ -12,6 +13,7 @@
     "avgReach": 15000,
     "engagementRate": 6.2,
     "followerGrowth": 2.0,
+    "engagementBreakdown": {"likes": 55, "comments": 30, "shares": 15},
     "topPosts": [
       {"type": "Video", "title": "AI Gadgets Review", "link": "https://example.com/post3", "stats": "20k views"},
       {"type": "Short", "title": "Crypto Basics", "link": "https://example.com/post4", "stats": "15k views"}
@@ -21,6 +23,7 @@
     "avgReach": 9000,
     "engagementRate": 4.7,
     "followerGrowth": -1.0,
+    "engagementBreakdown": {"likes": 50, "comments": 35, "shares": 15},
     "topPosts": [
       {"type": "Reel", "title": "Plant Shelf Tour", "link": "https://example.com/post5", "stats": "11k views"},
       {"type": "Tutorial", "title": "Potting Basics", "link": "https://example.com/post6", "stats": "8k views"}

--- a/apps/brand/components/PerformanceTab.tsx
+++ b/apps/brand/components/PerformanceTab.tsx
@@ -1,5 +1,15 @@
 "use client";
 import { useEffect, useState } from "react";
+import { Pie } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { FaChartLine, FaHeart, FaUsers } from "react-icons/fa";
+
+ChartJS.register(ArcElement, Tooltip, Legend);
 
 type Props = {
   creatorId: string;
@@ -17,6 +27,11 @@ interface PerfData {
   engagementRate: number;
   followerGrowth: number;
   topPosts: TopPost[];
+  engagementBreakdown: {
+    likes: number;
+    comments: number;
+    shares: number;
+  };
 }
 
 export default function PerformanceTab({ creatorId }: Props) {
@@ -44,35 +59,67 @@ export default function PerformanceTab({ creatorId }: Props) {
   const trendUp = data.followerGrowth >= 0;
   const trendPercent = Math.round(Math.abs(data.followerGrowth));
 
+  const chartData = {
+    labels: ["Likes", "Comments", "Shares"],
+    datasets: [
+      {
+        data: [
+          data.engagementBreakdown.likes,
+          data.engagementBreakdown.comments,
+          data.engagementBreakdown.shares,
+        ],
+        backgroundColor: ["#f472b6", "#60a5fa", "#facc15"],
+        borderWidth: 0,
+      },
+    ],
+  };
+
   return (
-    <div className="mt-6 space-y-2 text-sm text-zinc-300">
-      <div>
-        <strong>Avg Reach:</strong> {data.avgReach.toLocaleString()}
-      </div>
-      <div>
-        <strong>Engagement Rate:</strong> {data.engagementRate}%
-      </div>
-      <div className="flex items-center gap-1">
-        <strong>Follower Growth:</strong>
-        <span className={trendUp ? "text-green-400" : "text-red-400"}>
-          {trendUp ? "▲" : "▼"}
-        </span>
-        <span>{trendPercent}%</span>
+    <div className="mt-6 space-y-6 text-sm text-zinc-300">
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div className="flex items-center gap-2 p-4 bg-Siora-light rounded-lg border border-Siora-border">
+          <FaUsers className="text-Siora-accent" />
+          <div>
+            <div className="text-xs uppercase tracking-wide">Avg Reach</div>
+            <div className="text-base font-semibold">{data.avgReach.toLocaleString()}</div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 p-4 bg-Siora-light rounded-lg border border-Siora-border">
+          <FaHeart className="text-Siora-accent" />
+          <div>
+            <div className="text-xs uppercase tracking-wide">Engagement Rate</div>
+            <div className="text-base font-semibold">{data.engagementRate}%</div>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 p-4 bg-Siora-light rounded-lg border border-Siora-border">
+          <FaChartLine className="text-Siora-accent" />
+          <div>
+            <div className="text-xs uppercase tracking-wide">Follower Growth</div>
+            <div className={`text-base font-semibold ${trendUp ? "text-green-400" : "text-red-400"}`}>{trendUp ? "▲" : "▼"} {trendPercent}%</div>
+          </div>
+        </div>
       </div>
       {data.topPosts && (
         <div>
-          <strong>Top Posts:</strong>
-          <ul className="list-disc list-inside space-y-1 mt-1">
+          <h3 className="text-md font-semibold mb-2">Top Posts</h3>
+          <ul className="space-y-2">
             {data.topPosts.map((p) => (
-              <li key={p.link}>
+              <li key={p.link} className="p-3 bg-Siora-light rounded border border-Siora-border">
                 <a href={p.link} target="_blank" rel="noreferrer" className="underline">
                   {p.title}
-                </a>{" "}- {p.stats}
+                </a>
+                <span className="ml-2 text-zinc-400">- {p.stats}</span>
               </li>
             ))}
           </ul>
         </div>
       )}
+      <div>
+        <h3 className="text-md font-semibold mb-2">Engagement Breakdown</h3>
+        <div className="max-w-xs">
+          <Pie data={chartData} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/brand/package.json
+++ b/apps/brand/package.json
@@ -22,7 +22,10 @@
     "@prisma/client": "^6.9.0",
     "prisma": "^6.9.0",
     "shared-utils": "workspace:*",
-    "shared-ui": "workspace:*"
+    "shared-ui": "workspace:*",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.4.1",
+    "react-icons": "^4.11.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss7-compat": "^2.2.17",


### PR DESCRIPTION
## Summary
- add PerformanceTab component to creator page
- include engagement breakdown data for creators
- enhance PerformanceTab with icons and chart
- install charting & icon packages in brand package.json

## Testing
- `npm run lint -w apps/brand` *(fails: next not found)*
- `npm install` *(fails: Unsupported URL Type "workspace:")*

------
https://chatgpt.com/codex/tasks/task_e_6851c24d6bbc832c87e9a99133666f1e