### PR TITLE
Add persona PDF export button

### DIFF
--- a/apps/creator/app/persona/page.tsx
+++ b/apps/creator/app/persona/page.tsx
@@ -74,6 +74,7 @@ export default function GeneratePersonaPage() {
                   niche,
                   highlights: goal,
                   handle,
+                  date: new Date().toLocaleDateString(),
                 }}
               />
             }
@@ -85,7 +86,7 @@ export default function GeneratePersonaPage() {
                 className="mt-4 bg-indigo-600 hover:bg-indigo-500 transition-colors duration-200 text-white px-4 py-2 rounded-md disabled:opacity-50"
                 disabled={pdfLoading}
               >
-                {pdfLoading ? 'Preparing...' : 'Download PDF'}
+                {pdfLoading ? 'Preparing...' : 'Download Persona PDF'}
               </button>
             )}
           </PDFDownloadLink>

--- a/components/pdf/PersonaPDF.tsx
+++ b/components/pdf/PersonaPDF.tsx
@@ -7,22 +7,25 @@ export interface PersonaData {
   niche: string
   highlights?: string
   handle?: string
+  date: string
 }
 
 const styles = StyleSheet.create({
   page: { padding: 32, fontFamily: 'Helvetica' },
-  header: { fontSize: 20, fontWeight: 'bold', textAlign: 'center', marginBottom: 16, color: '#4f46e5' },
+  header: { fontSize: 24, fontWeight: 'bold', textAlign: 'center', color: '#7c3aed' },
+  subHeader: { fontSize: 12, textAlign: 'center', marginBottom: 16, color: '#475569' },
   section: { marginBottom: 12 },
   label: { fontSize: 12, fontWeight: 'bold', marginBottom: 4 },
   text: { fontSize: 12, marginBottom: 4 },
 })
 
 export default function PersonaPDF({ data }: { data: PersonaData }) {
-  const { handle, persona, strengths, tone, niche, highlights } = data
+  const { handle, persona, strengths, tone, niche, highlights, date } = data
   return (
     <Document>
       <Page size="A4" style={styles.page}>
         <Text style={styles.header}>Siora Creator Persona</Text>
+        <Text style={styles.subHeader}>{date}{handle ? ` | ${handle}` : ''}</Text>
         {handle && (
           <View style={styles.section}>
             <Text style={styles.label}>Creator</Text>


### PR DESCRIPTION
## Summary
- include date in `PersonaPDF` and brand color header
- show "Download Persona PDF" button and pass date to PDF export

## Testing
- `pnpm lint` *(fails: Next.js ESLint config prompt)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_687f4f0e2e1c832c92ef3bd87c9cdb10