### PR TITLE
Add simple conversations API

### DIFF
--- a/apps/home/app/api/messages/route.ts
+++ b/apps/home/app/api/messages/route.ts
@@ -1,24 +1,52 @@
 import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
 
 interface Message {
-  senderId: string;
-  recipientId: string;
+  sender: string;
+  receiver: string;
   message: string;
   timestamp: string;
 }
 
-const messages: Message[] = [];
+type MessageDB = Record<string, Message[]>;
+
+const DB_PATH = path.join(process.cwd(), '..', '..', 'db', 'conversations.json');
+
+async function readData(): Promise<MessageDB> {
+  try {
+    const file = await fs.readFile(DB_PATH, 'utf8');
+    const data = JSON.parse(file);
+    return data && typeof data === 'object' ? (data as MessageDB) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeData(data: MessageDB) {
+  await fs.writeFile(DB_PATH, JSON.stringify(data, null, 2));
+}
 
 export async function POST(req: Request) {
   try {
-    const { senderId, recipientId, message, timestamp } = await req.json();
+    const { sender, receiver, message } = await req.json();
 
-    if (!senderId || !recipientId || !message || !timestamp) {
+    if (!sender || !receiver || !message) {
       return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
     }
 
-    const newMessage: Message = { senderId, recipientId, message, timestamp };
-    messages.push(newMessage);
+    const data = await readData();
+    const key = [sender, receiver].sort().join('_');
+    const entry = data[key] ?? [];
+    const newMessage: Message = {
+      sender,
+      receiver,
+      message,
+      timestamp: new Date().toISOString(),
+    };
+    entry.push(newMessage);
+    data[key] = entry;
+    await writeData(data);
 
     return NextResponse.json({ message: newMessage });
   } catch (err) {
@@ -30,20 +58,22 @@ export async function POST(req: Request) {
 export async function GET(req: Request) {
   try {
     const { searchParams } = new URL(req.url);
-    const user1 = searchParams.get('user1');
-    const user2 = searchParams.get('user2');
+    const userId = searchParams.get('userId');
 
-    if (!user1 || !user2) {
-      return NextResponse.json({ error: 'user1 and user2 required' }, { status: 400 });
+    if (!userId) {
+      return NextResponse.json({ error: 'userId required' }, { status: 400 });
     }
 
-    const convo = messages.filter(
-      (m) =>
-        (m.senderId === user1 && m.recipientId === user2) ||
-        (m.senderId === user2 && m.recipientId === user1)
-    );
+    const data = await readData();
+    const conversations: MessageDB = {};
+    for (const [key, msgs] of Object.entries(data)) {
+      const [a, b] = key.split('_');
+      if (a === userId || b === userId) {
+        conversations[key] = msgs;
+      }
+    }
 
-    return NextResponse.json({ messages: convo });
+    return NextResponse.json({ conversations });
   } catch (err) {
     console.error('messages GET error', err);
     return NextResponse.json({ error: 'Server error' }, { status: 500 });

--- a/db/conversations.json
+++ b/db/conversations.json
@@ -1,0 +1,24 @@
+{
+  "user1_user2": [
+    {
+      "sender": "user1",
+      "receiver": "user2",
+      "message": "Hey there!",
+      "timestamp": "2024-05-01T12:00:00.000Z"
+    },
+    {
+      "sender": "user2",
+      "receiver": "user1",
+      "message": "Hi! How's it going?",
+      "timestamp": "2024-05-01T12:05:00.000Z"
+    }
+  ],
+  "user1_brand1": [
+    {
+      "sender": "brand1",
+      "receiver": "user1",
+      "message": "We'd like to collaborate.",
+      "timestamp": "2024-06-10T09:00:00.000Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add /api/messages endpoint for basic conversation storage
- include mock conversation data for testing

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685726e8ba30832cba7823468dc38e98