### PR TITLE
Fix context errors in brand app

### DIFF
--- a/apps/brand/app/creator/[id]/profile.tsx
+++ b/apps/brand/app/creator/[id]/profile.tsx
@@ -1,3 +1,4 @@
+"use client";
 import creators from "@/app/data/mock_creators_200.json";
 import { notFound } from "next/navigation";
 import { useState } from "react";

--- a/apps/brand/app/layout.tsx
+++ b/apps/brand/app/layout.tsx
@@ -1,3 +1,4 @@
+"use client";
 import './globals.css';
 import type { ReactNode } from 'react';
 import { SessionProvider } from 'next-auth/react';

--- a/apps/brand/components/TagInput.tsx
+++ b/apps/brand/components/TagInput.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useState } from 'react';
 
 interface TagInputProps {


### PR DESCRIPTION
## Summary
- mark layout as a client component
- mark creator profile and tag input as client components

## Testing
- `npm run lint` *(fails: Next.js prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68598a3dd768832c99109848c5fbd125