### PR TITLE
Fix logo path in creator export API

### DIFF
--- a/apps/creator/app/api/export-lead-magnet/route.ts
+++ b/apps/creator/app/api/export-lead-magnet/route.ts
@@ -16,7 +16,9 @@ export async function POST(req: Request) {
     const cssPath = path.join(process.cwd(), 'apps', 'creator', 'app', 'api', 'export-lead-magnet', 'pdf.css')
     const css = fs.readFileSync(cssPath, 'utf8')
 
-    const logoPath = path.join(process.cwd(), 'apps', 'creator', 'public', 'siora-logo.svg')
+    // Resolve logo path relative to the current working directory so it works
+    // when the app is started from the `apps/creator` workspace
+    const logoPath = path.join(process.cwd(), 'public', 'siora-logo.svg')
     const logoSvg = fs.readFileSync(logoPath)
     const logoData = Buffer.from(logoSvg).toString('base64')
 


### PR DESCRIPTION
## Summary
- fix export API's path to the logo so dev server can find `siora-logo.svg`

## Testing
- `npm run lint -w apps/creator` *(fails: _no-unused-vars_, _no-explicit-any_, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68598d87eee0832c9af95a3e33e89f0e