### PR TITLE
Add basic NextAuth credentials login

### DIFF
--- a/apps/home/app/api/auth/[...nextauth]/route.ts
+++ b/apps/home/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from 'next-auth';
+import { authOptions } from '../../../../lib/auth';
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/apps/home/app/dashboard/page.tsx
+++ b/apps/home/app/dashboard/page.tsx
@@ -1,15 +1,30 @@
 import Link from 'next/link';
-import personas from '../../../../data/personas.json';
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '../../lib/auth';
+import { promises as fs } from 'fs';
+import path from 'path';
 
 interface Persona {
   id: string | number;
+  userId: string;
   title: string;
   handle: string;
   tone: string;
 }
 
-export default function DashboardPage() {
-  const list = personas as Persona[];
+export default async function DashboardPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    redirect('/signin');
+  }
+
+  const file = await fs.readFile(
+    path.join(process.cwd(), '..', '..', 'data', 'personas.json'),
+    'utf8'
+  );
+  const data = JSON.parse(file) as Persona[];
+  const list = data.filter((p) => p.userId === session!.user!.id);
   return (
     <main className="min-h-screen bg-white text-gray-900 p-6 space-y-6">
       <h1 className="text-3xl font-bold">Personas</h1>

--- a/apps/home/app/layout.tsx
+++ b/apps/home/app/layout.tsx
@@ -1,5 +1,7 @@
 import './globals.css';
 import type { ReactNode } from 'react';
+import Providers from './providers';
+import AuthStatus from '../components/AuthStatus';
 
 export const metadata = {
   title: 'Siora',
@@ -9,7 +11,14 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="font-sans">{children}</body>
+      <body className="font-sans">
+        <Providers>
+          <div className="p-4 flex justify-end">
+            <AuthStatus />
+          </div>
+          {children}
+        </Providers>
+      </body>
     </html>
   );
 }

--- a/apps/home/app/providers.tsx
+++ b/apps/home/app/providers.tsx
@@ -1,0 +1,7 @@
+"use client";
+import { SessionProvider } from 'next-auth/react';
+import type { PropsWithChildren } from 'react';
+
+export default function Providers({ children }: PropsWithChildren) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/apps/home/app/signin/page.tsx
+++ b/apps/home/app/signin/page.tsx
@@ -1,0 +1,56 @@
+"use client";
+import { useState } from 'react';
+import { signIn } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+
+export default function SignInPage() {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await signIn('credentials', {
+      redirect: false,
+      username,
+      password,
+    });
+    if (res?.ok) {
+      router.push('/dashboard');
+    } else {
+      setError('Invalid credentials');
+    }
+  }
+
+  return (
+    <main className="min-h-screen flex items-center justify-center bg-white p-4">
+      <form onSubmit={handleSubmit} className="space-y-4 w-80">
+        <h1 className="text-2xl font-bold text-center">Sign In</h1>
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <input
+          type="text"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          placeholder="Username"
+          className="w-full border p-2 rounded"
+          required
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="w-full border p-2 rounded"
+          required
+        />
+        <button
+          type="submit"
+          className="w-full bg-indigo-600 text-white p-2 rounded"
+        >
+          Sign In
+        </button>
+      </form>
+    </main>
+  );
+}

--- a/apps/home/components/AuthStatus.tsx
+++ b/apps/home/components/AuthStatus.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { signIn, signOut, useSession } from 'next-auth/react';
+
+export default function AuthStatus() {
+  const { data: session, status } = useSession();
+
+  if (status === 'loading') {
+    return <p>Loading...</p>;
+  }
+
+  if (!session) {
+    return (
+      <button onClick={() => signIn()} className="underline text-sm">
+        Sign In
+      </button>
+    );
+  }
+
+  return (
+    <button onClick={() => signOut()} className="underline text-sm">
+      Sign Out
+    </button>
+  );
+}

--- a/apps/home/lib/auth.ts
+++ b/apps/home/lib/auth.ts
@@ -1,0 +1,47 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { NextAuthOptions, User } from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+
+interface StoredUser {
+  id: string;
+  username: string;
+  password: string;
+}
+
+async function loadUsers(): Promise<StoredUser[]> {
+  try {
+    const file = await fs.readFile(
+      path.join(process.cwd(), '..', '..', 'data', 'users.json'),
+      'utf8'
+    );
+    return JSON.parse(file) as StoredUser[];
+  } catch {
+    return [];
+  }
+}
+
+export const authOptions: NextAuthOptions = {
+  session: { strategy: 'jwt' },
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        username: { label: 'Username', type: 'text' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials) return null;
+        const users = await loadUsers();
+        const user = users.find(
+          (u) =>
+            u.username === credentials.username &&
+            u.password === credentials.password
+        );
+        if (!user) return null;
+        return { id: user.id, name: user.username } as User;
+      },
+    }),
+  ],
+  pages: { signIn: '/signin' },
+};

--- a/apps/home/package.json
+++ b/apps/home/package.json
@@ -14,6 +14,7 @@
     "react-dom": "^19.0.0",
     "framer-motion": "^12.6.3",
     "react-markdown": "^10.1.0",
+    "next-auth": "^4.24.5",
     "shared-ui": "workspace:*",
     "shared-utils": "workspace:*"
   },

--- a/data/personas.json
+++ b/data/personas.json
@@ -1,18 +1,21 @@
 [
   {
     "id": "1",
+    "userId": "1",
     "title": "Sophie Tan",
     "handle": "@livelaughluxe",
     "tone": "Warm & Aspirational"
   },
   {
     "id": "2",
+    "userId": "2",
     "title": "Marc Venter",
     "handle": "@techdad.eth",
     "tone": "Witty & Analytical"
   },
   {
     "id": "3",
+    "userId": "3",
     "title": "Paola Mendes",
     "handle": "@plantgirlpaola",
     "tone": "Soft & Visual"

--- a/data/users.json
+++ b/data/users.json
@@ -1,0 +1,5 @@
+[
+  { "id": "1", "username": "sophie", "password": "pass1" },
+  { "id": "2", "username": "marc", "password": "pass2" },
+  { "id": "3", "username": "paola", "password": "pass3" }
+]


### PR DESCRIPTION
## Summary
- add NextAuth credentials auth logic and user data
- show sign in/out in layout
- filter dashboard personas by logged in user

## Testing
- `npx -y turbo run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572d703b90832cbb118dd544ad4dda