### PR TITLE
Add collect email API

### DIFF
--- a/apps/home/app/api/collect-email/route.ts
+++ b/apps/home/app/api/collect-email/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+import PDFDocument from 'pdfkit';
+
+export async function POST(req: Request) {
+  try {
+    const { email } = await req.json();
+    if (!email || typeof email !== 'string') {
+      return NextResponse.json({ error: 'Email required' }, { status: 400 });
+    }
+
+    const csvPath = path.join(process.cwd(), '..', '..', 'db', 'emails.csv');
+    try {
+      await fs.access(csvPath);
+    } catch {
+      await fs.writeFile(csvPath, 'email,timestamp\n');
+    }
+    const line = `"${email.replace(/"/g, '""')}",${new Date().toISOString()}\n`;
+    await fs.appendFile(csvPath, line);
+
+    const doc = new PDFDocument();
+    const chunks: Buffer[] = [];
+    doc.fontSize(20).text('Thanks for signing up!', { align: 'center' });
+    doc.end();
+    for await (const chunk of doc) {
+      chunks.push(chunk);
+    }
+    const pdfBuffer = Buffer.concat(chunks);
+
+    return new NextResponse(pdfBuffer, {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Content-Disposition': 'attachment; filename="lead-magnet.pdf"',
+      },
+    });
+  } catch (err) {
+    console.error('collect-email POST error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/db/emails.csv
+++ b/db/emails.csv
@@ -1,0 +1,1 @@
+email,timestamp


### PR DESCRIPTION
## Summary
- create collect-email API route
- store email in CSV
- return a generated PDF

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685721873cf8832c9465ecfeb2cef397