### PR TITLE
Add Pro-only gating for media kit and growth tools

### DIFF
--- a/apps/creator/app/api/checkout/route.ts
+++ b/apps/creator/app/api/checkout/route.ts
@@ -1,10 +1,16 @@
 import Stripe from "stripe";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY || "", {
   apiVersion: "2024-04-10",
 });
 
 export async function POST() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user || session.user.plan !== "pro") {
+    return new Response("Forbidden", { status: 403 });
+  }
   const checkout = await stripe.checkout.sessions.create({
     mode: "payment",
     line_items: [

--- a/apps/creator/app/growth-plan/page.tsx
+++ b/apps/creator/app/growth-plan/page.tsx
@@ -1,11 +1,30 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
 import { loadPersonasFromLocal, StoredPersona } from "@/lib/localPersonas";
 import type { PersonaProfile } from "@/types/persona";
 import type { GrowthPlan } from "@/types/growth";
 
+function LockIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+    >
+      <path
+        fillRule="evenodd"
+        d="M12 1.5a4.5 4.5 0 00-4.5 4.5v3H6a2 2 0 00-2 2v9a2 2 0 002 2h12a2 2 0 002-2v-9a2 2 0 00-2-2h-1.5v-3A4.5 4.5 0 0012 1.5zm-3 4.5a3 3 0 116 0v3h-6v-3z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
 export default function GrowthPlanPage() {
+  const { data: session, status } = useSession();
   const [personas, setPersonas] = useState<StoredPersona[]>([]);
 
   useEffect(() => {
@@ -106,6 +125,26 @@ export default function GrowthPlanPage() {
     }));
     return plan;
   };
+
+  if (status === "loading") {
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-background text-foreground p-6">
+        <p>Loading...</p>
+      </main>
+    );
+  }
+
+  if (!session || session.user?.plan !== "pro") {
+    return (
+      <main className="min-h-screen flex flex-col items-center justify-center bg-background text-foreground p-6">
+        <LockIcon className="w-8 h-8 mb-4" />
+        <p className="mb-4">Alleen beschikbaar voor Pro-gebruikers.</p>
+        <a href="/subscribe" className="text-indigo-600 underline">
+          Upgrade naar Pro
+        </a>
+      </main>
+    );
+  }
 
   if (personas.length === 0) {
     return (

--- a/apps/creator/app/media-kit/page.tsx
+++ b/apps/creator/app/media-kit/page.tsx
@@ -1,10 +1,29 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useSession } from "next-auth/react";
 import { loadPersonasFromLocal, StoredPersona } from "@/lib/localPersonas";
 import type { PersonaProfile, FullPersona } from "@/types/persona";
 
+function LockIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+    >
+      <path
+        fillRule="evenodd"
+        d="M12 1.5a4.5 4.5 0 00-4.5 4.5v3H6a2 2 0 00-2 2v9a2 2 0 002 2h12a2 2 0 002-2v-9a2 2 0 00-2-2h-1.5v-3A4.5 4.5 0 0012 1.5zm-3 4.5a3 3 0 116 0v3h-6v-3z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
 export default function MediaKitPage() {
+  const { data: session, status } = useSession();
   const [personas, setPersonas] = useState<StoredPersona[]>([]);
   const [selectedIndex, setSelectedIndex] = useState(0);
 
@@ -13,6 +32,26 @@ export default function MediaKitPage() {
   }, []);
 
   const persona = personas[selectedIndex]?.persona as PersonaProfile | undefined;
+
+  if (status === "loading") {
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-background text-foreground p-6">
+        <p>Loading...</p>
+      </main>
+    );
+  }
+
+  if (!session || session.user?.plan !== "pro") {
+    return (
+      <main className="min-h-screen flex flex-col items-center justify-center bg-background text-foreground p-6">
+        <LockIcon className="w-8 h-8 mb-4" />
+        <p className="mb-4">Alleen beschikbaar voor Pro-gebruikers.</p>
+        <a href="/subscribe" className="text-indigo-600 underline">
+          Upgrade naar Pro
+        </a>
+      </main>
+    );
+  }
 
 
   const handleCheckout = async () => {

--- a/apps/creator/app/profile/page.tsx
+++ b/apps/creator/app/profile/page.tsx
@@ -3,10 +3,29 @@
 import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { jsPDF } from "jspdf";
+import { useSession } from "next-auth/react";
 import { loadPersonasFromLocal, StoredPersona } from "@/lib/localPersonas";
 import type { FullPersona } from "@/types/persona";
 
+function LockIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+    >
+      <path
+        fillRule="evenodd"
+        d="M12 1.5a4.5 4.5 0 00-4.5 4.5v3H6a2 2 0 00-2 2v9a2 2 0 002 2h12a2 2 0 002-2v-9a2 2 0 00-2-2h-1.5v-3A4.5 4.5 0 0012 1.5zm-3 4.5a3 3 0 116 0v3h-6v-3z"
+        clipRule="evenodd"
+      />
+    </svg>
+  );
+}
+
 export default function ProfilePage() {
+  const { data: session, status } = useSession();
   const [persona, setPersona] = useState<FullPersona | null>(null);
 
   useEffect(() => {
@@ -38,6 +57,14 @@ export default function ProfilePage() {
       html2canvas: { scale: 0.6 },
     });
   };
+
+  if (status === "loading") {
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-background text-foreground p-6">
+        <p>Loading...</p>
+      </main>
+    );
+  }
 
   if (!persona) {
     return (
@@ -135,13 +162,22 @@ export default function ProfilePage() {
       </section>
 
       <div className="flex flex-col sm:flex-row sm:justify-between gap-4">
-        <button
-          type="button"
-          onClick={downloadPdf}
-          className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-md"
-        >
-          Download Media Kit
-        </button>
+        {session?.user?.plan === "pro" ? (
+          <button
+            type="button"
+            onClick={downloadPdf}
+            className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-white rounded-md"
+          >
+            Download Media Kit
+          </button>
+        ) : (
+          <a
+            href="/subscribe"
+            className="px-4 py-2 bg-indigo-600 text-white rounded-md flex items-center gap-2 justify-center"
+          >
+            <LockIcon className="w-4 h-4" /> Pro only
+          </a>
+        )}
         <a
           href="/contact"
           className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white text-center rounded-md"


### PR DESCRIPTION
## Summary
- gate `media-kit` page behind Pro plan
- gate `Growth Plan` page behind Pro plan
- lock `Download Media Kit` button on profile page for free users
- restrict `/api/checkout` to Pro plan users

## Testing
- `npx turbo run lint` *(fails: command not found)*
- `npx tsc -p apps/creator/tsconfig.json --noEmit` *(fails: type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685807ad16ac832c84006d672ffef19a