### PR TITLE
Add creator metrics API route

### DIFF
--- a/apps/creator/app/api/creator/[id]/metrics/route.ts
+++ b/apps/creator/app/api/creator/[id]/metrics/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  return NextResponse.json({
+    followers: 12000,
+    engagementRate: 5.2,
+    avgLikes: 620,
+    avgComments: 45,
+    monthlyGrowth: 8.1,
+    topFormats: ['Reels', 'Carousels', 'Skits']
+  })
+}


### PR DESCRIPTION
## Summary
- add `/api/creator/[id]/metrics` endpoint returning mock metrics

## Testing
- `npm run lint -w apps/creator` *(fails: `next` not found)*
- `npm install` *(fails: unsupported URL type for workspace dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685724f0e5f4832cbaf095700295ad0a