### PR TITLE
Add html2pdf export for Media Kit

### DIFF
--- a/apps/creator/app/globals.css
+++ b/apps/creator/app/globals.css
@@ -33,4 +33,14 @@ body {
   animation: fade-in-up 0.6s ease-out both;
 }
 
+@media print {
+  body {
+    background: #ffffff !important;
+    color: #000000 !important;
+  }
+  .border {
+    border-color: #000000 !important;
+  }
+}
+
 

--- a/apps/creator/app/media-kit/page.tsx
+++ b/apps/creator/app/media-kit/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { jsPDF } from "jspdf";
+import html2pdf from "html2pdf.js";
 import { loadPersonasFromLocal, StoredPersona } from "@/lib/localPersonas";
 import type { PersonaProfile, FullPersona } from "@/types/persona";
 
@@ -19,11 +19,14 @@ export default function MediaKitPage() {
     if (!persona) return;
     const element = document.getElementById("media-kit");
     if (!element) return;
-    const doc = new jsPDF();
-    doc.html(element, {
-      callback: () => doc.save(`${persona.name || "media-kit"}.pdf`),
-      html2canvas: { scale: 0.6 },
-    });
+    const opt = {
+      margin: 0.5,
+      filename: `${persona.name || "media-kit"}.pdf`,
+      image: { type: "jpeg", quality: 0.98 },
+      html2canvas: { scale: 2 },
+      jsPDF: { unit: "in", format: "letter", orientation: "portrait" },
+    } as const;
+    html2pdf().set(opt).from(element).save();
   };
 
   if (personas.length === 0) {

--- a/apps/creator/package.json
+++ b/apps/creator/package.json
@@ -19,6 +19,7 @@
     "@tailwindcss/vite": "^4.1.3",
     "framer-motion": "^12.6.3",
     "jspdf": "^3.0.1",
+    "html2pdf.js": "^0.10.3",
     "markdown-pdf": "^11.0.0",
     "marked": "^12.0.2",
     "puppeteer": "^21.9.0",


### PR DESCRIPTION
## Summary
- enable printing to PDF from the Media Kit page using **html2pdf.js**
- add basic print styles so colors and borders look correct
- include `html2pdf.js` as a creator workspace dependency

## Testing
- `npm run lint --workspaces=false` *(fails: turbo not found)*
- `npm install html2pdf.js --workspace=apps/creator` *(fails: Unsupported URL Type "workspace:")*

------
https://chatgpt.com/codex/tasks/task_e_68572d36c418832cb3d157522859709f