### PR TITLE
Add download email modal

### DIFF
--- a/apps/creator/app/dashboard/lead-magnet/page.tsx
+++ b/apps/creator/app/dashboard/lead-magnet/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import LeadMagnetDownloadModal from "@/components/LeadMagnetDownloadModal";
 import type { LeadMagnetIdea } from "@/types/leadMagnet";
 import {
   loadLeadMagnetIdea,
@@ -29,6 +30,7 @@ export default function LeadMagnetDashboard() {
   const [idea, setIdea] = useState<LeadMagnetIdea | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
     const stored = loadLeadMagnetIdea();
@@ -57,6 +59,12 @@ export default function LeadMagnetDashboard() {
   };
 
   const downloadPdf = () => {
+    setShowModal(true);
+  };
+
+  const handleDownload = (email: string) => {
+    setShowModal(false);
+    console.log("Download PDF for", email);
     alert("PDF download coming soon!");
   };
 
@@ -106,5 +114,10 @@ export default function LeadMagnetDashboard() {
         Generate new idea
       </Link>
     </main>
+    <LeadMagnetDownloadModal
+      open={showModal}
+      onClose={() => setShowModal(false)}
+      onDownload={handleDownload}
+    />
   );
 }

--- a/apps/creator/components/LeadMagnetDownloadModal.tsx
+++ b/apps/creator/components/LeadMagnetDownloadModal.tsx
@@ -1,0 +1,52 @@
+"use client";
+import { useState } from "react";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onDownload: (email: string) => void;
+};
+
+export default function LeadMagnetDownloadModal({ open, onClose, onDownload }: Props) {
+  const [email, setEmail] = useState("");
+
+  if (!open) return null;
+
+  const handleSubmit = () => {
+    onDownload(email);
+    setEmail("");
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+      <div className="bg-background text-foreground border border-white/10 rounded-md p-6 w-80 space-y-4">
+        <p className="text-center text-sm">
+          Enter your email to download your personalized lead magnet
+        </p>
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full p-2 rounded-md bg-zinc-800 text-white"
+        />
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1 text-sm rounded border border-white/20"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            className="px-3 py-1 text-sm rounded bg-indigo-600 text-white"
+          >
+            Download Now
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add modal component to capture email before downloading lead magnet
- wire up modal into lead magnet dashboard page

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571f55ec88832cb464d69594820be0