### PR TITLE
Add privacy and terms pages

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -16,6 +16,8 @@ const navLinks: NavLink[] = [
   { href: "/shortlist", label: "Shortlist" },
   { href: "/matches", label: "Matches" },
   { href: "/inbox", label: "Inbox" },
+  { href: "/privacy", label: "Privacy" },
+  { href: "/terms", label: "Terms" },
 ];
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/web/app/privacy/page.tsx
+++ b/apps/web/app/privacy/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy - Siora',
+  description: 'Learn how Siora collects and uses your data.',
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="min-h-screen bg-gray-900 text-white px-6 py-12">
+      <div className="prose prose-invert max-w-3xl mx-auto">
+        <h1>Privacy Policy</h1>
+        <p>Siora collects information you choose to share with us such as your Instagram details and account preferences. We also gather usage data so we can improve matchmaking between creators and brands.</p>
+        <p>We use this information only to operate and enhance the Siora platform. Your profile data helps us surface better creator matches and personalize your experience.</p>
+        <p>We never sell your personal data. Limited information is shared with trusted partners like Stripe for payment processing. These partners only receive the details required to provide their services.</p>
+        <p>You have full control over your information. You may request deletion of your data or update your preferences at any time by contacting us.</p>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/terms/page.tsx
+++ b/apps/web/app/terms/page.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service - Siora',
+  description: 'The terms governing use of the Siora platform.',
+};
+
+export default function TermsPage() {
+  return (
+    <main className="min-h-screen bg-gray-900 text-white px-6 py-12">
+      <div className="prose prose-invert max-w-3xl mx-auto">
+        <h1>Terms of Service</h1>
+        <p>By using Siora you agree to use the service responsibly and comply with all applicable laws. You are responsible for maintaining the security of your account.</p>
+        <p>All content on the platform is owned by Siora or its licensors. You may not copy or resell any part of the service without permission.</p>
+        <p>Payments are handled through Stripe and are subject to Stripe's terms. We are not liable for issues arising from Stripe's processing.</p>
+        <p>Siora is provided "as is" without warranties. We limit our liability to the fullest extent permitted by law.</p>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add Privacy Policy page
- add Terms of Service page
- surface links to Privacy and Terms in dashboard nav

## Testing
- `npm run lint -w apps/web`
- `CI=1 npm run build -w apps/web` *(fails: `phantomjs-prebuilt` module not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f49b3ed40832c8ab074d601343ee0