### PR TITLE
Add dashboard page for persona list

### DIFF
--- a/apps/home/app/dashboard/page.tsx
+++ b/apps/home/app/dashboard/page.tsx
@@ -1,0 +1,33 @@
+import Link from 'next/link';
+import personas from '../../../../data/personas.json';
+
+interface Persona {
+  id: string | number;
+  title: string;
+  handle: string;
+  tone: string;
+}
+
+export default function DashboardPage() {
+  const list = personas as Persona[];
+  return (
+    <main className="min-h-screen bg-white text-gray-900 p-6 space-y-6">
+      <h1 className="text-3xl font-bold">Personas</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {list.map((p) => (
+          <div key={p.id} className="border rounded-lg p-4 shadow">
+            <h2 className="text-xl font-semibold">{p.title}</h2>
+            <p className="text-gray-500">{p.handle}</p>
+            <p className="text-sm text-gray-700 mb-4">{p.tone}</p>
+            <Link
+              href={`/creator/${encodeURIComponent(p.handle.replace(/^@/, ''))}`}
+              className="inline-block px-4 py-2 bg-indigo-600 text-white rounded"
+            >
+              View
+            </Link>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/data/personas.json
+++ b/data/personas.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "1",
+    "title": "Sophie Tan",
+    "handle": "@livelaughluxe",
+    "tone": "Warm & Aspirational"
+  },
+  {
+    "id": "2",
+    "title": "Marc Venter",
+    "handle": "@techdad.eth",
+    "tone": "Witty & Analytical"
+  },
+  {
+    "id": "3",
+    "title": "Paola Mendes",
+    "handle": "@plantgirlpaola",
+    "tone": "Soft & Visual"
+  }
+]


### PR DESCRIPTION
## Summary
- show personas on a new dashboard page for the home app
- store sample personas as JSON data

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_685728a59ae4832ca01c584417a179e0