### PR TITLE
Add shortlist management to brand dashboard

### DIFF
--- a/apps/brand/app/shortlist/page.tsx
+++ b/apps/brand/app/shortlist/page.tsx
@@ -1,19 +1,19 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import creators from "@/app/data/mock_creators_200.json";
-import CreatorCard from "@/components/CreatorCard";
+import ShortlistItem from "@/components/ShortlistItem";
 import { useBrandUser } from "@/lib/brandUser";
 import { useShortlist } from "@/lib/shortlist";
-import Link from "next/link";
 import { useCreatorMeta } from "@/lib/creatorMeta";
 
 export default function ShortlistPage() {
   const { user } = useBrandUser();
   const router = useRouter();
   const { ids, toggle } = useShortlist(user?.email ?? null);
-  const { status: collabStatus } = useCreatorMeta(user?.email ?? null);
+  const { notes } = useCreatorMeta(user?.email ?? null);
+  const [compare, setCompare] = useState(false);
 
   useEffect(() => {
     if (!user) router.replace("/signin");
@@ -57,30 +57,41 @@ export default function ShortlistPage() {
   return (
     <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
       <div className="max-w-7xl mx-auto space-y-8">
-        <div className="flex items-center justify-between">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
           <h1 className="text-4xl font-extrabold tracking-tight">My Shortlist</h1>
-          {saved.length > 0 && (
-            <button
-              type="button"
-              onClick={exportPdf}
-              className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-500"
-            >
-              Export PDF
-            </button>
-          )}
+          <div className="flex items-center gap-4">
+            {saved.length > 0 && (
+              <button
+                type="button"
+                onClick={exportPdf}
+                className="px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-500"
+              >
+                Export PDF
+              </button>
+            )}
+            <label className="flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                checked={compare}
+                onChange={(e) => setCompare(e.target.checked)}
+              />
+              Compare Mode
+            </label>
+          </div>
         </div>
         {saved.length === 0 ? (
           <p className="text-center text-zinc-400 mt-10">No creators saved.</p>
         ) : (
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div
+            className={`grid gap-6 ${compare ? "md:grid-cols-2" : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3"}`}
+          >
             {saved.map((c) => (
-              <CreatorCard key={c.id} creator={c} onShortlist={toggle} shortlisted={true}>
-                <div className="mt-2 flex flex-wrap items-center gap-2 text-sm">
-                  <Link href={`/creator/${c.id}/profile`} className="text-Siora-accent underline">Profile</Link>
-                  <Link href={`/creator/${c.id}/notes`} className="text-Siora-accent underline">Notes</Link>
-                  <span className="text-zinc-400 ml-auto">Status: {collabStatus[c.id] ?? "not_contacted"}</span>
-                </div>
-              </CreatorCard>
+              <ShortlistItem
+                key={c.id}
+                creator={c as any}
+                note={notes[c.id]}
+                onDelete={() => toggle(c.id)}
+              />
             ))}
           </div>
         )}

--- a/apps/brand/components/ShortlistItem.tsx
+++ b/apps/brand/components/ShortlistItem.tsx
@@ -1,0 +1,42 @@
+"use client";
+import { FaTrash } from "react-icons/fa";
+import type { Creator } from "@/app/data/creators";
+
+interface Props {
+  creator: Creator;
+  note?: string;
+  onDelete?: () => void;
+}
+
+export default function ShortlistItem({ creator, note, onDelete }: Props) {
+  const imgSrc = (creator as any).image || "https://placehold.co/80x80";
+  return (
+    <div className="flex gap-4 p-4 bg-white dark:bg-Siora-mid border border-gray-300 dark:border-Siora-border rounded-2xl shadow-Siora-hover">
+      <img src={imgSrc} alt={creator.name} className="w-20 h-20 rounded object-cover" />
+      <div className="flex-1">
+        <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+          {creator.name}
+        </h3>
+        {creator.tags && (
+          <div className="flex flex-wrap gap-1 mt-1">
+            {creator.tags.map((t) => (
+              <span key={t} className="bg-gray-100 dark:bg-Siora-light text-gray-700 dark:text-zinc-300 rounded px-2 py-1 text-xs">
+                {t}
+              </span>
+            ))}
+          </div>
+        )}
+        {note && (
+          <p className="text-sm text-gray-700 dark:text-zinc-300 mt-2 line-clamp-3">
+            {note}
+          </p>
+        )}
+      </div>
+      {onDelete && (
+        <button onClick={onDelete} className="text-red-500 hover:text-red-700 self-start">
+          <FaTrash />
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ShortlistItem` component with image, tags, note and delete
- enhance shortlist page with compare toggle and new card layout

## Testing
- `npm run lint -w apps/brand` *(fails: next not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685719756534832c9a1c33ddc56fdd81