### PR TITLE
Fix ts-eslint plugin crash

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -48,6 +48,8 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^9.0.0",
     "eslint-config-next": "15.3.0",
+    "@typescript-eslint/eslint-plugin": "8.34.1",
+    "@typescript-eslint/parser": "8.34.1",
     "postcss": "^8.5.4",
     "tailwindcss": "^4.1.10",
     "typescript": "^5.4.0"


### PR DESCRIPTION
## Summary
- set explicit `@typescript-eslint` versions for the web app
- reinstall dependencies and run lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685afdb648d8832ca4896cb1c855415c