### PR TITLE
Add lead magnet dashboard panel

### DIFF
--- a/apps/creator/app/dashboard/lead-magnet/page.tsx
+++ b/apps/creator/app/dashboard/lead-magnet/page.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import type { LeadMagnetIdea } from "@/types/leadMagnet";
+import {
+  loadLeadMagnetIdea,
+  saveLeadMagnetIdea,
+} from "@/lib/localLeadMagnet";
+
+export default function LeadMagnetDashboard() {
+  const [idea, setIdea] = useState<LeadMagnetIdea | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const stored = loadLeadMagnetIdea();
+    if (stored) setIdea(stored);
+  }, []);
+
+  const regenerate = async () => {
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch("/api/leadMagnet", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ niche: "marketing", audience: "creators" }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || "Request failed");
+      setIdea(data as LeadMagnetIdea);
+      saveLeadMagnetIdea(data as LeadMagnetIdea);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Something went wrong";
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const downloadPdf = () => {
+    alert("PDF download coming soon!");
+  };
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 space-y-6 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold">Lead Magnet</h1>
+      {idea ? (
+        <div className="space-y-2 border border-white/10 p-4 rounded-md">
+          <h2 className="text-lg font-semibold">{idea.title}</h2>
+          <p className="text-sm text-foreground/80">{idea.description}</p>
+          <p className="text-sm">Benefit: {idea.benefit}</p>
+          <p className="text-sm font-semibold">CTA: {idea.cta}</p>
+        </div>
+      ) : (
+        <p>No lead magnet idea generated yet.</p>
+      )}
+      {error && <p className="text-red-500">{error}</p>}
+      <div className="flex gap-4">
+        <button
+          type="button"
+          onClick={regenerate}
+          disabled={loading}
+          className="bg-indigo-600 hover:bg-indigo-500 transition-colors duration-200 text-white px-4 py-2 rounded-md disabled:opacity-50"
+        >
+          {loading ? "Generating..." : "Regenerate"}
+        </button>
+        <button
+          type="button"
+          onClick={downloadPdf}
+          className="bg-indigo-600 hover:bg-indigo-500 transition-colors duration-200 text-white px-4 py-2 rounded-md"
+        >
+          Download as PDF
+        </button>
+      </div>
+      <Link href="/lead-magnet" className="underline text-sm">
+        Generate new idea
+      </Link>
+    </main>
+  );
+}

--- a/apps/creator/app/dashboard/page.tsx
+++ b/apps/creator/app/dashboard/page.tsx
@@ -66,6 +66,9 @@ export default function DashboardPage() {
         <Link href="/performance" className="underline">
           Performance
         </Link>
+        <Link href="/dashboard/lead-magnet" className="underline">
+          Lead Magnet
+        </Link>
       </nav>
       <PerformanceMetrics />
       {items.length === 0 ? (

--- a/apps/creator/app/lead-magnet/page.tsx
+++ b/apps/creator/app/lead-magnet/page.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import type { LeadMagnetIdea } from "@/types/leadMagnet";
+import {
+  saveLeadMagnetIdea,
+  loadLeadMagnetIdea,
+} from "@/lib/localLeadMagnet";
 
 export default function LeadMagnetPage() {
   const [niche, setNiche] = useState("");
@@ -9,6 +13,11 @@ export default function LeadMagnetPage() {
   const [idea, setIdea] = useState<LeadMagnetIdea | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+
+  useEffect(() => {
+    const stored = loadLeadMagnetIdea();
+    if (stored) setIdea(stored);
+  }, []);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -25,6 +34,7 @@ export default function LeadMagnetPage() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Request failed");
       setIdea(data as LeadMagnetIdea);
+      saveLeadMagnetIdea(data as LeadMagnetIdea);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
     } finally {

--- a/apps/creator/app/tools/page.tsx
+++ b/apps/creator/app/tools/page.tsx
@@ -2,6 +2,10 @@
 
 import { useState, useEffect } from "react";
 import type { LeadMagnetIdea } from "@/types/leadMagnet";
+import {
+  saveLeadMagnetIdea,
+  loadLeadMagnetIdea,
+} from "@/lib/localLeadMagnet";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 
@@ -49,6 +53,11 @@ export default function ToolsPage() {
   const [magnetIdea, setMagnetIdea] = useState<LeadMagnetIdea | null>(null);
   const [magnetLoading, setMagnetLoading] = useState(false);
   const [magnetError, setMagnetError] = useState("");
+
+  useEffect(() => {
+    const stored = loadLeadMagnetIdea();
+    if (stored) setMagnetIdea(stored);
+  }, []);
 
   const runHookGen = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -131,6 +140,7 @@ export default function ToolsPage() {
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Request failed");
       setMagnetIdea(data as LeadMagnetIdea);
+      saveLeadMagnetIdea(data as LeadMagnetIdea);
     } catch (err) {
       setMagnetError(err instanceof Error ? err.message : "Something went wrong");
     } finally {

--- a/apps/creator/lib/localLeadMagnet.ts
+++ b/apps/creator/lib/localLeadMagnet.ts
@@ -1,0 +1,23 @@
+export type { LeadMagnetIdea } from "@/types/leadMagnet";
+
+const STORAGE_KEY = "latestLeadMagnetIdea";
+
+export function saveLeadMagnetIdea(idea: import("@/types/leadMagnet").LeadMagnetIdea) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(idea));
+  } catch (err) {
+    console.error("Failed to save lead magnet idea", err);
+  }
+}
+
+export function loadLeadMagnetIdea(): import("@/types/leadMagnet").LeadMagnetIdea | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) return JSON.parse(stored) as import("@/types/leadMagnet").LeadMagnetIdea;
+  } catch (err) {
+    console.error("Failed to load lead magnet idea", err);
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- persist lead magnet ideas locally
- show the latest saved idea on a new Lead Magnet dashboard page
- let users regenerate and download as PDF (placeholder)
- link Lead Magnet tab from main dashboard

## Testing
- `npm run lint` *(fails: `turbo` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570f89d7ec832c82f8ad85fb92fcf5