### PR TITLE
Fix internal navigation and add shared nav component

### DIFF
--- a/apps/brand/app/campaigns/[id]/applications/page.tsx
+++ b/apps/brand/app/campaigns/[id]/applications/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import Toast from '@/components/Toast';
 import { creators } from '@/app/data/creators';
 
@@ -18,6 +18,7 @@ interface Application {
 export default function ApplicationsPage() {
   const params = useParams<{ id: string }>();
   const campaignId = params.id;
+  const router = useRouter();
   const [apps, setApps] = useState<Application[]>([]);
   const [toast, setToast] = useState('');
 
@@ -49,7 +50,7 @@ export default function ApplicationsPage() {
       });
       setApps((prev) => prev.filter((a) => a.id !== application.id));
       setToast('Application accepted');
-      window.location.href = `/campaigns/${campaignId}/messages/${application.userId}`;
+      router.push(`/campaigns/${campaignId}/messages/${application.userId}`);
     } catch {
       setToast('Failed to accept');
     }

--- a/apps/brand/app/layout.tsx
+++ b/apps/brand/app/layout.tsx
@@ -3,7 +3,14 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import { SessionProvider } from 'next-auth/react';
 import { BrandUserProvider } from '@/lib/brandUser';
-import { PageTransition } from 'shared-ui';
+import { PageTransition, Nav, NavLink } from 'shared-ui';
+
+const navLinks: NavLink[] = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/shortlist', label: 'Shortlist' },
+  { href: '/matches', label: 'Matches' },
+  { href: '/inbox', label: 'Inbox' },
+];
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
@@ -12,6 +19,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <SessionProvider>
           <BrandUserProvider>
             <main className="max-w-7xl mx-auto px-6 sm:px-8 py-10">
+              <Nav links={navLinks} />
               <PageTransition>{children}</PageTransition>
             </main>
           </BrandUserProvider>

--- a/apps/creator/app/contact/page.tsx
+++ b/apps/creator/app/contact/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+import { useSession } from "next-auth/react";
+
+export default function ContactPage() {
+  const { data } = useSession();
+  const email = data?.user?.email ?? "creator@example.com";
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center bg-background text-foreground p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Contact</h1>
+      <p>
+        Reach out via{' '}
+        <a href={`mailto:${email}`} className="underline text-indigo-600">
+          {email}
+        </a>
+      </p>
+    </main>
+  );
+}

--- a/apps/creator/app/growth-plan/page.tsx
+++ b/apps/creator/app/growth-plan/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
+import Link from "next/link";
 import { loadPersonasFromLocal, StoredPersona } from "@/lib/localPersonas";
 import type { PersonaProfile } from "@/types/persona";
 import type { GrowthPlan } from "@/types/growth";
@@ -139,9 +140,9 @@ export default function GrowthPlanPage() {
       <main className="min-h-screen flex flex-col items-center justify-center bg-background text-foreground p-6">
         <LockIcon className="w-8 h-8 mb-4" />
         <p className="mb-4">Alleen beschikbaar voor Pro-gebruikers.</p>
-        <a href="/subscribe" className="text-indigo-600 underline">
+        <Link href="/subscribe" className="text-indigo-600 underline">
           Upgrade naar Pro
-        </a>
+        </Link>
       </main>
     );
   }

--- a/apps/creator/app/layout.tsx
+++ b/apps/creator/app/layout.tsx
@@ -5,7 +5,7 @@ import Providers from './providers';
 import AuthStatus from '@/components/AuthStatus';
 import ThemeToggle from '@/components/ThemeToggle';
 import { ToastProvider } from '@/components/Toast';
-import { PageTransition } from 'shared-ui';
+import { PageTransition, Nav, NavLink } from 'shared-ui';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -13,6 +13,13 @@ export const metadata: Metadata = {
   title: 'Siora',
   description: 'Your identity, illuminated.',
 };
+
+const navLinks: NavLink[] = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/campaigns', label: 'Campaigns' },
+  { href: '/applications', label: 'Applications' },
+  { href: '/profile', label: 'Profile' },
+];
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
@@ -31,6 +38,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <ThemeToggle />
               <AuthStatus />
             </div>
+            <Nav links={navLinks} />
             <PageTransition>{children}</PageTransition>
           </ToastProvider>
         </Providers>

--- a/apps/creator/app/media-kit/page.tsx
+++ b/apps/creator/app/media-kit/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useSession } from "next-auth/react";
+import Link from "next/link";
 import { loadPersonasFromLocal, StoredPersona } from "@/lib/localPersonas";
 import type { PersonaProfile, FullPersona } from "@/types/persona";
 
@@ -46,9 +47,9 @@ export default function MediaKitPage() {
       <main className="min-h-screen flex flex-col items-center justify-center bg-background text-foreground p-6">
         <LockIcon className="w-8 h-8 mb-4" />
         <p className="mb-4">Alleen beschikbaar voor Pro-gebruikers.</p>
-        <a href="/subscribe" className="text-indigo-600 underline">
+        <Link href="/subscribe" className="text-indigo-600 underline">
           Upgrade naar Pro
-        </a>
+        </Link>
       </main>
     );
   }

--- a/apps/creator/app/profile/page.tsx
+++ b/apps/creator/app/profile/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { jsPDF } from "jspdf";
 import { useSession } from "next-auth/react";
+import Link from "next/link";
 import { loadPersonasFromLocal, StoredPersona } from "@/lib/localPersonas";
 import type { FullPersona } from "@/types/persona";
 
@@ -171,19 +172,19 @@ export default function ProfilePage() {
             Download Media Kit
           </button>
         ) : (
-          <a
+          <Link
             href="/subscribe"
             className="px-4 py-2 bg-indigo-600 text-white rounded-md flex items-center gap-2 justify-center"
           >
             <LockIcon className="w-4 h-4" /> Pro only
-          </a>
+          </Link>
         )}
-        <a
+        <Link
           href="/contact"
           className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 text-white text-center rounded-md"
         >
           Work with me
-        </a>
+        </Link>
       </div>
     </main>
   );

--- a/packages/shared-ui/src/Nav.tsx
+++ b/packages/shared-ui/src/Nav.tsx
@@ -1,0 +1,29 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export interface NavLink {
+  href: string;
+  label: string;
+}
+
+export function Nav({ links }: { links: NavLink[] }) {
+  const pathname = usePathname();
+  return (
+    <nav className="flex gap-4 text-sm mb-6">
+      {links.map((l) => (
+        <Link
+          key={l.href}
+          href={l.href}
+          className={
+            pathname === l.href
+              ? "underline font-semibold"
+              : "underline"
+          }
+        >
+          {l.label}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -1,3 +1,5 @@
 export * from './ChatPanel';
 export * from './Badge';
 export * from './PageTransition';
+
+export * from "./Nav";


### PR DESCRIPTION
## Summary
- add a reusable `<Nav>` component in `shared-ui`
- use `<Nav>` in creator and brand layouts
- replace hardcoded anchor tags with `Link`
- fix internal redirect in brand campaign applications
- add missing `/contact` page for creators

## Testing
- `npm run lint -w apps/creator` *(fails: @typescript-eslint/no-unused-vars etc.)*
- `npm run lint -w apps/brand` *(fails: react-hooks/rules-of-hooks etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6859afc826e0832c9bfdae2ee3351724