### PR TITLE
Add upgrade section

### DIFF
--- a/apps/creator/app/settings/page.tsx
+++ b/apps/creator/app/settings/page.tsx
@@ -52,10 +52,46 @@ export default function SettingsPage() {
     );
   }
 
+  const [loading, setLoading] = useState(false);
+
+  const upgrade = async () => {
+    setLoading(true);
+    const res = await fetch("/api/subscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ plan: "pro" }),
+    });
+    const data = await res.json();
+    if (data.url) {
+      window.location.href = data.url as string;
+    } else {
+      setLoading(false);
+      alert("Error creating checkout");
+    }
+  };
+
   return (
-    <main className="min-h-screen bg-background text-foreground p-6 max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold mb-4">Profile Settings</h1>
-      <Settings persona={profile} onChange={handleChange} />
+    <main className="min-h-screen bg-background text-foreground p-6 max-w-2xl mx-auto space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold mb-4">Profile Settings</h1>
+        <Settings persona={profile} onChange={handleChange} />
+      </div>
+      <div className="border border-white/10 rounded-lg p-6 bg-background">
+        <h2 className="text-xl font-semibold mb-2">Upgrade to Pro</h2>
+        <ul className="list-disc list-inside space-y-1 mb-4 text-sm">
+          <li>Onbeperkte personas</li>
+          <li>Toegang tot alle AI-tools</li>
+          <li>Prioritaire ondersteuning</li>
+        </ul>
+        <p className="text-lg font-bold mb-4">€29 per maand</p>
+        <button
+          onClick={upgrade}
+          className="bg-purple-600 text-white px-4 py-2 rounded-md"
+          disabled={loading}
+        >
+          {loading ? "Bezig..." : "Upgrade via Stripe"}
+        </button>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add Pro upgrade section on settings page with Stripe checkout

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm install` *(fails: unsupported URL type 'workspace:' when installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68580539a0b0832c862aedb91e709830