### PR TITLE
Enable dark mode with Vercel config

### DIFF
--- a/apps/web/app/creator/layout.tsx
+++ b/apps/web/app/creator/layout.tsx
@@ -23,7 +23,7 @@ const navLinks: NavLink[] = [
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className={`${inter.variable} dark`}>
+    <html lang="en" className={inter.variable}>
       <head>
         {/* Favicons */}
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
@@ -31,7 +31,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
         <link rel="manifest" href="/site.webmanifest" />
       </head>
-      <body className="bg-Siora-dark text-white font-sans antialiased min-h-screen">
+      <body className="font-sans antialiased min-h-screen bg-white text-black dark:bg-Siora-dark dark:text-white">
         <Providers>
           <ToastProvider>
             <div className="p-4 flex justify-between items-center">

--- a/apps/web/app/home/layout.tsx
+++ b/apps/web/app/home/layout.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react';
 import Providers from './providers';
 import AuthStatus from '@home/components/AuthStatus';
 import { PageTransition } from 'shared-ui';
+import { ThemeProvider } from '../providers';
 
 export const metadata = {
   title: 'Siora',
@@ -12,13 +13,15 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="font-sans">
-        <Providers>
-          <div className="p-4 flex justify-end">
-            <AuthStatus />
-          </div>
-          <PageTransition>{children}</PageTransition>
-        </Providers>
+      <body className="font-sans min-h-screen bg-white text-black dark:bg-Siora-dark dark:text-white">
+        <ThemeProvider>
+          <Providers>
+            <div className="p-4 flex justify-end">
+              <AuthStatus />
+            </div>
+            <PageTransition>{children}</PageTransition>
+          </Providers>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -6,6 +6,7 @@ import { SessionProvider } from 'next-auth/react';
 import { BrandUserProvider } from '../lib/brandUser';
 import TrpcProvider from './trpcProvider';
 import { PageTransition, Nav, NavLink } from 'shared-ui';
+import { ThemeProvider } from './providers';
 import * as React from 'react'
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
@@ -19,18 +20,20 @@ const navLinks: NavLink[] = [
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={`${inter.variable} dark`}>
-      <body className="bg-Siora-dark text-white font-sans antialiased min-h-screen">
-        <SessionProvider>
-          <BrandUserProvider>
-            <TrpcProvider>
-              <main className="max-w-7xl mx-auto px-6 sm:px-8 py-10">
-                <Nav links={navLinks} />
-                <PageTransition>{children}</PageTransition>
-              </main>
-            </TrpcProvider>
-          </BrandUserProvider>
-        </SessionProvider>
+    <html lang="en" className={inter.variable}>
+      <body className="font-sans antialiased min-h-screen bg-white text-black dark:bg-Siora-dark dark:text-white">
+        <ThemeProvider>
+          <SessionProvider>
+            <BrandUserProvider>
+              <TrpcProvider>
+                <main className="max-w-7xl mx-auto px-6 sm:px-8 py-10">
+                  <Nav links={navLinks} />
+                  <PageTransition>{children}</PageTransition>
+                </main>
+              </TrpcProvider>
+            </BrandUserProvider>
+          </SessionProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "buildCommand": "npm run build:web",
+  "devCommand": "npm run dev:web",
+  "outputDirectory": "apps/web/.next",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary
- wrap layouts with `ThemeProvider` so the UI can toggle dark mode
- cleanup body classes and rely on `dark:` utilities
- add `vercel.json` with project build configuration

## Testing
- `npm run lint`
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_687c1d770108832cb5643e3afcbb2764