### PR TITLE
Improve error handling

### DIFF
--- a/apps/brand/app/dashboard/suggested/page.tsx
+++ b/apps/brand/app/dashboard/suggested/page.tsx
@@ -19,6 +19,7 @@ export default function SuggestedCreators() {
   const [budget, setBudget] = useState("");
   const [results, setResults] = useState<MatchResult[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const { data: session } = useSession();
   const user = session?.user?.email ?? null;
@@ -26,6 +27,7 @@ export default function SuggestedCreators() {
 
   const submit = async () => {
     setLoading(true);
+    setError(null);
     try {
       const res = await fetch("/api/campaign-match", {
         method: "POST",
@@ -36,6 +38,7 @@ export default function SuggestedCreators() {
       setResults(Array.isArray(data.results) ? data.results : []);
     } catch (err) {
       console.error(err);
+      setError("Failed to fetch suggestions");
     } finally {
       setLoading(false);
     }
@@ -45,6 +48,7 @@ export default function SuggestedCreators() {
     <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
       <div className="max-w-7xl mx-auto space-y-8">
         <h1 className="text-4xl font-extrabold tracking-tight">Suggested Creators</h1>
+        {error && <p className="text-red-500">{error}</p>}
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
           <input
             value={niche}

--- a/apps/brand/app/error.tsx
+++ b/apps/brand/app/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useEffect } from "react";
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-6">
+      <h2 className="text-2xl font-bold mb-4">Something went wrong</h2>
+      <button
+        onClick={() => reset()}
+        className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/apps/brand/app/goal-dashboard/page.tsx
+++ b/apps/brand/app/goal-dashboard/page.tsx
@@ -17,9 +17,11 @@ export default function GoalDashboard() {
   const [matches, setMatches] = useState<Match[]>([]);
   const [sort, setSort] = useState<"score" | "name">("score");
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   async function fetchMatches() {
     setLoading(true);
+    setError(null);
     try {
       const res = await fetch("/api/goal-match", {
         method: "POST",
@@ -30,6 +32,7 @@ export default function GoalDashboard() {
       if (Array.isArray(data.matches)) setMatches(data.matches as Match[]);
     } catch (err) {
       console.error(err);
+      setError("Failed to fetch matches");
     } finally {
       setLoading(false);
     }
@@ -45,6 +48,9 @@ export default function GoalDashboard() {
     <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
       <div className="max-w-7xl mx-auto space-y-8">
         <h1 className="text-4xl font-extrabold tracking-tight">Campaign Matcher</h1>
+        {error && (
+          <p className="text-red-500">{error}</p>
+        )}
         <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
           <input value={goals} onChange={e => setGoals(e.target.value)} placeholder="Campaign goals" className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border" />
           <input value={tone} onChange={e => setTone(e.target.value)} placeholder="Tone" className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border" />

--- a/apps/brand/app/not-found.tsx
+++ b/apps/brand/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-6">
+      <h2 className="text-2xl font-bold mb-4">404 - Page Not Found</h2>
+      <p>The page you are looking for does not exist.</p>
+    </div>
+  );
+}

--- a/apps/creator/app/dashboard/page.tsx
+++ b/apps/creator/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import PersonaCard from "@/components/PersonaCard";
 import PerformanceMetrics from "@/components/PerformanceMetrics";
 import type { PersonaProfile } from "@/types/persona";
+import { useToast } from "@/components/Toast";
 
 interface PersonaRecord {
   id: string;
@@ -16,6 +17,7 @@ interface PersonaRecord {
 export default function DashboardPage() {
   const [items, setItems] = useState<PersonaRecord[]>([]);
   const [loading, setLoading] = useState(true);
+  const toast = useToast();
 
   useEffect(() => {
     async function load() {
@@ -27,6 +29,7 @@ export default function DashboardPage() {
         }
       } catch (err) {
         console.error("Failed to load personas", err);
+        toast("Failed to load personas");
       } finally {
         setLoading(false);
       }
@@ -41,6 +44,7 @@ export default function DashboardPage() {
       setItems((prev) => prev.filter((p) => p.id !== id));
     } catch (err) {
       console.error("Failed to delete persona", err);
+      toast("Failed to delete persona");
     }
   }
 

--- a/apps/creator/app/error.tsx
+++ b/apps/creator/app/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useEffect } from "react";
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-6">
+      <h2 className="text-2xl font-bold mb-4">Something went wrong</h2>
+      <button
+        onClick={() => reset()}
+        className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/apps/creator/app/not-found.tsx
+++ b/apps/creator/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-6">
+      <h2 className="text-2xl font-bold mb-4">404 - Page Not Found</h2>
+      <p>The page you are looking for does not exist.</p>
+    </div>
+  );
+}

--- a/apps/home/app/error.tsx
+++ b/apps/home/app/error.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { useEffect } from "react";
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-6">
+      <h2 className="text-2xl font-bold mb-4">Something went wrong</h2>
+      <button
+        onClick={() => reset()}
+        className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded"
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/apps/home/app/not-found.tsx
+++ b/apps/home/app/not-found.tsx
@@ -1,0 +1,8 @@
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center p-6">
+      <h2 className="text-2xl font-bold mb-4">404 - Page Not Found</h2>
+      <p>The page you are looking for does not exist.</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add default 404 and 500 pages to all apps
- show toast messages on creator dashboard errors
- surface brand dashboard errors to the user

## Testing
- `npm install --legacy-peer-deps`
- `npm run build` *(fails: Build failed because of webpack errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a7b89f14c832ca3654ab0d8fb3709