### PR TITLE
Add page transitions with framer-motion

### DIFF
--- a/apps/brand/app/layout.tsx
+++ b/apps/brand/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import { SessionProvider } from 'next-auth/react';
 import { BrandUserProvider } from '@/lib/brandUser';
+import { PageTransition } from 'shared-ui';
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -9,7 +10,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
       <body className="bg-white text-black dark:bg-Siora-dark dark:text-white font-sans antialiased min-h-screen">
         <SessionProvider>
           <BrandUserProvider>
-            <main className="max-w-7xl mx-auto px-6 sm:px-8 py-10">{children}</main>
+            <main className="max-w-7xl mx-auto px-6 sm:px-8 py-10">
+              <PageTransition>{children}</PageTransition>
+            </main>
           </BrandUserProvider>
         </SessionProvider>
       </body>

--- a/apps/creator/app/layout.tsx
+++ b/apps/creator/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next';
 import Providers from './providers';
 import AuthStatus from '@/components/AuthStatus';
 import ThemeToggle from '@/components/ThemeToggle';
+import { PageTransition } from 'shared-ui';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -25,11 +26,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <body className={inter.className}>
         <Providers>
           <div className="p-4 flex justify-between items-center">
-            <ThemeToggle />
-            <AuthStatus />
-          </div>
-          {children}
-        </Providers>
+          <ThemeToggle />
+          <AuthStatus />
+        </div>
+        <PageTransition>{children}</PageTransition>
+      </Providers>
       </body>
     </html>
   );

--- a/apps/home/app/layout.tsx
+++ b/apps/home/app/layout.tsx
@@ -2,6 +2,7 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import Providers from './providers';
 import AuthStatus from '../components/AuthStatus';
+import { PageTransition } from 'shared-ui';
 
 export const metadata = {
   title: 'Siora',
@@ -16,7 +17,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           <div className="p-4 flex justify-end">
             <AuthStatus />
           </div>
-          {children}
+          <PageTransition>{children}</PageTransition>
         </Providers>
       </body>
     </html>

--- a/packages/shared-ui/src/PageTransition.tsx
+++ b/packages/shared-ui/src/PageTransition.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { PropsWithChildren } from "react";
+import { usePathname } from "next/navigation";
+import { AnimatePresence, motion } from "framer-motion";
+
+export function PageTransition({ children }: PropsWithChildren) {
+  const pathname = usePathname();
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={pathname}
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.2 }}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -1,2 +1,3 @@
 export * from './ChatPanel';
 export * from './Badge';
+export * from './PageTransition';


### PR DESCRIPTION
## Summary
- add shared `PageTransition` component using framer-motion
- export new component from `shared-ui`
- wrap pages with `PageTransition` in all app layouts for smooth fade transitions

## Testing
- `npx turbo run lint` *(fails: Workspace 'packages/shared-ui' not found in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6858050c3210832cba51c7a55bd8a6ec