### PR TITLE
Auto-fill creator profile settings from persona

### DIFF
--- a/apps/creator/app/page.tsx
+++ b/apps/creator/app/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { useState, useRef, useEffect } from 'react';
 import styles from './styles.module.css';
 import ReactMarkdown from "react-markdown";
+import { saveProfileSettings } from "@/lib/profileSettings";
 
 
 export default function Home() {
@@ -131,10 +132,16 @@ export default function Home() {
     try {
       localStorage.setItem("lastPersona", persona);
       setStoredPersona(persona);
+      saveProfileSettings({
+        bio: persona,
+        tone,
+        formats: favFormats.split(',').map(f => f.trim()).filter(Boolean),
+        collabTypes: dreamBrands.split(',').map(b => b.trim()).filter(Boolean)
+      });
     } catch (err) {
       console.error("Failed to persist persona", err);
     }
-  }, [persona]);
+  }, [persona, tone, favFormats, dreamBrands]);
 
   useEffect(() => {
     if (isLoading) {

--- a/apps/creator/app/persona/[id]/edit/page.tsx
+++ b/apps/creator/app/persona/[id]/edit/page.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { useState, useRef, useEffect } from 'react';
 import { useParams } from 'next/navigation';
 import ReactMarkdown from "react-markdown";
+import { saveProfileSettings } from "@/lib/profileSettings";
 import styles from '../../../styles.module.css';
 
 export default function EditPersonaPage() {
@@ -88,6 +89,12 @@ export default function EditPersonaPage() {
       } else {
         const data = await res.json();
         setPersona(data.result);
+        saveProfileSettings({
+          bio: data.result,
+          tone,
+          formats: favFormats.split(',').map(f => f.trim()).filter(Boolean),
+          collabTypes: dreamBrands.split(',').map(b => b.trim()).filter(Boolean)
+        });
       }
     } catch (error) {
       console.error(error);

--- a/apps/creator/app/settings/page.tsx
+++ b/apps/creator/app/settings/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Settings, { ExtendedPersona } from "@/components/Settings";
+import { loadProfileSettings, saveProfileSettings } from "@/lib/profileSettings";
+import { loadPersonasFromLocal } from "@/lib/localPersonas";
+
+export default function SettingsPage() {
+  const [profile, setProfile] = useState<ExtendedPersona | null>(null);
+
+  useEffect(() => {
+    const stored = loadProfileSettings();
+    if (stored) {
+      setProfile({
+        name: "My Persona",
+        personality: "",
+        interests: [],
+        summary: stored.bio,
+        vibe: stored.tone,
+        favFormats: stored.formats.join(','),
+        preferredCollabs: stored.collabTypes.join(',')
+      });
+    } else {
+      const local = loadPersonasFromLocal();
+      if (local.length > 0) {
+        const p = local[0].persona as ExtendedPersona;
+        setProfile({
+          ...p,
+          tagline: (p as any).tagline || '',
+          contentPreference: (p as any).contentPreference || '',
+          favFormats: (p as any).favFormats || '',
+          preferredCollabs: (p as any).preferredCollabs || ''
+        });
+      }
+    }
+  }, []);
+
+  const handleChange = (p: ExtendedPersona) => {
+    saveProfileSettings({
+      bio: p.summary,
+      tone: p.vibe ?? '',
+      formats: p.favFormats ? p.favFormats.split(',').map(f => f.trim()).filter(Boolean) : [],
+      collabTypes: p.preferredCollabs ? p.preferredCollabs.split(',').map(c => c.trim()).filter(Boolean) : []
+    });
+  };
+
+  if (!profile) {
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-background text-foreground p-6">
+        <p>No profile data found.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 max-w-2xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Profile Settings</h1>
+      <Settings persona={profile} onChange={handleChange} />
+    </main>
+  );
+}

--- a/apps/creator/components/Settings.tsx
+++ b/apps/creator/components/Settings.tsx
@@ -7,6 +7,7 @@ export interface ExtendedPersona extends FullPersona {
   tagline?: string
   contentPreference?: string
   favFormats?: string
+  preferredCollabs?: string
 }
 
 interface Props {
@@ -21,6 +22,7 @@ export default function Settings({ persona, onChange }: Props) {
   const [formats, setFormats] = useState<string[]>(
     persona.favFormats ? persona.favFormats.split(',').map((f) => f.trim()) : []
   )
+  const [collabs, setCollabs] = useState<string>(persona.preferredCollabs || '')
 
   useEffect(() => {
     const updated: ExtendedPersona = {
@@ -28,10 +30,11 @@ export default function Settings({ persona, onChange }: Props) {
       summary: bio,
       tagline,
       contentPreference: contentPref,
-      favFormats: formats.join(',')
+      favFormats: formats.join(','),
+      preferredCollabs: collabs
     }
     onChange?.(updated)
-  }, [tagline, bio, contentPref, formats, onChange, persona])
+  }, [tagline, bio, contentPref, formats, collabs, onChange, persona])
 
   const toggleFormat = (f: string) => {
     setFormats((prev) => (prev.includes(f) ? prev.filter((x) => x !== f) : [...prev, f]))
@@ -83,6 +86,15 @@ export default function Settings({ persona, onChange }: Props) {
           ))}
         </div>
       </div>
+      <div>
+        <label className="block text-sm font-medium mb-1">Preferred Collaborations</label>
+        <input
+          type="text"
+          value={collabs}
+          onChange={(e) => setCollabs(e.target.value)}
+          className="w-full p-2 rounded-md bg-background text-foreground border border-white/10"
+        />
+      </div>
       <div className="border border-white/10 rounded-lg p-4 bg-background">
         <h3 className="text-lg font-semibold">Preview</h3>
         <p className="mt-2 text-xl font-bold">{persona.name}</p>
@@ -95,6 +107,9 @@ export default function Settings({ persona, onChange }: Props) {
               <li key={f}>{f}</li>
             ))}
           </ul>
+        )}
+        {collabs && (
+          <p className="mt-2 text-sm text-foreground/80">Collabs: {collabs}</p>
         )}
       </div>
     </div>

--- a/apps/creator/lib/profileSettings.ts
+++ b/apps/creator/lib/profileSettings.ts
@@ -1,0 +1,28 @@
+export interface ProfileSettings {
+  bio: string
+  tone: string
+  formats: string[]
+  collabTypes: string[]
+}
+
+const STORAGE_KEY = 'profileSettings'
+
+export function saveProfileSettings(data: ProfileSettings) {
+  if (typeof window === 'undefined') return
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
+  } catch (err) {
+    console.error('Failed to save profile settings', err)
+  }
+}
+
+export function loadProfileSettings(): ProfileSettings | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored) return JSON.parse(stored) as ProfileSettings
+  } catch (err) {
+    console.error('Failed to load profile settings', err)
+  }
+  return null
+}

--- a/apps/creator/types/profileSettings.ts
+++ b/apps/creator/types/profileSettings.ts
@@ -1,0 +1,6 @@
+export type ProfileSettings = {
+  bio: string
+  tone: string
+  formats: string[]
+  collabTypes: string[]
+}


### PR DESCRIPTION
## Summary
- add profile settings lib to store user bio, tone, formats and collab types
- extend `Settings` component with preferred collaboration field
- update persona generator pages to save profile settings after generation
- add `/settings` page to edit these values

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm run build` *(fails: turbo not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68570bca9828832cb6aec3d56e48bbe7