### PR TITLE
Add persona dynamic route

### DIFF
--- a/apps/home/app/persona/[id]/page.tsx
+++ b/apps/home/app/persona/[id]/page.tsx
@@ -1,0 +1,24 @@
+import personas from '../../../../../data/personas.json';
+
+interface Persona {
+  id: string;
+  title: string;
+  handle: string;
+  tone?: string;
+}
+
+export default function PersonaPage({ params }: { params: { id: string } }) {
+  const persona = (personas as Persona[]).find(p => p.id === params.id);
+
+  if (!persona) {
+    return <main className="p-6">Persona not found.</main>;
+  }
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center p-6 space-y-4">
+      <h1 className="text-2xl font-bold">{persona.title}</h1>
+      <p className="text-gray-700">Handle: {persona.handle}</p>
+      {persona.tone && <p className="text-gray-700">Tone: {persona.tone}</p>}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add dynamic persona page to display persona by ID from `data/personas.json`

## Testing
- `npm run lint -w apps/home` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572b0c5e40832c954a77cc17fb594e