### PR TITLE
Fix invalid package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "full-Siora-mvp",
+  "name": "full-siora-mvp",
   "private": true,
   "packageManager": "npm@10.5.0",
   "workspaces": [


### PR DESCRIPTION
## Summary
- fix the `name` field in `package.json` to use allowed characters

## Testing
- `npm pkg get name`
- `npm install` *(fails: Unsupported URL Type "workspace:")*

------
https://chatgpt.com/codex/tasks/task_e_6858073f4280832c853ecca70d5d28e2