### PR TITLE
Add discover brands feed

### DIFF
--- a/apps/creator/app/discover-brands/page.tsx
+++ b/apps/creator/app/discover-brands/page.tsx
@@ -1,0 +1,62 @@
+"use client"
+import { useEffect, useMemo, useState } from 'react'
+import { brandOpportunities, BrandOpportunity } from '@/data/brandOpportunities'
+import { loadPersonasFromLocal, StoredPersona } from '@/lib/localPersonas'
+import BrandOpportunityCard from '@/components/BrandOpportunityCard'
+
+export default function DiscoverBrandsPage() {
+  const [personas, setPersonas] = useState<StoredPersona[]>([])
+  const [personaIndex, setPersonaIndex] = useState(0)
+
+  useEffect(() => {
+    setPersonas(loadPersonasFromLocal())
+  }, [])
+
+  const grouped = useMemo(() => {
+    const groups: Record<string, BrandOpportunity[]> = {}
+    for (const b of brandOpportunities) {
+      if (!groups[b.industry]) groups[b.industry] = []
+      groups[b.industry].push(b)
+    }
+    return groups
+  }, [])
+
+  const computeMatch = (brand: BrandOpportunity) => {
+    const base = brand.id.charCodeAt(0) + personaIndex * 7
+    return 60 + (base % 40) // mock 60-99
+  }
+
+  return (
+    <main className="min-h-screen bg-background text-foreground p-6 space-y-6 overflow-y-auto">
+      <h1 className="text-2xl font-bold">Discover Brand Opportunities</h1>
+      {personas.length > 0 && (
+        <div>
+          <label className="block text-sm font-semibold mb-1">Select Persona</label>
+          <select
+            className="w-full p-2 rounded-md bg-zinc-800 text-white"
+            value={personaIndex}
+            onChange={e => setPersonaIndex(parseInt(e.target.value, 10))}
+          >
+            {personas.map((p, idx) => (
+              <option key={idx} value={idx}>
+                {(p.persona as { name?: string }).name || `Persona ${idx + 1}`}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+      <div className="space-y-8">
+        {Object.entries(grouped).map(([industry, brands]) => (
+          <section key={industry} className="space-y-4">
+            <h2 className="text-xl font-semibold">{industry}</h2>
+            <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+              {brands.map(b => (
+                <BrandOpportunityCard key={b.id} brand={b} match={computeMatch(b)} />
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </main>
+  )
+}

--- a/apps/creator/components/BrandOpportunityCard.tsx
+++ b/apps/creator/components/BrandOpportunityCard.tsx
@@ -1,0 +1,48 @@
+import Image from 'next/image'
+import { motion } from 'framer-motion'
+import type { BrandOpportunity } from '@/data/brandOpportunities'
+import { useRouter } from 'next/navigation'
+
+interface Props {
+  brand: BrandOpportunity
+  match: number
+}
+
+export default function BrandOpportunityCard({ brand, match }: Props) {
+  const router = useRouter()
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="p-4 rounded-lg border border-white/10 bg-background flex flex-col space-y-2"
+    >
+      <div className="flex items-center gap-3">
+        <Image
+          src={brand.logo}
+          alt={brand.name}
+          width={40}
+          height={40}
+          className="rounded-full"
+          unoptimized
+        />
+        <h3 className="font-semibold">{brand.name}</h3>
+        <span className="ml-auto text-sm font-medium">{match}% match</span>
+      </div>
+      <p className="text-sm text-foreground/70">{brand.lookingFor}</p>
+      <div className="flex flex-wrap gap-1">
+        {brand.tags.map((t) => (
+          <span key={t} className="px-2 py-0.5 text-xs bg-zinc-800 rounded">
+            {t}
+          </span>
+        ))}
+      </div>
+      <button
+        onClick={() => router.push(`/pitch?brand=${encodeURIComponent(brand.name)}`)}
+        className="mt-2 px-3 py-1 bg-indigo-600 text-white rounded self-start"
+      >
+        Pitch this Brand
+      </button>
+    </motion.div>
+  )
+}

--- a/apps/creator/data/brandOpportunities.ts
+++ b/apps/creator/data/brandOpportunities.ts
@@ -1,0 +1,59 @@
+export interface BrandOpportunity {
+  id: string;
+  name: string;
+  logo: string;
+  lookingFor: string;
+  industry: string;
+  tags: string[];
+}
+
+export const brandOpportunities: BrandOpportunity[] = [
+  {
+    id: 'o1',
+    name: 'TechTrends',
+    logo: 'https://via.placeholder.com/80?text=TT',
+    lookingFor: 'Creators to showcase our latest gadgets in engaging unboxings.',
+    industry: 'Tech',
+    tags: ['tech', 'gadgets', 'innovation'],
+  },
+  {
+    id: 'o2',
+    name: 'FitFuel',
+    logo: 'https://via.placeholder.com/80?text=FitFuel',
+    lookingFor: 'Fitness enthusiasts to demo our new plant protein line.',
+    industry: 'Fitness',
+    tags: ['fitness', 'nutrition'],
+  },
+  {
+    id: 'o3',
+    name: 'GlowUp',
+    logo: 'https://via.placeholder.com/80?text=GlowUp',
+    lookingFor: 'Beauty creators to review our summer skincare launch.',
+    industry: 'Beauty',
+    tags: ['beauty', 'skincare'],
+  },
+  {
+    id: 'o4',
+    name: 'MindfulLife',
+    logo: 'https://via.placeholder.com/80?text=Mindful',
+    lookingFor: 'Wellness influencers for a meditation app campaign.',
+    industry: 'Wellness',
+    tags: ['wellness', 'meditation'],
+  },
+  {
+    id: 'o5',
+    name: 'FreshBite',
+    logo: 'https://via.placeholder.com/80?text=Fresh',
+    lookingFor: 'Food bloggers to feature our new meal kits.',
+    industry: 'Food',
+    tags: ['food', 'organic'],
+  },
+  {
+    id: 'o6',
+    name: 'HomeEase',
+    logo: 'https://via.placeholder.com/80?text=HomeEase',
+    lookingFor: 'DIY creators to highlight smart home products.',
+    industry: 'Home',
+    tags: ['home', 'smart-tech'],
+  },
+];


### PR DESCRIPTION
## Summary
- add brand opportunities mock data
- create animated card component for opportunities
- show opportunities at `/discover-brands`

## Testing
- `npm install` *(fails: Unsupported URL type "workspace:")*
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857288c3894832c866bf32f083e2f08