### PR TITLE
Fix onboarding and sign-in state issues

### DIFF
--- a/apps/brand/app/signin/page.tsx
+++ b/apps/brand/app/signin/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 import { signIn } from "next-auth/react";
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { useBrandUser } from "@/lib/brandUser";
 import Toast from "@/components/Toast";
 
 export default function SignInPage() {
+  const router = useRouter();
   const { setUser } = useBrandUser();
   const [email, setEmail] = useState("");
   const [toast, setToast] = useState("");
@@ -24,6 +26,7 @@ export default function SignInPage() {
     setSubmitting(true);
     setUser({ email });
     setToast("Signed in!");
+    router.push("/brands");
     setTimeout(() => setSubmitting(false), 1000);
   };
 

--- a/apps/creator/app/onboarding/page.tsx
+++ b/apps/creator/app/onboarding/page.tsx
@@ -57,7 +57,7 @@ export default function CreatorOnboarding() {
     try {
       await mutation.mutateAsync(data);
       localStorage.removeItem("creatorOnboarding");
-      setStep(5);
+      setStep(6);
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## Summary
- fix creator onboarding final step to show completion screen
- redirect brand sign-in to the brands dashboard

## Testing
- `npm run lint -w apps/brand` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a7ebc78dc832c95a86468925f372f