### PR TITLE
Add creator metrics component

### DIFF
--- a/apps/brand/app/api/creator-metrics/[id]/route.ts
+++ b/apps/brand/app/api/creator-metrics/[id]/route.ts
@@ -1,0 +1,15 @@
+import data from '@/app/data/creatorMetrics.json';
+
+export async function GET(_req: Request, { params }: { params: { id: string } }) {
+  const record = (data as Record<string, any>)[params.id];
+  if (!record) {
+    return new Response(JSON.stringify({ error: 'Not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+  return new Response(JSON.stringify(record), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}

--- a/apps/brand/app/creator/[id]/page.tsx
+++ b/apps/brand/app/creator/[id]/page.tsx
@@ -1,6 +1,7 @@
 import { creators } from "@/app/data/creators";
 import { notFound } from "next/navigation";
 import PerformanceTab from "@/components/PerformanceTab";
+import CreatorMetrics from "@/components/CreatorMetrics";
 
 type Props = {
   params: {
@@ -58,6 +59,7 @@ export default function CreatorProfile({ params }: Props) {
 
         <div>
           <h2 className="text-lg font-semibold mb-2">Performance</h2>
+          <CreatorMetrics creatorId={creator.id} />
           <PerformanceTab creatorId={creator.id} />
         </div>
       </div>

--- a/apps/brand/app/data/creatorMetrics.json
+++ b/apps/brand/app/data/creatorMetrics.json
@@ -1,0 +1,26 @@
+{
+  "1": {
+    "totalFollowers": 120000,
+    "engagementRate": 3.8,
+    "avgLikes": 2800,
+    "avgComments": 350,
+    "monthlyGrowthRate": 4.0,
+    "topContent": ["Glow routine - Reel", "Skincare Q&A - Story"]
+  },
+  "2": {
+    "totalFollowers": 45000,
+    "engagementRate": 6.2,
+    "avgLikes": 3100,
+    "avgComments": 500,
+    "monthlyGrowthRate": 2.5,
+    "topContent": ["AI Gadgets Review - Video", "Crypto Basics - Short"]
+  },
+  "3": {
+    "totalFollowers": 82000,
+    "engagementRate": 4.7,
+    "avgLikes": 2500,
+    "avgComments": 400,
+    "monthlyGrowthRate": -1.0,
+    "topContent": ["Plant Shelf Tour - Reel", "Potting Basics - Tutorial"]
+  }
+}

--- a/apps/brand/components/CreatorMetrics.tsx
+++ b/apps/brand/components/CreatorMetrics.tsx
@@ -1,0 +1,84 @@
+"use client";
+import { useEffect, useState } from "react";
+
+type Props = {
+  creatorId: string;
+};
+
+interface Metrics {
+  totalFollowers: number;
+  engagementRate: number;
+  avgLikes: number;
+  avgComments: number;
+  monthlyGrowthRate: number;
+  topContent: string[];
+}
+
+export default function CreatorMetrics({ creatorId }: Props) {
+  const [data, setData] = useState<Metrics | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/creator-metrics/${creatorId}`);
+        if (res.ok) {
+          setData(await res.json());
+        }
+      } catch (err) {
+        console.error("metrics fetch", err);
+      }
+    }
+    load();
+  }, [creatorId]);
+
+  if (!data) {
+    return <p className="text-sm text-zinc-400">Loading metrics...</p>;
+  }
+
+  return (
+    <div className="space-y-4 text-sm text-zinc-300">
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+        <div className="p-4 bg-Siora-light rounded-lg border border-Siora-border">
+          <div className="text-xs uppercase tracking-wide">Followers</div>
+          <div className="text-base font-semibold">
+            {data.totalFollowers.toLocaleString()}
+          </div>
+        </div>
+        <div className="p-4 bg-Siora-light rounded-lg border border-Siora-border">
+          <div className="text-xs uppercase tracking-wide">Engagement Rate</div>
+          <div className="text-base font-semibold">{data.engagementRate}%</div>
+        </div>
+        <div className="p-4 bg-Siora-light rounded-lg border border-Siora-border">
+          <div className="text-xs uppercase tracking-wide">Monthly Growth</div>
+          <div className="text-base font-semibold">
+            {data.monthlyGrowthRate}%
+          </div>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="p-4 bg-Siora-light rounded-lg border border-Siora-border">
+          <div className="text-xs uppercase tracking-wide">Avg Likes/Post</div>
+          <div className="text-base font-semibold">
+            {data.avgLikes.toLocaleString()}
+          </div>
+        </div>
+        <div className="p-4 bg-Siora-light rounded-lg border border-Siora-border">
+          <div className="text-xs uppercase tracking-wide">Avg Comments/Post</div>
+          <div className="text-base font-semibold">
+            {data.avgComments.toLocaleString()}
+          </div>
+        </div>
+      </div>
+      {data.topContent && data.topContent.length > 0 && (
+        <div>
+          <h3 className="text-md font-semibold mb-2">Top Content</h3>
+          <ul className="list-disc pl-5 space-y-1">
+            {data.topContent.map((t, idx) => (
+              <li key={idx}>{t}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add API route for creator metrics and sample data
- create `CreatorMetrics` component
- show metrics on `/brand/creator/[id]` page

## Testing
- `npm run lint -w apps/brand` *(fails: next not found)*
- `npm install` *(fails: unsupported URL type "workspace:")*

------
https://chatgpt.com/codex/tasks/task_e_685724e794d0832cbfaf79c703d2e67a