### PR TITLE
Add performance tab with metrics visualization

### DIFF
--- a/apps/brand/app/brands/[id]/page.tsx
+++ b/apps/brand/app/brands/[id]/page.tsx
@@ -1,5 +1,8 @@
+"use client";
+import { useState } from "react";
 import personas from "@/app/data/mock_creators_200.json";
 import { notFound } from "next/navigation";
+import PerformanceTab from "@/components/PerformanceTab";
 
 type Props = {
   params: { id: string };
@@ -8,6 +11,8 @@ type Props = {
 export default function PersonaProfile({ params }: Props) {
   const persona = personas.find((p) => p.id.toString() === params.id);
   if (!persona) return notFound();
+
+  const [tab, setTab] = useState<'overview' | 'performance'>('overview');
 
   return (
     <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
@@ -22,30 +27,50 @@ export default function PersonaProfile({ params }: Props) {
           <p className="text-zinc-400 text-sm mt-1">
             {persona.tone} • {persona.platform}
           </p>
-          <p className="mt-4 text-zinc-300 leading-relaxed">{persona.summary}</p>
-          <div className="mt-6 space-y-2 text-sm text-zinc-300">
-            <div>
-              <strong>Followers:</strong> {persona.followers.toLocaleString()}
-            </div>
-            <div>
-              <strong>Engagement Rate:</strong> {persona.engagementRate}%
-            </div>
+          <div className="mt-4 flex gap-2">
+            <button
+              onClick={() => setTab('overview')}
+              className={tab === 'overview' ? 'px-3 py-1 rounded bg-Siora-accent' : 'px-3 py-1 rounded bg-Siora-light'}
+            >
+              Overview
+            </button>
+            <button
+              onClick={() => setTab('performance')}
+              className={tab === 'performance' ? 'px-3 py-1 rounded bg-Siora-accent' : 'px-3 py-1 rounded bg-Siora-light'}
+            >
+              Performance
+            </button>
           </div>
-          {persona.tags && (
-            <div className="mt-6">
-              <h2 className="text-md font-semibold mb-2">Vibes</h2>
-              <div className="flex flex-wrap gap-2">
-                {persona.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="text-xs bg-Siora-light text-white border border-Siora-border px-3 py-1 rounded-full"
-                  >
-                    {tag}
-                  </span>
-                ))}
+
+          {tab === 'overview' && (
+            <>
+              <p className="mt-4 text-zinc-300 leading-relaxed">{persona.summary}</p>
+              <div className="mt-6 space-y-2 text-sm text-zinc-300">
+                <div>
+                  <strong>Followers:</strong> {persona.followers.toLocaleString()}
+                </div>
+                <div>
+                  <strong>Engagement Rate:</strong> {persona.engagementRate}%
+                </div>
               </div>
-            </div>
+              {persona.tags && (
+                <div className="mt-6">
+                  <h2 className="text-md font-semibold mb-2">Vibes</h2>
+                  <div className="flex flex-wrap gap-2">
+                    {persona.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="text-xs bg-Siora-light text-white border border-Siora-border px-3 py-1 rounded-full"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </>
           )}
+          {tab === 'performance' && <PerformanceTab creatorId={persona.id.toString()} />}
         </div>
       </div>
     </main>

--- a/apps/brand/components/PerformanceTab.tsx
+++ b/apps/brand/components/PerformanceTab.tsx
@@ -59,6 +59,10 @@ export default function PerformanceTab({ creatorId }: Props) {
   const trendUp = data.followerGrowth >= 0;
   const trendPercent = Math.round(Math.abs(data.followerGrowth));
 
+  const reachPct = Math.min(100, Math.round((data.avgReach / 20000) * 100));
+  const engagePct = Math.min(100, Math.round((data.engagementRate / 10) * 100));
+  const growthPct = Math.min(100, Math.round((Math.abs(data.followerGrowth) / 10) * 100));
+
   const chartData = {
     labels: ["Likes", "Comments", "Shares"],
     datasets: [
@@ -77,25 +81,49 @@ export default function PerformanceTab({ creatorId }: Props) {
   return (
     <div className="mt-6 space-y-6 text-sm text-zinc-300">
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <div className="flex items-center gap-2 p-4 bg-Siora-light rounded-lg border border-Siora-border">
-          <FaUsers className="text-Siora-accent" />
-          <div>
-            <div className="text-xs uppercase tracking-wide">Avg Reach</div>
-            <div className="text-base font-semibold">{data.avgReach.toLocaleString()}</div>
+        <div
+          className="flex flex-col gap-2 p-4 bg-Siora-light rounded-lg border border-Siora-border"
+          title="Average number of people each post reaches"
+        >
+          <div className="flex items-center gap-2">
+            <FaUsers className="text-Siora-accent" />
+            <div>
+              <div className="text-xs uppercase tracking-wide">Avg Reach</div>
+              <div className="text-base font-semibold">{data.avgReach.toLocaleString()}</div>
+            </div>
+          </div>
+          <div className="w-full h-2 bg-zinc-700/50 rounded">
+            <div className="h-2 bg-Siora-accent rounded" style={{ width: `${reachPct}%` }} />
           </div>
         </div>
-        <div className="flex items-center gap-2 p-4 bg-Siora-light rounded-lg border border-Siora-border">
-          <FaHeart className="text-Siora-accent" />
-          <div>
-            <div className="text-xs uppercase tracking-wide">Engagement Rate</div>
-            <div className="text-base font-semibold">{data.engagementRate}%</div>
+        <div
+          className="flex flex-col gap-2 p-4 bg-Siora-light rounded-lg border border-Siora-border"
+          title="Percentage of followers who interact with posts"
+        >
+          <div className="flex items-center gap-2">
+            <FaHeart className="text-Siora-accent" />
+            <div>
+              <div className="text-xs uppercase tracking-wide">Engagement Rate</div>
+              <div className="text-base font-semibold">{data.engagementRate}%</div>
+            </div>
+          </div>
+          <div className="w-full h-2 bg-zinc-700/50 rounded">
+            <div className="h-2 bg-green-400 rounded" style={{ width: `${engagePct}%` }} />
           </div>
         </div>
-        <div className="flex items-center gap-2 p-4 bg-Siora-light rounded-lg border border-Siora-border">
-          <FaChartLine className="text-Siora-accent" />
-          <div>
-            <div className="text-xs uppercase tracking-wide">Follower Growth</div>
-            <div className={`text-base font-semibold ${trendUp ? "text-green-400" : "text-red-400"}`}>{trendUp ? "▲" : "▼"} {trendPercent}%</div>
+        <div
+          className="flex flex-col gap-2 p-4 bg-Siora-light rounded-lg border border-Siora-border"
+          title="Change in followers over the last month"
+        >
+          <div className="flex items-center gap-2">
+            <FaChartLine className="text-Siora-accent" />
+            <div>
+              <div className="text-xs uppercase tracking-wide">Follower Growth</div>
+              <div className={`text-base font-semibold ${trendUp ? "text-green-400" : "text-red-400"}`}>{trendUp ? "▲" : "▼"} {trendPercent}%</div>
+            </div>
+          </div>
+          <div className="w-full h-2 bg-zinc-700/50 rounded">
+            <div className={`h-2 rounded ${trendUp ? "bg-green-400" : "bg-red-400"}`} style={{ width: `${growthPct}%` }} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- visualize creator performance metrics with bars and tooltips
- enable a new Performance tab on persona profiles

## Testing
- `npm run lint -w apps/brand` *(fails: next not found)*
- `npm run build -w apps/brand` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571aeefe60832cb2d0149f81a35425