### PR TITLE
Add message polling for chat threads

### DIFF
--- a/apps/brand/app/campaigns/[id]/messages/[creatorId]/page.tsx
+++ b/apps/brand/app/campaigns/[id]/messages/[creatorId]/page.tsx
@@ -3,7 +3,6 @@ import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import creators from "@/app/data/mock_creators_200.json";
 import { ChatPanel, ChatMessage } from "shared-ui";
-import mockMessages, { StoredMessage } from "@/app/data/mock_messages";
 
 interface Message extends ChatMessage {
   creatorId: string;
@@ -12,20 +11,38 @@ interface Message extends ChatMessage {
 
 export default function CampaignChatPage({ params }: { params: { creatorId: string; id: string } }) {
   const creator = creators.find((c) => c.id === params.creatorId);
+  const brandId = "brand1"; // demo brand id until auth
   const [messages, setMessages] = useState<Message[]>([]);
   const [sending, setSending] = useState(false);
 
   useEffect(() => {
-    const stored = (mockMessages[params.creatorId] ?? []) as StoredMessage[];
-    const mapped = stored.map((m, i) => ({
-      id: `${params.creatorId}-${i}`,
-      creatorId: params.creatorId,
-      sender: m.sender,
-      text: m.content,
-      timestamp: m.timestamp,
-      campaign: params.id,
-    }));
-    setMessages(mapped);
+    async function load() {
+      try {
+        const res = await fetch(
+          `/api/messages?brandId=${brandId}&creatorId=${params.creatorId}`
+        );
+        if (res.ok) {
+          const data = await res.json();
+          if (Array.isArray(data.messages)) {
+            const mapped = data.messages.map((m: any, i: number) => ({
+              id: `${brandId}-${params.creatorId}-${i}`,
+              creatorId: params.creatorId,
+              sender: m.senderId === brandId ? "brand" : "creator",
+              text: m.message,
+              timestamp: m.timestamp,
+              campaign: params.id,
+            }));
+            setMessages(mapped);
+          }
+        }
+      } catch (err) {
+        console.error("failed to load messages", err);
+      }
+    }
+    load();
+    // simple polling until real-time WebSocket integration is added
+    const interval = setInterval(load, 15000);
+    return () => clearInterval(interval);
   }, [params.creatorId, params.id]);
 
   const send = async (text: string) => {


### PR DESCRIPTION
## Summary
- refresh chat pages every 15 seconds
- mention upcoming WebSocket integration in comments

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npx tsc -p packages/shared-ui/tsconfig.json` *(fails: missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_685726fec674832c9b9f49659a527baf