### PR TITLE
Add sample inbox threads

### DIFF
--- a/apps/brand/app/data/inboxThreads.ts
+++ b/apps/brand/app/data/inboxThreads.ts
@@ -1,0 +1,59 @@
+export interface InboxMessage {
+  id: string;
+  text: string;
+  timestamp: string;
+  direction: 'fromBrand' | 'fromCreator';
+}
+
+export const inboxThreads: Record<string, InboxMessage[]> = {
+  '1': [
+    {
+      id: 't1m1',
+      direction: 'fromCreator',
+      text: 'Hey there! Thanks for reaching out.',
+      timestamp: '2024-08-01T10:00:00.000Z'
+    },
+    {
+      id: 't1m2',
+      direction: 'fromBrand',
+      text: 'Excited to chat about a potential collab!',
+      timestamp: '2024-08-01T10:05:00.000Z'
+    },
+    {
+      id: 't1m3',
+      direction: 'fromCreator',
+      text: 'Looking forward to it!',
+      timestamp: '2024-08-01T10:10:00.000Z'
+    }
+  ],
+  '2': [
+    {
+      id: 't2m1',
+      direction: 'fromCreator',
+      text: "I'd love to hear more about your campaign.",
+      timestamp: '2024-08-02T11:00:00.000Z'
+    },
+    {
+      id: 't2m2',
+      direction: 'fromBrand',
+      text: 'I will send the details shortly.',
+      timestamp: '2024-08-02T11:02:00.000Z'
+    }
+  ],
+  '3': [
+    {
+      id: 't3m1',
+      direction: 'fromBrand',
+      text: 'Hi! Just checking in about the product sample.',
+      timestamp: '2024-08-03T09:00:00.000Z'
+    },
+    {
+      id: 't3m2',
+      direction: 'fromCreator',
+      text: 'Got it! Shooting content this weekend.',
+      timestamp: '2024-08-03T09:05:00.000Z'
+    }
+  ]
+};
+
+export default inboxThreads;

--- a/apps/brand/app/inbox/page.tsx
+++ b/apps/brand/app/inbox/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { ChatPanel, ChatMessage } from "shared-ui";
 import creators from "@/app/data/mock_creators_200.json";
+import inboxThreads from "@/app/data/inboxThreads";
 
 interface Creator {
   id: string;
@@ -14,36 +15,6 @@ const contacts: Creator[] = creators.slice(0, 5).map((c: any) => ({
   name: c.name,
 }));
 
-const mockThreads: Record<string, ChatMessage[]> = {
-  "1": [
-    {
-      id: "m1",
-      sender: "creator",
-      text: "Hey there! Thanks for reaching out.",
-      timestamp: new Date().toISOString(),
-    },
-    {
-      id: "m2",
-      sender: "brand",
-      text: "Excited to chat about a potential collab!",
-      timestamp: new Date().toISOString(),
-    },
-  ],
-  "2": [
-    {
-      id: "m3",
-      sender: "creator",
-      text: "I'd love to hear more about your campaign.",
-      timestamp: new Date().toISOString(),
-    },
-    {
-      id: "m4",
-      sender: "brand",
-      text: "I'll send you the details shortly.",
-      timestamp: new Date().toISOString(),
-    },
-  ],
-};
 
 export default function InboxPage() {
   const [selected, setSelected] = useState<Creator | null>(null);
@@ -51,7 +22,14 @@ export default function InboxPage() {
 
   const openChat = (c: Creator) => {
     setSelected(c);
-    setMessages(mockThreads[c.id] ?? []);
+    const thread = inboxThreads[c.id] ?? [];
+    const mapped = thread.map((m) => ({
+      id: m.id,
+      sender: m.direction === 'fromBrand' ? 'brand' : 'creator',
+      text: m.text,
+      timestamp: m.timestamp,
+    }));
+    setMessages(mapped);
   };
 
   const send = async (text: string) => {


### PR DESCRIPTION
## Summary
- add an `inboxThreads` data file containing 3 short message threads
- populate the brand inbox page from this mock dataset

## Testing
- `npm run lint -w apps/brand` *(fails: `next` not found)*
- `npm install --ignore-scripts` *(fails: unsupported URL type `workspace:`)*

------
https://chatgpt.com/codex/tasks/task_e_685726f0d63c832c849db23c72c46fdc