### PR TITLE
Add evaluation checklist feature

### DIFF
--- a/apps/brand/app/api/generate-checklist/pdf.css
+++ b/apps/brand/app/api/generate-checklist/pdf.css
@@ -1,0 +1,20 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #fafafa;
+  color: #333;
+  line-height: 1.6;
+  padding: 20px;
+}
+h1, h2, h3, h4, h5 {
+  font-weight: bold;
+  margin-top: 1.2em;
+}
+pre {
+  background: #f0f0f0;
+  padding: 10px;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+code {
+  font-family: "Courier New", monospace;
+}

--- a/apps/brand/app/api/generate-checklist/route.ts
+++ b/apps/brand/app/api/generate-checklist/route.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server'
+import markdownpdf from 'markdown-pdf'
+import path from 'path'
+
+interface ChecklistRequest {
+  creatorName: string
+  format?: 'markdown' | 'pdf'
+}
+
+export async function POST(req: Request) {
+  try {
+    const { creatorName, format } = (await req.json()) as Partial<ChecklistRequest>
+
+    if (!creatorName) {
+      return NextResponse.json({ error: 'creatorName required' }, { status: 400 })
+    }
+
+    const items = [
+      `Review ${creatorName}'s engagement metrics`,
+      'Check audience demographics for brand fit',
+      'Look at previous brand collaborations',
+      'Assess content quality and consistency',
+    ]
+    const markdown = `# Evaluation Checklist for ${creatorName}\n\n` + items
+      .map((i, idx) => `${idx + 1}. ${i}`)
+      .join('\n')
+
+    if (format === 'pdf') {
+      const cssPath = path.join(
+        process.cwd(),
+        'apps',
+        'brand',
+        'app',
+        'api',
+        'generate-checklist',
+        'pdf.css',
+      )
+      const buffer: Buffer = await new Promise((resolve, reject) => {
+        markdownpdf({ cssPath })
+          .from.string(markdown)
+          .to.buffer((err, buff) => {
+            if (err) reject(err)
+            else resolve(buff)
+          })
+      })
+      return new NextResponse(buffer, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/pdf',
+          'Content-Disposition': 'attachment; filename="checklist.pdf"',
+        },
+      })
+    }
+
+    return NextResponse.json({ markdown })
+  } catch (err) {
+    console.error('generate checklist error', err)
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+}

--- a/apps/brand/app/creator/[id]/profile.tsx
+++ b/apps/brand/app/creator/[id]/profile.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { useState } from "react";
 import PerformanceTab from "@/components/PerformanceTab";
 import ContractModal from "@/components/ContractModal";
+import EvaluationChecklistModal from "@/components/EvaluationChecklistModal";
 
 type Props = {
   params: {
@@ -15,6 +16,7 @@ export default function CreatorProfile({ params }: Props) {
   if (!creator) return notFound();
 
   const [contractOpen, setContractOpen] = useState(false);
+  const [checklistOpen, setChecklistOpen] = useState(false);
 
   return (
     <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
@@ -68,11 +70,23 @@ export default function CreatorProfile({ params }: Props) {
           >
             Generate Contract
           </button>
+          <button
+            onClick={() => setChecklistOpen(true)}
+            className="ml-4 mt-4 px-3 py-1 text-sm rounded bg-Siora-accent text-white"
+          >
+            Generate Evaluation Checklist
+          </button>
         </div>
       </div>
       <ContractModal
         open={contractOpen}
         onClose={() => setContractOpen(false)}
+        creatorName={creator.name}
+      />
+      <EvaluationChecklistModal
+        open={checklistOpen}
+        onClose={() => setChecklistOpen(false)}
+        creatorId={creator.id.toString()}
         creatorName={creator.name}
       />
     </main>

--- a/apps/brand/components/CreatorCard.tsx
+++ b/apps/brand/components/CreatorCard.tsx
@@ -10,6 +10,7 @@ import { getCreatorBadges } from "shared-utils";
 import { FaEnvelope } from "react-icons/fa";
 
 import { ReactNode } from "react";
+import EvaluationChecklistModal from "./EvaluationChecklistModal";
 
 type Props = {
   creator: Creator;
@@ -19,6 +20,7 @@ type Props = {
 };
 export default function CreatorCard({ creator, onShortlist, shortlisted, children }: Props) {
   const [loading, setLoading] = useState(false);
+  const [checklistOpen, setChecklistOpen] = useState(false);
   const badges = getCreatorBadges({
     verified: creator.verified,
     completedCollabs: creator.completedCollabs,
@@ -96,6 +98,12 @@ export default function CreatorCard({ creator, onShortlist, shortlisted, childre
       >
         {loading ? 'Contacting...' : 'Contact'}
       </button>
+      <button
+        onClick={() => setChecklistOpen(true)}
+        className="ml-4 text-sm mt-4 text-Siora-accent underline"
+      >
+        Generate Evaluation Checklist
+      </button>
       {onShortlist && (
         <button
           onClick={() => onShortlist(creator.id)}
@@ -105,6 +113,12 @@ export default function CreatorCard({ creator, onShortlist, shortlisted, childre
         </button>
       )}
       {children}
+      <EvaluationChecklistModal
+        open={checklistOpen}
+        onClose={() => setChecklistOpen(false)}
+        creatorId={creator.id}
+        creatorName={creator.name}
+      />
     </motion.div>
   );
 }

--- a/apps/brand/components/EvaluationChecklistModal.tsx
+++ b/apps/brand/components/EvaluationChecklistModal.tsx
@@ -1,0 +1,110 @@
+"use client";
+import { useState } from "react";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  creatorId: string;
+  creatorName: string;
+}
+
+export default function EvaluationChecklistModal({
+  open,
+  onClose,
+  creatorId,
+  creatorName,
+}: Props) {
+  const [loading, setLoading] = useState(false);
+  const [markdown, setMarkdown] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const generate = async () => {
+    setLoading(true);
+    setMarkdown(null);
+    try {
+      const res = await fetch("/api/generate-checklist", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ creatorName }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setMarkdown(data.markdown);
+      } else {
+        alert("Failed to generate checklist");
+      }
+    } catch {
+      alert("Server error");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const save = () => {
+    if (!markdown) return;
+    try {
+      const raw = localStorage.getItem("savedChecklists") || "[]";
+      const list = JSON.parse(raw) as any[];
+      list.unshift({ creatorId, creatorName, markdown, timestamp: new Date().toISOString() });
+      localStorage.setItem("savedChecklists", JSON.stringify(list));
+      alert("Checklist saved");
+    } catch (err) {
+      console.error("save checklist", err);
+    }
+  };
+
+  const exportPdf = async () => {
+    if (!markdown) return;
+    const res = await fetch("/api/generate-checklist", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ creatorName, format: "pdf" }),
+    });
+    if (!res.ok) {
+      alert("Failed to generate PDF");
+      return;
+    }
+    const blob = await res.blob();
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = "checklist.pdf";
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-Siora-mid border border-Siora-border rounded-xl p-6 w-96 space-y-4 shadow-Siora-hover">
+        <h2 className="text-xl font-semibold">Evaluation Checklist for {creatorName}</h2>
+        {markdown && (
+          <pre className="whitespace-pre-wrap text-sm border border-Siora-border p-2 rounded bg-Siora-light text-white">
+            {markdown}
+          </pre>
+        )}
+        <div className="flex justify-end gap-2">
+          {!markdown ? (
+            <button onClick={generate} disabled={loading} className="px-3 py-1 text-sm rounded bg-Siora-accent text-white disabled:opacity-50">
+              {loading ? "Generating..." : "Generate"}
+            </button>
+          ) : (
+            <>
+              <button onClick={save} className="px-3 py-1 text-sm rounded bg-Siora-accent text-white">
+                Save for Later
+              </button>
+              <button onClick={exportPdf} className="px-3 py-1 text-sm rounded bg-Siora-accent text-white">
+                Export as PDF
+              </button>
+            </>
+          )}
+          <button onClick={onClose} className="px-3 py-1 text-sm rounded border border-Siora-border text-white">
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/api/generate-checklist` route with optional PDF output
- provide modal component to display checklist
- expose button on creator cards to open the modal
- add same button on creator profile pages

## Testing
- `npm install` *(fails: Unsupported URL Type "workspace:" )*
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857131d701c832c809b14f8a6abd7e0