### PR TITLE
Add creator chat page for brand

### DIFF
--- a/apps/brand/app/messages/[creatorId]/page.tsx
+++ b/apps/brand/app/messages/[creatorId]/page.tsx
@@ -5,8 +5,12 @@ import { ChatPanel, ChatMessage } from "shared-ui";
 
 type Message = ChatMessage & { creatorId: string; campaign?: string };
 
-export default function ChatPage({ params }: { params: { id: string } }) {
-  const creator = creators.find((c) => c.id === params.id);
+export default function ChatPage({
+  params,
+}: {
+  params: { creatorId: string };
+}) {
+  const creator = creators.find((c) => c.id === params.creatorId);
   const [messages, setMessages] = useState<Message[]>([]);
   const [campaign, setCampaign] = useState("");
   const [sending, setSending] = useState(false);
@@ -14,7 +18,7 @@ export default function ChatPage({ params }: { params: { id: string } }) {
   useEffect(() => {
     async function load() {
       try {
-        const res = await fetch(`/api/messages?creatorId=${params.id}`);
+        const res = await fetch(`/api/messages?creatorId=${params.creatorId}`);
         if (res.ok) {
           const data = await res.json();
           setMessages(data.messages);
@@ -24,17 +28,22 @@ export default function ChatPage({ params }: { params: { id: string } }) {
       }
     }
     load();
-  }, [params.id]);
+  }, [params.creatorId]);
 
   const send = async (text: string) => {
     if (!text.trim()) return;
     setSending(true);
     try {
-      const res = await fetch('/api/messages', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ creatorId: params.id, sender: 'brand', text, campaign }),
-      });
+        const res = await fetch("/api/messages", {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            creatorId: params.creatorId,
+            sender: "brand",
+            text,
+            campaign,
+          }),
+        });
       if (res.ok) {
         const data = await res.json();
         setMessages((prev) => [...prev, data.message]);

--- a/packages/shared-ui/src/ChatPanel.tsx
+++ b/packages/shared-ui/src/ChatPanel.tsx
@@ -32,11 +32,22 @@ export function ChatPanel({ messages, onSend, sending, currentUser }: ChatPanelP
 
   return (
     <div className="flex flex-col h-96">
-      <div className="flex-1 overflow-y-auto border border-Siora-border rounded-lg p-4 bg-Siora-mid text-white mb-2">
+      <div className="flex-1 overflow-y-auto border border-Siora-border rounded-xl p-4 bg-Siora-mid text-white mb-2 space-y-3">
         {messages.map((m) => (
-          <div key={m.id} className={`mb-3 ${m.sender === currentUser ? 'text-right' : 'text-left'}`}>\
-            <div className="text-xs text-zinc-400 mb-1">{new Date(m.timestamp).toLocaleString()}</div>
-            <div className={`inline-block px-3 py-1 rounded ${m.sender === currentUser ? 'bg-Siora-accent' : 'bg-gray-700'}`}>{m.text}</div>
+          <div
+            key={m.id}
+            className={`flex ${m.sender === currentUser ? 'justify-end' : 'justify-start'}`}
+          >
+            <div>
+              <div className="text-xs text-zinc-400 mb-1">
+                {new Date(m.timestamp).toLocaleString()}
+              </div>
+              <div
+                className={`inline-block px-4 py-2 rounded-2xl border border-Siora-border ${m.sender === currentUser ? 'bg-Siora-accent' : 'bg-gray-700'}`}
+              >
+                {m.text}
+              </div>
+            </div>
           </div>
         ))}
         <div ref={bottomRef} />


### PR DESCRIPTION
## Summary
- rename message route to `[creatorId]`
- update dynamic page to use `creatorId` param
- refine `ChatPanel` with softer modern styling

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685710d902f4832c9d99bb4b19a32dab