### PR TITLE
Enable dark mode and Vercel config

### DIFF
--- a/apps/web/app/home/layout.tsx
+++ b/apps/web/app/home/layout.tsx
@@ -2,7 +2,7 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import Providers from './providers';
 import AuthStatus from '@home/components/AuthStatus';
-import { PageTransition } from 'shared-ui';
+import { PageTransition, ThemeToggle } from 'shared-ui';
 
 export const metadata = {
   title: 'Siora',
@@ -14,8 +14,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     <html lang="en">
       <body className="font-sans">
         <Providers>
-          <div className="p-4 flex justify-end">
+          <div className="p-4 flex justify-between">
             <AuthStatus />
+            <ThemeToggle />
           </div>
           <PageTransition>{children}</PageTransition>
         </Providers>

--- a/apps/web/app/home/providers.tsx
+++ b/apps/web/app/home/providers.tsx
@@ -1,7 +1,12 @@
 "use client";
 import { SessionProvider } from 'next-auth/react';
 import type { PropsWithChildren } from 'react';
+import { ThemeProvider } from '../providers';
 
 export default function Providers({ children }: PropsWithChildren) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <ThemeProvider>
+      <SessionProvider>{children}</SessionProvider>
+    </ThemeProvider>
+  );
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,7 +5,8 @@ import { Inter } from 'next/font/google';
 import { SessionProvider } from 'next-auth/react';
 import { BrandUserProvider } from '../lib/brandUser';
 import TrpcProvider from './trpcProvider';
-import { PageTransition, Nav, NavLink } from 'shared-ui';
+import { PageTransition, Nav, NavLink, ThemeToggle } from 'shared-ui';
+import { ThemeProvider } from './providers';
 import * as React from 'react'
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
@@ -19,18 +20,23 @@ const navLinks: NavLink[] = [
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className={`${inter.variable} dark`}>
+    <html lang="en" className={inter.variable}>
       <body className="min-h-screen bg-gradient-to-b from-Siora-dark via-Siora-mid to-Siora-light text-white font-sans antialiased">
-        <SessionProvider>
-          <BrandUserProvider>
-            <TrpcProvider>
-              <main className="max-w-7xl mx-auto px-6 sm:px-8 py-10">
-                <Nav links={navLinks} />
-                <PageTransition>{children}</PageTransition>
-              </main>
-            </TrpcProvider>
-          </BrandUserProvider>
-        </SessionProvider>
+        <ThemeProvider>
+          <SessionProvider>
+            <BrandUserProvider>
+              <TrpcProvider>
+                <main className="max-w-7xl mx-auto px-6 sm:px-8 py-10">
+                  <div className="flex justify-end mb-4">
+                    <ThemeToggle />
+                  </div>
+                  <Nav links={navLinks} />
+                  <PageTransition>{children}</PageTransition>
+                </main>
+              </TrpcProvider>
+            </BrandUserProvider>
+          </SessionProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/packages/shared-ui/src/ThemeToggle.tsx
+++ b/packages/shared-ui/src/ThemeToggle.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { Switch } from "@headlessui/react";
+import { useContext } from "react";
+import { ThemeContext } from "@/app/providers";
+
+export default function ThemeToggle() {
+  const { theme, toggle } = useContext(ThemeContext);
+  const enabled = theme === "dark";
+
+  return (
+    <Switch
+      checked={enabled}
+      onChange={toggle}
+      className={`${enabled ? "bg-indigo-600" : "bg-gray-200"} relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none`}
+    >
+      <span
+        className={`${enabled ? "translate-x-6" : "translate-x-1"} inline-block h-4 w-4 transform rounded-full bg-white transition`}
+      />
+    </Switch>
+  );
+}

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -4,3 +4,4 @@ export * from './PageTransition';
 
 export { default as Spinner } from "./Spinner";
 export * from "./Nav";
+export { default as ThemeToggle } from './ThemeToggle';

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "npm run vercel-build",
+  "outputDirectory": "apps/web/.next",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary
- add a ThemeToggle component to shared-ui
- wrap layouts with ThemeProvider so dark mode can be toggled
- expose ThemeToggle in shared-ui index
- add Vercel configuration file for deployment

## Testing
- `npm run lint`
- `npx turbo run build --filter=web` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_687c2146e654832ca003c50b688ace2b