### PR TITLE
Add in-dashboard contract generator

### DIFF
--- a/apps/brand/app/api/contract/generate/route.ts
+++ b/apps/brand/app/api/contract/generate/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server'
+
+interface ContractRequest {
+  brandName?: string
+  creatorName: string
+  deliverables: string
+  payment: string
+  startDate?: string
+  endDate?: string
+}
+
+export async function POST(req: Request) {
+  try {
+    const {
+      brandName = 'Demo Brand',
+      creatorName,
+      deliverables,
+      payment,
+      startDate,
+      endDate,
+    } = (await req.json()) as Partial<ContractRequest>
+
+    if (!creatorName || !deliverables || !payment) {
+      return NextResponse.json(
+        { error: 'Missing required fields' },
+        { status: 400 }
+      )
+    }
+
+    const lines = [
+      `Contract between ${brandName} and ${creatorName}`,
+      '',
+      'Deliverables:',
+      deliverables,
+      '',
+      'Payment Terms:',
+      payment,
+    ]
+    if (startDate || endDate) {
+      lines.push('', 'Timeline:')
+      if (startDate) lines.push(`Start: ${startDate}`)
+      if (endDate) lines.push(`End: ${endDate}`)
+    }
+    lines.push('', 'Both parties agree to these terms.')
+
+    return NextResponse.json({ contract: lines.join('\n') })
+  } catch (err) {
+    console.error('contract generate error', err)
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+}

--- a/apps/brand/components/ContractModal.tsx
+++ b/apps/brand/components/ContractModal.tsx
@@ -12,32 +12,30 @@ export default function ContractModal({ open, onClose, creatorName }: Props) {
   const [endDate, setEndDate] = useState("");
   const [deliverables, setDeliverables] = useState("");
   const [payment, setPayment] = useState("");
-  const [fileUrl, setFileUrl] = useState<string | null>(null);
+  const [contract, setContract] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
   if (!open) return null;
 
   const generate = async () => {
     setLoading(true);
-    setFileUrl(null);
+    setContract(null);
     try {
-      const res = await fetch("/api/generate-contract", {
+      const res = await fetch("/api/contract/generate", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           brandName: "Demo Brand",
           creatorName,
           deliverables,
+          payment,
           startDate,
           endDate,
-          paymentTerms: payment,
-          format: "pdf",
         }),
       });
       if (res.ok) {
-        const blob = await res.blob();
-        const url = URL.createObjectURL(blob);
-        setFileUrl(url);
+        const data = await res.json();
+        setContract(data.contract);
       } else {
         alert("Failed to generate contract");
       }
@@ -52,41 +50,60 @@ export default function ContractModal({ open, onClose, creatorName }: Props) {
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
       <div className="bg-Siora-mid border border-Siora-border rounded-xl p-6 w-96 space-y-4 shadow-Siora-hover">
         <h2 className="text-xl font-semibold">Generate Contract</h2>
-        <input
-          type="date"
-          value={startDate}
-          onChange={(e) => setStartDate(e.target.value)}
-          className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
-          placeholder="Start Date"
-        />
-        <input
-          type="date"
-          value={endDate}
-          onChange={(e) => setEndDate(e.target.value)}
-          className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
-          placeholder="End Date"
-        />
-        <input
-          value={deliverables}
-          onChange={(e) => setDeliverables(e.target.value)}
-          placeholder="Deliverables"
-          className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
-        />
-        <input
-          value={payment}
-          onChange={(e) => setPayment(e.target.value)}
-          placeholder="Payment Terms"
-          className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
-        />
-        {fileUrl ? (
-          <a
-            href={fileUrl}
-            download="contract.pdf"
-            className="block text-sm text-Siora-accent underline"
-          >
-            Download Contract
-          </a>
-        ) : (
+        {!contract && (
+          <>
+            <input
+              type="date"
+              value={startDate}
+              onChange={(e) => setStartDate(e.target.value)}
+              className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
+              placeholder="Start Date"
+            />
+            <input
+              type="date"
+              value={endDate}
+              onChange={(e) => setEndDate(e.target.value)}
+              className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
+              placeholder="End Date"
+            />
+            <input
+              value={deliverables}
+              onChange={(e) => setDeliverables(e.target.value)}
+              placeholder="Deliverables"
+              className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
+            />
+            <input
+              value={payment}
+              onChange={(e) => setPayment(e.target.value)}
+              placeholder="Payment Terms"
+              className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
+            />
+          </>
+        )}
+        {contract && (
+          <>
+            <textarea
+              readOnly
+              value={contract}
+              className="w-full h-40 p-2 rounded-lg bg-Siora-light text-white border border-Siora-border overflow-y-auto"
+            />
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={async () => contract && (await navigator.clipboard.writeText(contract))}
+                className="px-3 py-1 text-sm rounded bg-Siora-accent text-white"
+              >
+                Copy to Clipboard
+              </button>
+              <button
+                onClick={() => alert('Export to PDF coming soon')}
+                className="px-3 py-1 text-sm rounded bg-Siora-accent text-white"
+              >
+                Export PDF
+              </button>
+            </div>
+          </>
+        )}
+        {!contract && (
           <button
             onClick={generate}
             disabled={loading}


### PR DESCRIPTION
## Summary
- create `/api/contract/generate` to return basic contract text
- update `ContractModal` to use the new endpoint
- show generated contract text with copy button and placeholder export PDF

## Testing
- `npm run lint -w apps/brand` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571b003734832cada4711e2cc8d57b