### PR TITLE
Add campaign checklist generator

### DIFF
--- a/apps/brand/app/api/checklist/route.ts
+++ b/apps/brand/app/api/checklist/route.ts
@@ -1,0 +1,56 @@
+export async function POST(req: Request) {
+  try {
+    const { description } = await req.json();
+    if (!description || typeof description !== 'string') {
+      return new Response(
+        JSON.stringify({ error: 'Campaign description required' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const messages = [
+      {
+        role: 'system',
+        content: [
+          'You create short influencer marketing checklists for brands.',
+          'Return 5-7 concise bullet items as JSON array of strings.',
+          'Use the campaign description as context.'
+        ].join('\n')
+      },
+      { role: 'user', content: description }
+    ];
+
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.7 })
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return new Response(
+        JSON.stringify({ error: 'OpenAI error', details: errorText }),
+        { status: response.status, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const data = await response.json();
+    const content = data.choices?.[0]?.message?.content ?? '[]';
+    const checklist = JSON.parse(content);
+
+    return new Response(JSON.stringify({ checklist }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    console.error('Unexpected error:', error);
+    return new Response(
+      JSON.stringify({ error: 'Unexpected error', details: message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/apps/brand/app/checklist/page.tsx
+++ b/apps/brand/app/checklist/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { useState } from "react";
+
+export default function ChecklistPage() {
+  const [description, setDescription] = useState("");
+  const [items, setItems] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const generate = async () => {
+    if (!description.trim()) return;
+    setLoading(true);
+    try {
+      const res = await fetch("/api/checklist", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ description })
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setItems(Array.isArray(data.checklist) ? data.checklist : []);
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
+      <div className="max-w-xl mx-auto space-y-4">
+        <h1 className="text-3xl font-bold">Campaign Checklist</h1>
+        <textarea
+          rows={2}
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder="Describe your campaign in 1–2 lines"
+          className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border focus:outline-none"
+        />
+        <button
+          onClick={generate}
+          disabled={loading}
+          className="px-4 py-2 bg-Siora-accent rounded text-white disabled:opacity-50"
+        >
+          {loading ? "Generating..." : "Generate Checklist"}
+        </button>
+        {items.length > 0 && (
+          <ul className="list-disc pl-5 space-y-1">
+            {items.map((item, idx) => (
+              <li key={idx}>{item}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/api/checklist` route to create a short campaign checklist via OpenAI
- add Checklist page with description input

## Testing
- `npx -y turbo run lint` *(fails: `next lint` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571324f5f8832c8f120cd995cf8139