### PR TITLE
Add tone selection for caption rewrite

### DIFF
--- a/apps/creator/app/api/rewriteCaption/route.ts
+++ b/apps/creator/app/api/rewriteCaption/route.ts
@@ -1,6 +1,6 @@
 export async function POST(req: Request) {
   try {
-    const { caption } = await req.json();
+    const { caption, tone } = await req.json();
     if (!caption || typeof caption !== 'string') {
       return new Response(
         JSON.stringify({ error: 'Provide a caption string.' }),
@@ -8,11 +8,17 @@ export async function POST(req: Request) {
       );
     }
 
+    const allowedTones = ['confident', 'playful', 'professional', 'witty'];
+    const toneLower =
+      typeof tone === 'string' && allowedTones.includes(tone.toLowerCase())
+        ? tone.toLowerCase()
+        : 'confident';
+
     const messages = [
       {
         role: 'system',
         content: [
-          'You help rewrite social media captions in a catchy, friendly tone.',
+          `You help rewrite social media captions in a ${toneLower} tone.`,
           'Return ONLY JSON in the form { "caption": string }.'
         ].join('\n')
       },

--- a/apps/creator/app/tools/page.tsx
+++ b/apps/creator/app/tools/page.tsx
@@ -57,6 +57,8 @@ export default function ToolsPage() {
   const [captionResult, setCaptionResult] = useState("");
   const [rewriteLoading, setRewriteLoading] = useState(false);
   const [rewriteError, setRewriteError] = useState("");
+  const toneOptions = ["Confident", "Playful", "Professional", "Witty"];
+  const [rewriteTone, setRewriteTone] = useState(toneOptions[0]);
 
   // Content Ideas state
   const [ideaTopic, setIdeaTopic] = useState("");
@@ -108,7 +110,7 @@ export default function ToolsPage() {
       const res = await fetch("/api/rewriteCaption", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ caption: captionInput }),
+        body: JSON.stringify({ caption: captionInput, tone: rewriteTone }),
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || "Request failed");
@@ -200,6 +202,20 @@ export default function ToolsPage() {
         onChange={(e) => setCaptionInput(e.target.value)}
         placeholder="Original caption"
       />
+      <div>
+        <label className="block text-sm font-semibold mb-1">Tone</label>
+        <select
+          className="w-full p-2 rounded-md bg-zinc-800 text-white"
+          value={rewriteTone}
+          onChange={(e) => setRewriteTone(e.target.value)}
+        >
+          {toneOptions.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </div>
       <button
         type="submit"
         className="w-full bg-indigo-600 hover:bg-indigo-500 text-white py-2 rounded-md disabled:opacity-50"


### PR DESCRIPTION
## Summary
- enable specifying tone when rewriting captions
- support `Confident`, `Playful`, `Professional`, and `Witty` in a new dropdown
- forward selected tone to the caption rewrite API and use it in the OpenAI prompt

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857130310d4832c86370097af21a576