### PR TITLE
Add filtering and tag display on dashboard and explorer

### DIFF
--- a/apps/brand/app/dashboard/page.tsx
+++ b/apps/brand/app/dashboard/page.tsx
@@ -26,6 +26,17 @@ export default function Dashboard() {
   const user = session?.user?.email ?? null;
   const { toggle, inShortlist } = useShortlist(user);
 
+  const unique = (arr: (string | undefined)[]) =>
+    Array.from(new Set(arr.filter(Boolean))) as string[];
+
+  const platforms = unique(creators.map((c) => c.platform));
+  const tones = unique(creators.map((c) => c.tone));
+  const niches = unique(creators.map((c) => c.niche));
+
+  const [platformFilter, setPlatformFilter] = useState("");
+  const [toneFilter, setToneFilter] = useState("");
+  const [nicheFilter, setNicheFilter] = useState("");
+
   const filtered = creators
     .filter((c) => {
       const matchesQuery = `${c.name} ${c.handle} ${c.niche} ${c.tags.join(" ")} ${c.tone} ${c.summary}`
@@ -49,6 +60,10 @@ export default function Dashboard() {
       const collabMatch =
         (c.completedCollabs ?? 0) >= filters.minCollabs;
 
+      const extraPlatform = !platformFilter || c.platform === platformFilter;
+      const extraTone = !toneFilter || c.tone === toneFilter;
+      const extraNiche = !nicheFilter || c.niche === nicheFilter;
+
       return (
         matchesQuery &&
         platformMatch &&
@@ -58,7 +73,10 @@ export default function Dashboard() {
         formatMatch &&
         valuesMatch &&
         erMatch &&
-        collabMatch
+        collabMatch &&
+        extraPlatform &&
+        extraTone &&
+        extraNiche
       );
     });
 
@@ -76,6 +94,45 @@ export default function Dashboard() {
           placeholder="Search creators..."
           className="w-full p-3 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
         />
+
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <select
+            value={platformFilter}
+            onChange={(e) => setPlatformFilter(e.target.value)}
+            className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
+          >
+            <option value="">All Platforms</option>
+            {platforms.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+          <select
+            value={toneFilter}
+            onChange={(e) => setToneFilter(e.target.value)}
+            className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
+          >
+            <option value="">All Tones</option>
+            {tones.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+          <select
+            value={nicheFilter}
+            onChange={(e) => setNicheFilter(e.target.value)}
+            className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
+          >
+            <option value="">All Niches</option>
+            {niches.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
+        </div>
 
         <AdvancedFilterBar onFilter={setFilters} />
 

--- a/apps/brand/app/explorer/page.tsx
+++ b/apps/brand/app/explorer/page.tsx
@@ -14,11 +14,17 @@ export default function ExplorerPage() {
   const [platform, setPlatform] = useState("");
   const [niche, setNiche] = useState("");
 
+  const unique = (arr: (string | undefined)[]) =>
+    Array.from(new Set(arr.filter(Boolean))) as string[];
+
+  const tones = unique(samplePersonas.map((p) => p.tone));
+  const platforms = unique(samplePersonas.map((p) => p.platform));
+  const niches = unique(samplePersonas.map((p) => p.niche));
+
   const filtered = samplePersonas.filter((p) => {
-    const matchTone = !tone || p.tone.toLowerCase().includes(tone.toLowerCase());
-    const matchPlatform =
-      !platform || p.platform.toLowerCase().includes(platform.toLowerCase());
-    const matchNiche = !niche || p.niche.toLowerCase().includes(niche.toLowerCase());
+    const matchTone = !tone || p.tone === tone;
+    const matchPlatform = !platform || p.platform === platform;
+    const matchNiche = !niche || p.niche === niche;
     return matchTone && matchPlatform && matchNiche;
   });
 
@@ -35,24 +41,42 @@ export default function ExplorerPage() {
         </motion.h1>
 
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <input
+          <select
             value={tone}
             onChange={(e) => setTone(e.target.value)}
-            placeholder="Filter by tone"
-            className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
-          />
-          <input
+            className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
+          >
+            <option value="">All Tones</option>
+            {tones.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+          <select
             value={platform}
             onChange={(e) => setPlatform(e.target.value)}
-            placeholder="Filter by platform"
-            className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
-          />
-          <input
+            className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
+          >
+            <option value="">All Platforms</option>
+            {platforms.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+          <select
             value={niche}
             onChange={(e) => setNiche(e.target.value)}
-            placeholder="Filter by niche"
-            className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
-          />
+            className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
+          >
+            <option value="">All Niches</option>
+            {niches.map((n) => (
+              <option key={n} value={n}>
+                {n}
+              </option>
+            ))}
+          </select>
         </div>
 
         {filtered.length === 0 ? (

--- a/apps/brand/components/CreatorCard.tsx
+++ b/apps/brand/components/CreatorCard.tsx
@@ -88,6 +88,18 @@ export default function CreatorCard({ creator, onShortlist, shortlisted, childre
       <p className="text-sm text-gray-700 dark:text-zinc-300 mb-4">
         {creator.summary}
       </p>
+      {creator.tags && (
+        <div className="flex flex-wrap gap-1 text-xs text-gray-500 dark:text-zinc-400 mb-2">
+          {creator.tags.map((tag) => (
+            <span
+              key={tag}
+              className="bg-Siora-light dark:bg-Siora-dark px-2 py-0.5 rounded"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
       <div className="flex items-center text-xs text-gray-500 dark:text-zinc-400 space-x-4">
         <span>{creator.followers.toLocaleString()} followers</span>
         <span>{creator.engagementRate}% ER</span>

--- a/apps/brand/components/PersonaCard.tsx
+++ b/apps/brand/components/PersonaCard.tsx
@@ -28,11 +28,18 @@ export default function PersonaCard({ persona, onToggle, inShortlist }: Props) {
       <p className="text-sm text-gray-700 dark:text-zinc-300 mb-4">
         {persona.summary}
       </p>
-      <div className="flex items-center text-xs text-gray-500 dark:text-zinc-400 space-x-4">
-        {persona.tags && (
-          <span>{persona.tags.join(", ")}</span>
-        )}
-      </div>
+      {persona.tags && (
+        <div className="flex flex-wrap gap-1 text-xs text-gray-500 dark:text-zinc-400 mb-2">
+          {persona.tags.map((tag) => (
+            <span
+              key={tag}
+              className="bg-Siora-light dark:bg-Siora-dark px-2 py-0.5 rounded"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
       <Link
         href={`/brands/${persona.id}`}
         className="inline-block text-sm mt-4 text-Siora-accent underline hover:text-indigo-400"


### PR DESCRIPTION
## Summary
- show tags on creator and persona cards
- add platform, tone and niche filters to brand dashboard
- add the same filters to persona explorer
- keep results filtered client-side

## Testing
- `npm run lint` *(fails: turbo not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572d4137c0832c85efb6e554900255