### PR TITLE
Add lead magnet PDF export via puppeteer

### DIFF
--- a/apps/creator/app/api/export-lead-magnet/pdf.css
+++ b/apps/creator/app/api/export-lead-magnet/pdf.css
@@ -1,0 +1,24 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #fafafa;
+  color: #333;
+  line-height: 1.6;
+  padding: 20px;
+}
+h1, h2, h3, h4, h5 {
+  font-weight: bold;
+  margin-top: 1.2em;
+}
+pre {
+  background: #f0f0f0;
+  padding: 10px;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+code {
+  font-family: "Courier New", monospace;
+}
+
+.logo { text-align:center; margin-bottom:20px; }
+.footer { text-align:center; margin-top:40px; font-size:12px; color:#666; }
+

--- a/apps/creator/app/api/export-lead-magnet/route.ts
+++ b/apps/creator/app/api/export-lead-magnet/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from 'next/server'
+import { marked } from 'marked'
+import puppeteer from 'puppeteer'
+import fs from 'fs'
+import path from 'path'
+
+export async function POST(req: Request) {
+  try {
+    const { markdown } = await req.json()
+    if (!markdown || typeof markdown !== 'string') {
+      return NextResponse.json({ error: 'Markdown string required' }, { status: 400 })
+    }
+
+    const htmlContent = marked.parse(markdown)
+
+    const cssPath = path.join(process.cwd(), 'apps', 'creator', 'app', 'api', 'export-lead-magnet', 'pdf.css')
+    const css = fs.readFileSync(cssPath, 'utf8')
+
+    const logoPath = path.join(process.cwd(), 'apps', 'creator', 'public', 'siora-logo.svg')
+    const logoSvg = fs.readFileSync(logoPath)
+    const logoData = Buffer.from(logoSvg).toString('base64')
+
+    const html = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+<style>${css}</style>
+</head>
+<body>
+<div class="logo"><img src="data:image/svg+xml;base64,${logoData}" alt="usesiora.com logo" width="120" /></div>
+${htmlContent}
+<footer class="footer">Created with Siora – the smart platform for modern creators</footer>
+</body>
+</html>`
+
+    const browser = await puppeteer.launch({ args: ['--no-sandbox'], headless: 'new' })
+    const page = await browser.newPage()
+    await page.setContent(html, { waitUntil: 'networkidle0' })
+    const buffer = await page.pdf({ format: 'A4', printBackground: true })
+    await browser.close()
+
+    return new NextResponse(buffer, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': 'attachment; filename="lead-magnet.pdf"'
+      }
+    })
+  } catch (err) {
+    console.error('lead magnet pdf export failed', err)
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+}

--- a/apps/creator/app/dashboard/lead-magnet/page.tsx
+++ b/apps/creator/app/dashboard/lead-magnet/page.tsx
@@ -56,8 +56,26 @@ export default function LeadMagnetDashboard() {
     }
   };
 
-  const downloadPdf = () => {
-    alert("PDF download coming soon!");
+  const downloadPdf = async () => {
+    if (!idea) return;
+    const markdown = `# ${idea.title}\n\n- ${idea.description}\n- Benefit: ${idea.benefit}\n- CTA: ${idea.cta}`;
+    try {
+      const res = await fetch("/api/export-lead-magnet", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ markdown })
+      });
+      if (!res.ok) throw new Error("Request failed");
+      const blob = await res.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "lead-magnet.pdf";
+      a.click();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      alert("PDF generation failed");
+    }
   };
 
   return (

--- a/apps/creator/package.json
+++ b/apps/creator/package.json
@@ -20,6 +20,8 @@
     "framer-motion": "^12.6.3",
     "jspdf": "^3.0.1",
     "markdown-pdf": "^11.0.0",
+    "marked": "^12.0.2",
+    "puppeteer": "^21.9.0",
     "next": "^15.2.5",
     "next-auth": "^4.24.11",
     "prisma": "^6.9.0",


### PR DESCRIPTION
## Summary
- allow dashboard to export generated lead magnet details as PDF
- implement `/api/export-lead-magnet` route using marked + puppeteer
- include usesiora.com logo and footer in the PDF style
- add puppeteer and marked dependencies

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571f3613e8832c88de0e0df09ea10e