### PR TITLE
Fix creator routes and add debug page

### DIFF
--- a/apps/web/app/404.tsx
+++ b/apps/web/app/404.tsx
@@ -1,0 +1,1 @@
+export { default } from './not-found'

--- a/apps/web/app/debug/pages/page.tsx
+++ b/apps/web/app/debug/pages/page.tsx
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import path from 'path';
+import Link from 'next/link';
+
+function collect(dir: string, base = ''): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const routes: string[] = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('_') || entry.name === 'components' || entry.name === 'lib') continue;
+    const full = path.join(dir, entry.name);
+    const rel = path.join(base, entry.name);
+    if (entry.isDirectory()) {
+      routes.push(...collect(full, rel));
+    } else if (entry.name === 'page.tsx' || entry.name === 'page.jsx') {
+      const route = '/' + base.replace(/\\index$/, '').replace(/\\/g, '/');
+      routes.push(route === '' ? '/' : route);
+    }
+  }
+  return routes;
+}
+
+export default function DebugPages() {
+  const root = path.join(process.cwd(), 'app');
+  const routes = collect(root).sort();
+  return (
+    <main className="min-h-screen p-6 space-y-4">
+      <h1 className="text-2xl font-bold">All Routes</h1>
+      <ul className="space-y-2 list-disc list-inside">
+        {routes.map((r) => (
+          <li key={r}>
+            <Link href={r}>{r}</Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -18,6 +18,12 @@ const navLinks: NavLink[] = [
   { href: "/inbox", label: "Inbox" },
 ];
 
+const devLinks: NavLink[] = [
+  { href: "/creator/persona", label: "Creator Persona" },
+  { href: "/creator/dashboard", label: "Creator Dashboard" },
+  { href: "/creator/profile", label: "Creator Profile" },
+];
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" className={`${inter.className} scroll-smooth`}>
@@ -36,6 +42,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                     <ThemeToggle />
                   </div>
                   <Nav links={navLinks} />
+                  <Nav links={devLinks} />
                   <PageTransition>{children}</PageTransition>
                 </main>
               </TrpcProvider>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "npx prisma generate --schema=../../prisma/schema.prisma && next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "postbuild": "node ../../tools/list_routes.mjs"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.17",

--- a/package.json
+++ b/package.json
@@ -4,13 +4,13 @@
   "packageManager": "pnpm@10.13.1",
   "workspaces": {
     "packages": [
-      "apps/web",
+      "apps/*",
       "packages/*"
     ]
   },
   "scripts": {
     "dev": "pnpm --filter web dev",
-    "build": "prisma generate --schema=./prisma/schema.prisma && turbo run build --filter=web",
+    "build": "prisma generate --schema=./prisma/schema.prisma && turbo run build --filter=web && pnpm --filter web run postbuild",
     "dev:web": "npm run dev -w apps/web",
     "build:web": "prisma generate --schema=./prisma/schema.prisma && npm run build -w apps/web",
     "lint": "turbo run lint",

--- a/tools/list_routes.mjs
+++ b/tools/list_routes.mjs
@@ -1,0 +1,23 @@
+import fs from 'fs';
+import path from 'path';
+
+function collect(dir, base = '') {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  let routes = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('_') || entry.name === 'components' || entry.name === 'lib') continue;
+    const rel = path.join(base, entry.name);
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      routes = routes.concat(collect(full, rel));
+    } else if (entry.name === 'page.tsx' || entry.name === 'page.jsx') {
+      const route = '/' + base.replace(/\\index$/, '').replace(/\\/g, '/');
+      routes.push(route === '' ? '/' : route);
+    }
+  }
+  return routes;
+}
+
+const root = path.join(process.cwd(), 'app');
+const routes = collect(root).sort();
+console.log('Built routes:\n' + routes.join('\n'));

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,11 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["apps/web/.next/**", "apps/web/dist/**"]
+      "outputs": [
+        "apps/web/.next/**",
+        "apps/web/dist/**",
+        "apps/creator/.next/**"
+      ]
     },
     "dev": {
       "cache": false

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,9 @@
 {
   "buildCommand": "pnpm build",
   "installCommand": "pnpm install --frozen-lockfile --strict-peer-dependencies",
-  "outputDirectory": ".next",
-  "framework": "nextjs"
+  "outputDirectory": "apps/web/.next",
+  "framework": "nextjs",
+  "rewrites": [
+    { "source": "/creator/:path*", "destination": "/creator/:path*" }
+  ]
 }


### PR DESCRIPTION
## Summary
- enable all apps as workspaces and run route list after build
- expose all build outputs in turbo
- adjust Vercel output directory and rewrites
- add Creator links to main layout
- include 404 page and `/debug/pages` route
- script to log built routes after build

## Testing
- `pnpm install`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_687f3f5d13a8832c9308196eb962502d