### PR TITLE
Add validation with toast on brand sign in

### DIFF
--- a/apps/brand/app/signin/page.tsx
+++ b/apps/brand/app/signin/page.tsx
@@ -2,17 +2,29 @@
 import { signIn } from "next-auth/react";
 import { useState } from "react";
 import { useBrandUser } from "@/lib/brandUser";
+import Toast from "@/components/Toast";
 
 export default function SignInPage() {
   const { setUser } = useBrandUser();
   const [email, setEmail] = useState("");
+  const [toast, setToast] = useState("");
+  const [submitting, setSubmitting] = useState(false);
 
   const handleGoogle = () => {
     signIn("google", { callbackUrl: "/select-role" });
   };
 
   const handleTemp = () => {
-    if (email) setUser({ email });
+    if (submitting) return;
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(email)) {
+      setToast("Please enter a valid email");
+      return;
+    }
+    setSubmitting(true);
+    setUser({ email });
+    setToast("Signed in!");
+    setTimeout(() => setSubmitting(false), 1000);
   };
 
   return (
@@ -32,11 +44,13 @@ export default function SignInPage() {
         />
         <button
           onClick={handleTemp}
-          className="bg-Siora-accent text-white px-3 py-1 rounded"
+          className="bg-Siora-accent text-white px-3 py-1 rounded disabled:opacity-50"
+          disabled={submitting}
         >
           Continue
         </button>
       </div>
+      {toast && <Toast message={toast} onClose={() => setToast("")} />}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add Toast import and new state to manage notifications
- validate email format before allowing temporary sign in
- disable submit button when submitting to avoid double clicks
- show toast feedback after action

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npx tsc -p apps/brand` *(fails: many missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68572192d86c832c9fd4e0920f07e90f