### PR TITLE
Add tagline generation feature

### DIFF
--- a/apps/creator/app/api/tagline/route.ts
+++ b/apps/creator/app/api/tagline/route.ts
@@ -1,0 +1,54 @@
+export async function POST(req: Request) {
+  try {
+    const { persona } = await req.json();
+    if (!persona || typeof persona !== 'string') {
+      return new Response(
+        JSON.stringify({ error: 'Invalid persona' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const messages = [
+      {
+        role: 'system',
+        content: [
+          'You craft sharp marketing taglines.',
+          'Write one to two punchy sentences that capture the essence of the creator persona.',
+        ].join('\n'),
+      },
+      { role: 'user', content: persona },
+    ];
+
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.7 }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return new Response(
+        JSON.stringify({ error: 'OpenAI error', details: errorText }),
+        { status: response.status, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const data = await response.json();
+    const tagline = data.choices?.[0]?.message?.content?.trim() ?? '';
+
+    return new Response(JSON.stringify({ tagline }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    console.error('Unexpected error:', error);
+    return new Response(
+      JSON.stringify({ error: 'Unexpected error', details: message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/apps/creator/app/persona/[id]/edit/page.tsx
+++ b/apps/creator/app/persona/[id]/edit/page.tsx
@@ -19,6 +19,8 @@ export default function EditPersonaPage() {
   const [tone, setTone] = useState('');
   const [platforms, setPlatforms] = useState('');
   const [persona, setPersona] = useState<string | null>(null);
+  const [tagline, setTagline] = useState('');
+  const [taglineLoading, setTaglineLoading] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [limitReached, setLimitReached] = useState(false);
   const [showSlowMessage, setShowSlowMessage] = useState(false);
@@ -117,6 +119,27 @@ export default function EditPersonaPage() {
       localStorage.setItem(`inputs-${idParam}`, JSON.stringify({ handle, niche, audience, goal, tone, platforms, struggles, dreamBrands, favFormats }));
     } catch (err) {
       console.error('Failed to save persona', err);
+    }
+  };
+
+  const handleTagline = async () => {
+    if (!persona) return;
+    setTagline('');
+    setTaglineLoading(true);
+    try {
+      const res = await fetch('/api/tagline', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ persona }),
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setTagline(data.tagline ?? '');
+      }
+    } catch (err) {
+      console.error('Failed to generate tagline', err);
+    } finally {
+      setTaglineLoading(false);
     }
   };
 
@@ -231,6 +254,15 @@ export default function EditPersonaPage() {
           <button type="button" onClick={handleSave} className="bg-green-600 hover:bg-green-500 transition-colors duration-200 text-white font-semibold py-2 px-4 rounded-md">
             Save Persona
           </button>
+          <button
+            type="button"
+            onClick={handleTagline}
+            disabled={taglineLoading}
+            className="bg-indigo-600 hover:bg-indigo-500 transition-colors duration-200 text-white font-semibold py-2 px-4 rounded-md disabled:opacity-50"
+          >
+            {taglineLoading ? 'Generating...' : 'Generate sharp tagline'}
+          </button>
+          {tagline && <p className="italic text-center">{tagline}</p>}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- add `/api/tagline` route to produce a short tagline for a persona
- extend creator persona edit page with new tagline feature

## Testing
- `npx turbo run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685805210cd8832ca83b79a3e8d01232