### PR TITLE
Style lead magnet preview

### DIFF
--- a/apps/creator/app/dashboard/lead-magnet/page.tsx
+++ b/apps/creator/app/dashboard/lead-magnet/page.tsx
@@ -8,6 +8,23 @@ import {
   saveLeadMagnetIdea,
 } from "@/lib/localLeadMagnet";
 
+function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className={className}
+    >
+      <path
+        fillRule="evenodd"
+        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.707a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 10-1.414 1.414L9 13.414l4.707-4.707z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
 export default function LeadMagnetDashboard() {
   const [idea, setIdea] = useState<LeadMagnetIdea | null>(null);
   const [loading, setLoading] = useState(false);
@@ -47,11 +64,22 @@ export default function LeadMagnetDashboard() {
     <main className="min-h-screen bg-background text-foreground p-6 space-y-6 max-w-xl mx-auto">
       <h1 className="text-2xl font-bold">Lead Magnet</h1>
       {idea ? (
-        <div className="space-y-2 border border-white/10 p-4 rounded-md">
-          <h2 className="text-lg font-semibold">{idea.title}</h2>
-          <p className="text-sm text-foreground/80">{idea.description}</p>
-          <p className="text-sm">Benefit: {idea.benefit}</p>
-          <p className="text-sm font-semibold">CTA: {idea.cta}</p>
+        <div className="space-y-4 border border-white/10 p-6 rounded-md bg-background">
+          <h2 className="text-xl font-bold">{idea.title}</h2>
+          <ul className="space-y-2">
+            <li className="flex items-start gap-2">
+              <CheckIcon className="w-4 h-4 text-indigo-600 dark:text-indigo-400 mt-0.5" />
+              <span className="text-sm text-foreground/80">{idea.description}</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckIcon className="w-4 h-4 text-indigo-600 dark:text-indigo-400 mt-0.5" />
+              <span className="text-sm text-foreground/80">Benefit: {idea.benefit}</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckIcon className="w-4 h-4 text-indigo-600 dark:text-indigo-400 mt-0.5" />
+              <span className="text-sm font-semibold">CTA: {idea.cta}</span>
+            </li>
+          </ul>
         </div>
       ) : (
         <p>No lead magnet idea generated yet.</p>

--- a/apps/creator/app/lead-magnet/page.tsx
+++ b/apps/creator/app/lead-magnet/page.tsx
@@ -7,6 +7,23 @@ import {
   loadLeadMagnetIdea,
 } from "@/lib/localLeadMagnet";
 
+function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className={className}
+    >
+      <path
+        fillRule="evenodd"
+        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.707a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 10-1.414 1.414L9 13.414l4.707-4.707z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
 export default function LeadMagnetPage() {
   const [niche, setNiche] = useState("");
   const [audience, setAudience] = useState("");
@@ -76,11 +93,22 @@ export default function LeadMagnetPage() {
       </form>
       {error && <p className="text-red-500">{error}</p>}
       {idea && (
-        <div className="space-y-2 border border-white/10 p-4 rounded-md">
-          <h2 className="text-lg font-semibold">{idea.title}</h2>
-          <p className="text-sm text-foreground/80">{idea.description}</p>
-          <p className="text-sm">Benefit: {idea.benefit}</p>
-          <p className="text-sm font-semibold">CTA: {idea.cta}</p>
+        <div className="space-y-4 border border-white/10 p-6 rounded-md bg-background">
+          <h2 className="text-xl font-bold">{idea.title}</h2>
+          <ul className="space-y-2">
+            <li className="flex items-start gap-2">
+              <CheckIcon className="w-4 h-4 text-indigo-600 dark:text-indigo-400 mt-0.5" />
+              <span className="text-sm text-foreground/80">{idea.description}</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckIcon className="w-4 h-4 text-indigo-600 dark:text-indigo-400 mt-0.5" />
+              <span className="text-sm text-foreground/80">Benefit: {idea.benefit}</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckIcon className="w-4 h-4 text-indigo-600 dark:text-indigo-400 mt-0.5" />
+              <span className="text-sm font-semibold">CTA: {idea.cta}</span>
+            </li>
+          </ul>
         </div>
       )}
     </main>

--- a/apps/creator/app/tools/page.tsx
+++ b/apps/creator/app/tools/page.tsx
@@ -6,6 +6,23 @@ import {
   saveLeadMagnetIdea,
   loadLeadMagnetIdea,
 } from "@/lib/localLeadMagnet";
+
+function CheckIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      className={className}
+    >
+      <path
+        fillRule="evenodd"
+        d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.707a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 10-1.414 1.414L9 13.414l4.707-4.707z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 
@@ -249,11 +266,22 @@ export default function ToolsPage() {
       </button>
       {magnetError && <p className="text-red-500 text-sm">{magnetError}</p>}
       {magnetIdea && (
-        <div className="text-sm text-zinc-300 border-t border-white/10 pt-2 space-y-1">
-          <p className="font-semibold">{magnetIdea.title}</p>
-          <p>{magnetIdea.description}</p>
-          <p>Benefit: {magnetIdea.benefit}</p>
-          <p className="font-semibold">CTA: {magnetIdea.cta}</p>
+        <div className="text-sm text-zinc-300 border-t border-white/10 pt-2 space-y-2">
+          <p className="font-semibold text-base text-foreground">{magnetIdea.title}</p>
+          <ul className="space-y-1">
+            <li className="flex items-start gap-2">
+              <CheckIcon className="w-3 h-3 text-indigo-600 dark:text-indigo-400 mt-0.5" />
+              <span className="text-foreground/80">{magnetIdea.description}</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckIcon className="w-3 h-3 text-indigo-600 dark:text-indigo-400 mt-0.5" />
+              <span className="text-foreground/80">Benefit: {magnetIdea.benefit}</span>
+            </li>
+            <li className="flex items-start gap-2">
+              <CheckIcon className="w-3 h-3 text-indigo-600 dark:text-indigo-400 mt-0.5" />
+              <span className="font-semibold">CTA: {magnetIdea.cta}</span>
+            </li>
+          </ul>
         </div>
       )}
     </form>


### PR DESCRIPTION
## Summary
- modernize the lead magnet preview UI
- add new CheckIcon svg and dark-mode aware styling

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685710c35f0c832ca54e039bc71b444a