### PR TITLE
Improve onboarding UX with loading states and transitions

### DIFF
--- a/apps/brand/app/creator/[id]/page.tsx
+++ b/apps/brand/app/creator/[id]/page.tsx
@@ -2,6 +2,8 @@ import { creators } from "@/app/data/creators";
 import { notFound } from "next/navigation";
 import PerformanceTab from "@/components/PerformanceTab";
 import CreatorMetrics from "@/components/CreatorMetrics";
+import { Suspense } from "react";
+import { Spinner } from "shared-ui";
 
 type Props = {
   params: {
@@ -59,8 +61,12 @@ export default function CreatorProfile({ params }: Props) {
 
         <div>
           <h2 className="text-lg font-semibold mb-2">Performance</h2>
-          <CreatorMetrics creatorId={creator.id} />
-          <PerformanceTab creatorId={creator.id} />
+          <Suspense fallback={<Spinner />}>
+            <CreatorMetrics creatorId={creator.id} />
+          </Suspense>
+          <Suspense fallback={<Spinner />}>
+            <PerformanceTab creatorId={creator.id} />
+          </Suspense>
         </div>
       </div>
     </main>

--- a/apps/brand/app/onboarding/page.tsx
+++ b/apps/brand/app/onboarding/page.tsx
@@ -1,12 +1,10 @@
 "use client";
 
 import { useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import { useRouter } from "next/navigation";
 import type { BrandOnboardResult } from "@/types/onboard";
-import {
-  campaignTemplates,
-  type CampaignTemplate,
-} from "@/app/data/campaignTemplates";
+import { campaignTemplates, type CampaignTemplate } from "@/app/data/campaignTemplates";
 
 export default function BrandOnboarding() {
   const router = useRouter();
@@ -101,11 +99,10 @@ export default function BrandOnboarding() {
     setStep((s) => Math.max(0, s - 1));
   };
 
-  return (
-    <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
-      <div className="max-w-xl mx-auto bg-Siora-mid p-6 rounded-2xl space-y-4">
-        <h1 className="text-2xl font-bold mb-2">Brand Onboarding</h1>
-        {step === 0 && (
+  function renderStep() {
+    switch (step) {
+      case 0:
+        return (
           <div className="space-y-3">
             {campaignTemplates.map((t) => (
               <button
@@ -124,8 +121,9 @@ export default function BrandOnboarding() {
               Start from Scratch
             </button>
           </div>
-        )}
-        {step === 1 && (
+        );
+      case 1:
+        return (
           <input
             name="name"
             value={form.name}
@@ -133,8 +131,9 @@ export default function BrandOnboarding() {
             placeholder="Brand name"
             className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
           />
-        )}
-        {step === 2 && (
+        );
+      case 2:
+        return (
           <textarea
             name="goals"
             value={form.goals}
@@ -142,8 +141,9 @@ export default function BrandOnboarding() {
             placeholder="Campaign goals"
             className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
           />
-        )}
-        {step === 3 && (
+        );
+      case 3:
+        return (
           <textarea
             name="product"
             value={form.product}
@@ -151,8 +151,9 @@ export default function BrandOnboarding() {
             placeholder="Product information"
             className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
           />
-        )}
-        {step === 4 && (
+        );
+      case 4:
+        return (
           <input
             name="creators"
             value={form.creators}
@@ -160,8 +161,9 @@ export default function BrandOnboarding() {
             placeholder="Ideal creator type"
             className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
           />
-        )}
-        {step === 5 && (
+        );
+      case 5:
+        return (
           <input
             name="budget"
             value={form.budget}
@@ -169,36 +171,60 @@ export default function BrandOnboarding() {
             placeholder="Budget range"
             className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
           />
-        )}
-        {step === 6 && summary && (
-          <div className="space-y-3">
-            <textarea
-              value={summary.mission}
-              onChange={(e) => setSummary({ ...summary, mission: e.target.value })}
-              className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
-            />
-            <input
-              value={summary.creatorTraits.join(", ")}
-              onChange={(e) =>
-                setSummary({
-                  ...summary,
-                  creatorTraits: e.target.value.split(/,|\n/).map((s) => s.trim()).filter(Boolean),
-                })
-              }
-              className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
-            />
-            <input
-              value={summary.platformFormat}
-              onChange={(e) => setSummary({ ...summary, platformFormat: e.target.value })}
-              className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
-            />
-            <textarea
-              value={summary.pitch}
-              onChange={(e) => setSummary({ ...summary, pitch: e.target.value })}
-              className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
-            />
-          </div>
-        )}
+        );
+      case 6:
+        return (
+          summary && (
+            <div className="space-y-3">
+              <textarea
+                value={summary.mission}
+                onChange={(e) => setSummary({ ...summary, mission: e.target.value })}
+                className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
+              />
+              <input
+                value={summary.creatorTraits.join(", ")}
+                onChange={(e) =>
+                  setSummary({
+                    ...summary,
+                    creatorTraits: e.target.value
+                      .split(/,|\n/)
+                      .map((s) => s.trim())
+                      .filter(Boolean),
+                  })
+                }
+                className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
+              />
+              <input
+                value={summary.platformFormat}
+                onChange={(e) => setSummary({ ...summary, platformFormat: e.target.value })}
+                className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
+              />
+              <textarea
+                value={summary.pitch}
+                onChange={(e) => setSummary({ ...summary, pitch: e.target.value })}
+                className="w-full p-2 rounded-lg bg-Siora-light text-white border border-Siora-border"
+              />
+            </div>
+          )
+        );
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
+      <div className="max-w-xl mx-auto bg-Siora-mid p-6 rounded-2xl space-y-4">
+        <h1 className="text-2xl font-bold mb-2">Brand Onboarding</h1>
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={step}
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -20 }}
+            transition={{ duration: 0.3 }}
+          >
+            {renderStep()}
+          </motion.div>
+        </AnimatePresence>
         <div className="flex justify-between pt-4">
           {step > 0 && step < 6 && (
             <button onClick={prev} className="px-4 py-2 bg-gray-700 rounded">

--- a/apps/brand/components/CreatorMetrics.tsx
+++ b/apps/brand/components/CreatorMetrics.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { Spinner } from "shared-ui";
 
 type Props = {
   creatorId: string;
@@ -32,7 +33,7 @@ export default function CreatorMetrics({ creatorId }: Props) {
   }, [creatorId]);
 
   if (!data) {
-    return <p className="text-sm text-zinc-400">Loading metrics...</p>;
+    return <Spinner />;
   }
 
   return (

--- a/apps/brand/components/PerformanceTab.tsx
+++ b/apps/brand/components/PerformanceTab.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { Spinner } from "shared-ui";
 import { Pie } from "react-chartjs-2";
 import {
   Chart as ChartJS,
@@ -53,7 +54,7 @@ export default function PerformanceTab({ creatorId }: Props) {
   }, [creatorId]);
 
   if (!data) {
-    return <p className="text-sm text-zinc-400">Loading performance...</p>;
+    return <Spinner />;
   }
 
   const trendUp = data.followerGrowth >= 0;

--- a/apps/creator/app/applications/page.tsx
+++ b/apps/creator/app/applications/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import campaigns from "@/app/data/campaigns";
+import { Spinner } from "shared-ui";
 
 interface Application {
   id: string;
@@ -34,7 +35,11 @@ export default function ApplicationsPage() {
     <main className="min-h-screen bg-background text-foreground p-6 space-y-6">
       <h1 className="text-2xl font-bold">My Applications</h1>
       {apps.length === 0 ? (
-        <p className="text-foreground/60">{loading ? "Loading..." : "No applications found."}</p>
+        loading ? (
+          <Spinner />
+        ) : (
+          <p className="text-foreground/60">No applications found.</p>
+        )
       ) : (
         <div className="space-y-4">
           {apps.map((a) => {

--- a/apps/creator/app/onboarding/page.tsx
+++ b/apps/creator/app/onboarding/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import { AnimatePresence, motion } from "framer-motion";
 import { useRouter } from "next/navigation";
 import { trpc } from "@/lib/trpcClient";
 import styles from "../styles.module.css";
@@ -62,155 +63,170 @@ export default function CreatorOnboarding() {
     }
   }
 
+  function renderStep() {
+    switch (step) {
+      case 0:
+        return (
+          <div className={styles.formBox}>
+            <h1 className={styles.title}>Welcome to Siora</h1>
+            <p className={styles.subtitle}>Let's set up your creator profile.</p>
+            <div className={styles.controls}>
+              <button className={styles.submitButton} onClick={next}>Get Started</button>
+            </div>
+          </div>
+        );
+      case 1:
+        return (
+          <div className={styles.formBox}>
+            <h2 className={styles.title}>Profile Basics</h2>
+            <input
+              className={styles.input}
+              placeholder="Name"
+              value={data.name}
+              onChange={(e) => setData({ ...data, name: e.target.value })}
+            />
+            <input
+              className={styles.input}
+              placeholder="Handle"
+              value={data.handle}
+              onChange={(e) => setData({ ...data, handle: e.target.value })}
+            />
+            <input
+              className={styles.input}
+              placeholder="Follower count"
+              type="number"
+              value={data.followers || ""}
+              onChange={(e) => setData({ ...data, followers: Number(e.target.value) })}
+            />
+            <input
+              className={styles.input}
+              placeholder="Niche"
+              value={data.niche}
+              onChange={(e) => setData({ ...data, niche: e.target.value })}
+            />
+            <div className={styles.controls}>
+              <button className={styles.navButton} onClick={prev}>Back</button>
+              <button className={styles.submitButton} onClick={next}>Next</button>
+            </div>
+          </div>
+        );
+      case 2:
+        return (
+          <div className={styles.formBox}>
+            <h2 className={styles.title}>Choose Your Tone</h2>
+            <div className="flex flex-wrap gap-2 mb-4">
+              {toneOptions.map((t) => (
+                <button
+                  key={t}
+                  className={`${styles.navButton} ${data.tone === t ? styles.submitButton : ""}`}
+                  onClick={() => setData({ ...data, tone: t })}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+            <div className={styles.controls}>
+              <button className={styles.navButton} onClick={prev}>Back</button>
+              <button className={styles.submitButton} onClick={next} disabled={!data.tone}>Next</button>
+            </div>
+          </div>
+        );
+      case 3:
+        return (
+          <div className={styles.formBox}>
+            <h2 className={styles.title}>Values & Content</h2>
+            <div className="space-y-2 mb-4">
+              {valueOptions.map((v) => (
+                <label key={v} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={data.values.includes(v)}
+                    onChange={(e) => {
+                      setData((d) => ({
+                        ...d,
+                        values: e.target.checked ? [...d.values, v] : d.values.filter((val) => val !== v),
+                      }));
+                    }}
+                  />
+                  {v}
+                </label>
+              ))}
+            </div>
+            <input
+              className={styles.input}
+              placeholder="Primary content type"
+              value={data.contentType}
+              onChange={(e) => setData({ ...data, contentType: e.target.value })}
+            />
+            <div className={styles.controls}>
+              <button className={styles.navButton} onClick={prev}>Back</button>
+              <button className={styles.submitButton} onClick={next}>Next</button>
+            </div>
+          </div>
+        );
+      case 4:
+        return (
+          <div className={styles.formBox}>
+            <h2 className={styles.title}>Brand Persona</h2>
+            <textarea
+              className={styles.input}
+              rows={4}
+              placeholder="Describe your brand persona"
+              value={data.brandPersona}
+              onChange={(e) => setData({ ...data, brandPersona: e.target.value })}
+            />
+            <div className={styles.controls}>
+              <button className={styles.navButton} onClick={prev}>Back</button>
+              <button className={styles.submitButton} onClick={next} disabled={!data.brandPersona}>Next</button>
+            </div>
+          </div>
+        );
+      case 5:
+        return (
+          <div className={styles.formBox}>
+            <h2 className={styles.title}>Review & Confirm</h2>
+            <div className="text-sm space-y-2 mb-4">
+              <p><strong>Name:</strong> {data.name}</p>
+              <p><strong>Handle:</strong> {data.handle}</p>
+              <p><strong>Followers:</strong> {data.followers}</p>
+              <p><strong>Niche:</strong> {data.niche}</p>
+              <p><strong>Tone:</strong> {data.tone}</p>
+              <p><strong>Values:</strong> {data.values.join(', ') || '-'}</p>
+              <p><strong>Content Type:</strong> {data.contentType}</p>
+              <p><strong>Brand Persona:</strong> {data.brandPersona}</p>
+            </div>
+            <div className={styles.controls}>
+              <button className={styles.navButton} onClick={prev}>Back</button>
+              <button className={styles.submitButton} onClick={handleConfirm}>Confirm</button>
+            </div>
+          </div>
+        );
+      case 6:
+        return (
+          <div className={styles.formBox}>
+            <h2 className={styles.title}>All set!</h2>
+            <p className={styles.subtitle}>Your profile has been saved.</p>
+            <button className={styles.submitButton} onClick={() => router.push('/dashboard')}>
+              Start Dashboard
+            </button>
+          </div>
+        );
+    }
+  }
+
   return (
     <div className={styles.wrapper}>
-      {step === 0 && (
-        <div className={styles.formBox}>
-          <h1 className={styles.title}>Welcome to Siora</h1>
-          <p className={styles.subtitle}>Let's set up your creator profile.</p>
-          <div className={styles.controls}>
-            <button className={styles.submitButton} onClick={next}>Get Started</button>
-          </div>
-        </div>
-      )}
-
-      {step === 1 && (
-        <div className={styles.formBox}>
-          <h2 className={styles.title}>Profile Basics</h2>
-          <input
-            className={styles.input}
-            placeholder="Name"
-            value={data.name}
-            onChange={(e) => setData({ ...data, name: e.target.value })}
-          />
-          <input
-            className={styles.input}
-            placeholder="Handle"
-            value={data.handle}
-            onChange={(e) => setData({ ...data, handle: e.target.value })}
-          />
-          <input
-            className={styles.input}
-            placeholder="Follower count"
-            type="number"
-            value={data.followers || ""}
-            onChange={(e) => setData({ ...data, followers: Number(e.target.value) })}
-          />
-          <input
-            className={styles.input}
-            placeholder="Niche"
-            value={data.niche}
-            onChange={(e) => setData({ ...data, niche: e.target.value })}
-          />
-          <div className={styles.controls}>
-            <button className={styles.navButton} onClick={prev}>Back</button>
-            <button className={styles.submitButton} onClick={next}>Next</button>
-          </div>
-        </div>
-      )}
-
-      {step === 2 && (
-        <div className={styles.formBox}>
-          <h2 className={styles.title}>Choose Your Tone</h2>
-          <div className="flex flex-wrap gap-2 mb-4">
-            {toneOptions.map((t) => (
-              <button
-                key={t}
-                className={`${styles.navButton} ${data.tone === t ? styles.submitButton : ""}`}
-                onClick={() => setData({ ...data, tone: t })}
-              >
-                {t}
-              </button>
-            ))}
-          </div>
-          <div className={styles.controls}>
-            <button className={styles.navButton} onClick={prev}>Back</button>
-            <button className={styles.submitButton} onClick={next} disabled={!data.tone}>Next</button>
-          </div>
-        </div>
-      )}
-
-      {step === 3 && (
-        <div className={styles.formBox}>
-          <h2 className={styles.title}>Values & Content</h2>
-          <div className="space-y-2 mb-4">
-            {valueOptions.map((v) => (
-              <label key={v} className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={data.values.includes(v)}
-                  onChange={(e) => {
-                    setData((d) => ({
-                      ...d,
-                      values: e.target.checked
-                        ? [...d.values, v]
-                        : d.values.filter((val) => val !== v),
-                    }));
-                  }}
-                />
-                {v}
-              </label>
-            ))}
-          </div>
-          <input
-            className={styles.input}
-            placeholder="Primary content type"
-            value={data.contentType}
-            onChange={(e) => setData({ ...data, contentType: e.target.value })}
-          />
-          <div className={styles.controls}>
-            <button className={styles.navButton} onClick={prev}>Back</button>
-            <button className={styles.submitButton} onClick={next}>Next</button>
-          </div>
-        </div>
-      )}
-
-      {step === 4 && (
-        <div className={styles.formBox}>
-          <h2 className={styles.title}>Brand Persona</h2>
-          <textarea
-            className={styles.input}
-            rows={4}
-            placeholder="Describe your brand persona"
-            value={data.brandPersona}
-            onChange={(e) => setData({ ...data, brandPersona: e.target.value })}
-          />
-          <div className={styles.controls}>
-            <button className={styles.navButton} onClick={prev}>Back</button>
-            <button className={styles.submitButton} onClick={next} disabled={!data.brandPersona}>Next</button>
-          </div>
-        </div>
-      )}
-
-      {step === 5 && (
-        <div className={styles.formBox}>
-          <h2 className={styles.title}>Review & Confirm</h2>
-          <div className="text-sm space-y-2 mb-4">
-            <p><strong>Name:</strong> {data.name}</p>
-            <p><strong>Handle:</strong> {data.handle}</p>
-            <p><strong>Followers:</strong> {data.followers}</p>
-            <p><strong>Niche:</strong> {data.niche}</p>
-            <p><strong>Tone:</strong> {data.tone}</p>
-            <p><strong>Values:</strong> {data.values.join(', ') || '-'}</p>
-            <p><strong>Content Type:</strong> {data.contentType}</p>
-            <p><strong>Brand Persona:</strong> {data.brandPersona}</p>
-          </div>
-          <div className={styles.controls}>
-            <button className={styles.navButton} onClick={prev}>Back</button>
-            <button className={styles.submitButton} onClick={handleConfirm}>Confirm</button>
-          </div>
-        </div>
-      )}
-
-      {step === 6 && (
-        <div className={styles.formBox}>
-          <h2 className={styles.title}>All set!</h2>
-          <p className={styles.subtitle}>Your profile has been saved.</p>
-          <button className={styles.submitButton} onClick={() => router.push('/dashboard')}>
-            Start Dashboard
-          </button>
-        </div>
-      )}
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={step}
+          initial={{ opacity: 0, x: 20 }}
+          animate={{ opacity: 1, x: 0 }}
+          exit={{ opacity: 0, x: -20 }}
+          transition={{ duration: 0.3 }}
+        >
+          {renderStep()}
+        </motion.div>
+      </AnimatePresence>
     </div>
   );
 }

--- a/apps/creator/app/profile/page.tsx
+++ b/apps/creator/app/profile/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import { jsPDF } from "jspdf";
 import { useSession } from "next-auth/react";
+import { Spinner } from "shared-ui";
 import Link from "next/link";
 import { loadPersonasFromLocal, StoredPersona } from "@/lib/localPersonas";
 import type { FullPersona } from "@/types/persona";
@@ -62,7 +63,7 @@ export default function ProfilePage() {
   if (status === "loading") {
     return (
       <main className="min-h-screen flex items-center justify-center bg-background text-foreground p-6">
-        <p>Loading...</p>
+        <Spinner />
       </main>
     );
   }

--- a/apps/creator/components/AuthStatus.tsx
+++ b/apps/creator/components/AuthStatus.tsx
@@ -1,11 +1,12 @@
 "use client";
 import { signIn, signOut, useSession } from "next-auth/react";
+import { Spinner } from "shared-ui";
 
 export default function AuthStatus() {
   const { data: session, status } = useSession();
 
   if (status === "loading") {
-    return <p>Loading...</p>;
+    return <Spinner />;
   }
 
   if (!session) {

--- a/apps/creator/components/HookIdeas.tsx
+++ b/apps/creator/components/HookIdeas.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import { Spinner } from 'shared-ui'
 import type { PersonaProfile } from '@/types/persona'
 
 interface Props {
@@ -50,7 +51,7 @@ export default function HookIdeas({ persona }: Props) {
   return (
     <div className="border border-white/10 bg-background text-foreground p-4 rounded-xl space-y-3">
       <h3 className="text-lg font-bold">Top Hook Ideas</h3>
-      {loading && <p className="text-sm text-foreground/60">Generating hooks...</p>}
+      {loading && <Spinner />}
       {error && <p className="text-sm text-red-500">{error}</p>}
       <ul className="space-y-2">
         {hooks.map((hook, idx) => (

--- a/packages/shared-ui/src/Spinner.tsx
+++ b/packages/shared-ui/src/Spinner.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+export default function Spinner() {
+  return (
+    <div className="flex items-center justify-center py-10" aria-label="Loading">
+      <div className="h-6 w-6 border-4 border-current border-t-transparent rounded-full animate-spin" />
+    </div>
+  );
+}

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -2,4 +2,5 @@ export * from './ChatPanel';
 export * from './Badge';
 export * from './PageTransition';
 
+export { default as Spinner } from "./Spinner";
 export * from "./Nav";


### PR DESCRIPTION
## Summary
- add shared Spinner component
- wrap metrics components in Suspense with Spinner fallback
- replace text loaders with Spinner
- smooth onboarding flows with Framer Motion

## Testing
- `npm run lint` *(fails: turbo not found)*
- `npm ci` *(fails: dependency conflict)*

------
https://chatgpt.com/codex/tasks/task_e_685a7b61d788832c97a331cfa6c3cca3