### PR TITLE
Add creator performance section

### DIFF
--- a/apps/brand/app/creator/[id]/page.tsx
+++ b/apps/brand/app/creator/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { creators } from "@/app/data/creators";
 import { notFound } from "next/navigation";
+import PerformanceTab from "@/components/PerformanceTab";
 
 type Props = {
   params: {
@@ -54,6 +55,8 @@ export default function CreatorProfile({ params }: Props) {
             <p className="text-zinc-300">{creator.tone}</p>
           </div>
         )}
+
+        <PerformanceTab creatorId={creator.id} />
       </div>
     </main>
   );

--- a/apps/brand/app/data/creators.ts
+++ b/apps/brand/app/data/creators.ts
@@ -9,6 +9,11 @@ export type CreatorPerformance = {
   avgReach: number;
   engagementRate: number;
   followerGrowth: number;
+  engagementBreakdown: {
+    likes: number;
+    comments: number;
+    shares: number;
+  };
   topPosts: TopPost[];
 };
 
@@ -76,6 +81,7 @@ I'm Sophie — I share skincare rituals, cozy routines, and self-care tips to he
       avgReach: 5500,
       engagementRate: 3.8,
       followerGrowth: 4.0,
+      engagementBreakdown: { likes: 60, comments: 25, shares: 15 },
       topPosts: [
         { type: 'Reel', title: 'Glow routine', link: 'https://example.com/post1', stats: '8k views' },
         { type: 'Story', title: 'Skincare Q&A', link: 'https://example.com/post2', stats: '5k views' },
@@ -125,6 +131,7 @@ Tech explainer meets crypto nerd. My YouTube channel covers AI, gadgets, and dec
       avgReach: 15000,
       engagementRate: 6.2,
       followerGrowth: 2.0,
+      engagementBreakdown: { likes: 50, comments: 30, shares: 20 },
       topPosts: [
         { type: 'Video', title: 'AI Gadgets Review', link: 'https://example.com/post3', stats: '20k views' },
         { type: 'Short', title: 'Crypto Basics', link: 'https://example.com/post4', stats: '15k views' },
@@ -173,6 +180,7 @@ I teach aesthetic plant care, budget-friendly home decor, and cozy vibes — all
       avgReach: 9000,
       engagementRate: 4.7,
       followerGrowth: -1.0,
+      engagementBreakdown: { likes: 55, comments: 20, shares: 25 },
       topPosts: [
         { type: 'Reel', title: 'Plant Shelf Tour', link: 'https://example.com/post5', stats: '11k views' },
         { type: 'Tutorial', title: 'Potting Basics', link: 'https://example.com/post6', stats: '8k views' },

--- a/apps/brand/app/data/performanceMetrics.json
+++ b/apps/brand/app/data/performanceMetrics.json
@@ -3,6 +3,7 @@
     "avgReach": 5500,
     "engagementRate": 3.8,
     "followerGrowth": 4.0,
+    "engagementBreakdown": {"likes": 60, "comments": 25, "shares": 15},
     "topPosts": [
       {"type": "Reel", "title": "Glow routine", "link": "https://example.com/post1", "stats": "8k views"},
       {"type": "Story", "title": "Skincare Q&A", "link": "https://example.com/post2", "stats": "5k views"}
@@ -12,6 +13,7 @@
     "avgReach": 15000,
     "engagementRate": 6.2,
     "followerGrowth": 2.0,
+    "engagementBreakdown": {"likes": 50, "comments": 30, "shares": 20},
     "topPosts": [
       {"type": "Video", "title": "AI Gadgets Review", "link": "https://example.com/post3", "stats": "20k views"},
       {"type": "Short", "title": "Crypto Basics", "link": "https://example.com/post4", "stats": "15k views"}
@@ -21,6 +23,7 @@
     "avgReach": 9000,
     "engagementRate": 4.7,
     "followerGrowth": -1.0,
+    "engagementBreakdown": {"likes": 55, "comments": 20, "shares": 25},
     "topPosts": [
       {"type": "Reel", "title": "Plant Shelf Tour", "link": "https://example.com/post5", "stats": "11k views"},
       {"type": "Tutorial", "title": "Potting Basics", "link": "https://example.com/post6", "stats": "8k views"}

--- a/apps/brand/components/PerformanceTab.tsx
+++ b/apps/brand/components/PerformanceTab.tsx
@@ -16,6 +16,11 @@ interface PerfData {
   avgReach: number;
   engagementRate: number;
   followerGrowth: number;
+  engagementBreakdown: {
+    likes: number;
+    comments: number;
+    shares: number;
+  };
   topPosts: TopPost[];
 }
 
@@ -45,20 +50,26 @@ export default function PerformanceTab({ creatorId }: Props) {
   const trendPercent = Math.round(Math.abs(data.followerGrowth));
 
   return (
-    <div className="mt-6 space-y-2 text-sm text-zinc-300">
-      <div>
-        <strong>Avg Reach:</strong> {data.avgReach.toLocaleString()}
+    <div className="mt-8 space-y-6 text-sm text-zinc-300">
+      <h2 className="text-lg font-semibold">Performance</h2>
+      <div className="grid grid-cols-3 gap-4">
+        <div className="bg-Siora-mid border border-Siora-border rounded-lg p-3 text-center space-y-1">
+          <div className="text-xl">📊</div>
+          <div>Avg Reach</div>
+          <div className="font-semibold">{data.avgReach.toLocaleString()}</div>
+        </div>
+        <div className="bg-Siora-mid border border-Siora-border rounded-lg p-3 text-center space-y-1">
+          <div className="text-xl">💬</div>
+          <div>Engagement</div>
+          <div className="font-semibold">{data.engagementRate}%</div>
+        </div>
+        <div className="bg-Siora-mid border border-Siora-border rounded-lg p-3 text-center space-y-1">
+          <div className="text-xl">{trendUp ? '📈' : '📉'}</div>
+          <div>Growth</div>
+          <div className="font-semibold">{trendPercent}%</div>
+        </div>
       </div>
-      <div>
-        <strong>Engagement Rate:</strong> {data.engagementRate}%
-      </div>
-      <div className="flex items-center gap-1">
-        <strong>Follower Growth:</strong>
-        <span className={trendUp ? "text-green-400" : "text-red-400"}>
-          {trendUp ? "▲" : "▼"}
-        </span>
-        <span>{trendPercent}%</span>
-      </div>
+
       {data.topPosts && (
         <div>
           <strong>Top Posts:</strong>
@@ -67,12 +78,30 @@ export default function PerformanceTab({ creatorId }: Props) {
               <li key={p.link}>
                 <a href={p.link} target="_blank" rel="noreferrer" className="underline">
                   {p.title}
-                </a>{" "}- {p.stats}
+                </a>{' '}- {p.stats}
               </li>
             ))}
           </ul>
         </div>
       )}
+
+      <div>
+        <strong>Engagement Breakdown:</strong>
+        <div className="mt-2 space-y-2">
+          {Object.entries(data.engagementBreakdown).map(([k, v]) => (
+            <div key={k} className="flex items-center gap-2">
+              <span className="w-20 capitalize">{k}</span>
+              <div className="flex-1 bg-zinc-700 rounded h-2">
+                <div
+                  className="bg-Siora-accent h-2 rounded"
+                  style={{ width: `${v}%` }}
+                />
+              </div>
+              <span className="w-10 text-right">{v}%</span>
+            </div>
+          ))}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show performance analytics on creator pages
- capture metrics data with new `engagementBreakdown`
- display performance cards, top posts and breakdown chart

## Testing
- `npm run lint -w apps/brand` *(fails: next not found)*
- `npm run build -w apps/brand` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851c2bb5f74832cad739780a4630fce