### PR TITLE
Persist shortlist in localStorage

### DIFF
--- a/apps/brand/README.md
+++ b/apps/brand/README.md
@@ -28,7 +28,7 @@ This app does not require any environment variables by default.
 
 ## Dashboard
 
-Visit `/signin` to log in. After signing in, head to `/brands` to search creator personas. Results can be filtered by tone, platform and vibe. Each profile can be saved to your personal shortlist which is stored in your browser. View your selections any time at `/shortlist`.
+Visit `/signin` to log in. After signing in, head to `/brands` to search creator personas. Results can be filtered by tone, platform and vibe. Each profile can be saved to your personal shortlist which is stored in your browser using `localStorage`. View your selections any time at `/shortlist`.
 
 `/dashboard` and `/personas` remain available for exploring personas without authentication.
 

--- a/apps/brand/components/CreatorCard.tsx
+++ b/apps/brand/components/CreatorCard.tsx
@@ -55,21 +55,12 @@ export default function CreatorCard({ creator, onShortlist, shortlisted, childre
     }
   };
 
-  const handleSave = async () => {
+  const handleSave = () => {
     if (onShortlist) onShortlist(creator.id);
     if (shortlisted) {
       setToast('Removed from shortlist');
-      return;
-    }
-    try {
-      await fetch('/api/shortlist/add', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ brandId: user?.email, creatorId: creator.id }),
-      });
+    } else {
       setToast('Creator saved to shortlist');
-    } catch {
-      setToast('Failed to save');
     }
   };
 


### PR DESCRIPTION
## Summary
- keep shortlist client-side only
- note localStorage usage in docs

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm install` *(fails: unsupported URL type workspace:*)

------
https://chatgpt.com/codex/tasks/task_e_6857229851d4832cacb4afbbf60fffd3