### PR TITLE
Fix build script filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 
   "scripts": {
   "dev": "turbo run dev",
-  "build": "prisma generate --schema=./prisma/schema.prisma && turbo run build --filter=apps/web",
+  "build": "prisma generate --schema=./prisma/schema.prisma && turbo run build --filter=web",
   "dev:web": "npm run dev -w apps/web",
   "build:web": "prisma generate --schema=./prisma/schema.prisma && npm run build -w apps/web",
   "lint": "turbo run lint",


### PR DESCRIPTION
## Summary
- fix Turbo build command to reference workspace name `web`

## Testing
- `npm run build` (fails due to font download, but command executes)
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_687c244acc30832c8c2c34d6d874c3ec