### PR TITLE
Add feedback flow

### DIFF
--- a/apps/brand/app/api/feedback/route.ts
+++ b/apps/brand/app/api/feedback/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+
+type FeedbackType = 'brand_to_creator' | 'creator_to_brand';
+interface Feedback {
+  id: string;
+  brandId: string;
+  creatorId: string;
+  rating: number;
+  communication: number;
+  reliability: number;
+  comments: string;
+  type: FeedbackType;
+  timestamp: string;
+}
+
+const DB_PATH = path.join(process.cwd(), '..', '..', 'db', 'feedback.json');
+
+async function readData(): Promise<Feedback[]> {
+  try {
+    const file = await fs.readFile(DB_PATH, 'utf8');
+    const data = JSON.parse(file);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeData(data: Feedback[]) {
+  await fs.writeFile(DB_PATH, JSON.stringify(data, null, 2));
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const creatorId = searchParams.get('creatorId');
+  const brandId = searchParams.get('brandId');
+  const data = await readData();
+  const filtered = data.filter(f => {
+    if (creatorId && f.creatorId !== creatorId) return false;
+    if (brandId && f.brandId !== brandId) return false;
+    return true;
+  });
+  return NextResponse.json(filtered);
+}
+
+export async function POST(req: Request) {
+  try {
+    const {
+      brandId,
+      creatorId,
+      rating,
+      communication,
+      reliability,
+      comments,
+      type,
+    } = await req.json();
+    if (!brandId || !creatorId) {
+      return NextResponse.json({ error: 'brandId and creatorId required' }, { status: 400 });
+    }
+    const numRating = Number(rating);
+    const numComm = Number(communication);
+    const numRel = Number(reliability);
+    if ([numRating, numComm, numRel].some(n => Number.isNaN(n) || n < 1 || n > 5)) {
+      return NextResponse.json({ error: 'ratings must be 1-5' }, { status: 400 });
+    }
+    const entry: Feedback = {
+      id: randomUUID(),
+      brandId,
+      creatorId,
+      rating: numRating,
+      communication: numComm,
+      reliability: numRel,
+      comments: comments || '',
+      type: type === 'creator_to_brand' ? 'creator_to_brand' : 'brand_to_creator',
+      timestamp: new Date().toISOString(),
+    };
+    const data = await readData();
+    data.push(entry);
+    await writeData(data);
+    return NextResponse.json(entry);
+  } catch (err) {
+    console.error('feedback save error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/apps/brand/app/feedback/[creatorId]/page.tsx
+++ b/apps/brand/app/feedback/[creatorId]/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+import { useState, useEffect } from 'react';
+import creators from "../../../../web/app/data/mock_creators_200.json";
+
+export default function CreatorFeedback({ params }: { params: { creatorId: string } }) {
+  const creator = (creators as any[]).find(c => c.id === params.creatorId);
+  const [rating, setRating] = useState(5);
+  const [communication, setCommunication] = useState(5);
+  const [reliability, setReliability] = useState(5);
+  const [comments, setComments] = useState("");
+  const [existing, setExisting] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch(`/api/feedback?creatorId=${params.creatorId}`)
+      .then(res => res.json())
+      .then(data => Array.isArray(data) ? setExisting(data) : []);
+  }, [params.creatorId]);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        brandId: 'brand1',
+        creatorId: params.creatorId,
+        rating,
+        communication,
+        reliability,
+        comments,
+        type: 'brand_to_creator',
+      }),
+    });
+    setComments('');
+    const res = await fetch(`/api/feedback?creatorId=${params.creatorId}`);
+    const data = await res.json();
+    setExisting(Array.isArray(data) ? data : []);
+  };
+
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Feedback for {creator?.name ?? params.creatorId}</h1>
+      <form onSubmit={submit} className="space-y-3">
+        <label className="block">Overall Rating (1-5)
+          <input type="number" min="1" max="5" value={rating} onChange={e => setRating(Number(e.target.value))} className="w-full p-2 rounded bg-Siora-light text-white" />
+        </label>
+        <label className="block">Communication (1-5)
+          <input type="number" min="1" max="5" value={communication} onChange={e => setCommunication(Number(e.target.value))} className="w-full p-2 rounded bg-Siora-light text-white" />
+        </label>
+        <label className="block">Reliability (1-5)
+          <input type="number" min="1" max="5" value={reliability} onChange={e => setReliability(Number(e.target.value))} className="w-full p-2 rounded bg-Siora-light text-white" />
+        </label>
+        <label className="block">Comments
+          <textarea value={comments} onChange={e => setComments(e.target.value)} className="w-full p-2 rounded bg-Siora-light text-white" />
+        </label>
+        <button type="submit" className="px-4 py-2 bg-Siora-accent rounded">Submit</button>
+      </form>
+      {existing.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">Previous Feedback</h2>
+          <ul className="space-y-1 text-sm">
+            {existing.map(f => (
+              <li key={f.id} className="border-b border-white/20 pb-1">{f.comments} - {f.rating}/5</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/creator/app/api/feedback/route.ts
+++ b/apps/creator/app/api/feedback/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+
+type FeedbackType = 'brand_to_creator' | 'creator_to_brand';
+interface Feedback {
+  id: string;
+  brandId: string;
+  creatorId: string;
+  rating: number;
+  communication: number;
+  reliability: number;
+  comments: string;
+  type: FeedbackType;
+  timestamp: string;
+}
+
+const DB_PATH = path.join(process.cwd(), '..', '..', 'db', 'feedback.json');
+
+async function readData(): Promise<Feedback[]> {
+  try {
+    const file = await fs.readFile(DB_PATH, 'utf8');
+    const data = JSON.parse(file);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeData(data: Feedback[]) {
+  await fs.writeFile(DB_PATH, JSON.stringify(data, null, 2));
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const creatorId = searchParams.get('creatorId');
+  const brandId = searchParams.get('brandId');
+  const data = await readData();
+  const filtered = data.filter(f => {
+    if (creatorId && f.creatorId !== creatorId) return false;
+    if (brandId && f.brandId !== brandId) return false;
+    return true;
+  });
+  return NextResponse.json(filtered);
+}
+
+export async function POST(req: Request) {
+  try {
+    const {
+      brandId,
+      creatorId,
+      rating,
+      communication,
+      reliability,
+      comments,
+      type,
+    } = await req.json();
+    if (!brandId || !creatorId) {
+      return NextResponse.json({ error: 'brandId and creatorId required' }, { status: 400 });
+    }
+    const numRating = Number(rating);
+    const numComm = Number(communication);
+    const numRel = Number(reliability);
+    if ([numRating, numComm, numRel].some(n => Number.isNaN(n) || n < 1 || n > 5)) {
+      return NextResponse.json({ error: 'ratings must be 1-5' }, { status: 400 });
+    }
+    const entry: Feedback = {
+      id: randomUUID(),
+      brandId,
+      creatorId,
+      rating: numRating,
+      communication: numComm,
+      reliability: numRel,
+      comments: comments || '',
+      type: type === 'creator_to_brand' ? 'creator_to_brand' : 'brand_to_creator',
+      timestamp: new Date().toISOString(),
+    };
+    const data = await readData();
+    data.push(entry);
+    await writeData(data);
+    return NextResponse.json(entry);
+  } catch (err) {
+    console.error('feedback save error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/apps/creator/app/feedback/[brandId]/page.tsx
+++ b/apps/creator/app/feedback/[brandId]/page.tsx
@@ -1,0 +1,70 @@
+"use client";
+import { useState, useEffect } from 'react';
+import brands from "../../../../web/app/creator/data/mock_brands.json";
+
+export default function BrandFeedback({ params }: { params: { brandId: string } }) {
+  const brand = (brands as any[]).find(b => b.id === params.brandId);
+  const [rating, setRating] = useState(5);
+  const [communication, setCommunication] = useState(5);
+  const [reliability, setReliability] = useState(5);
+  const [comments, setComments] = useState("");
+  const [existing, setExisting] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch(`/api/feedback?brandId=${params.brandId}`)
+      .then(res => res.json())
+      .then(data => Array.isArray(data) ? setExisting(data) : []);
+  }, [params.brandId]);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        brandId: params.brandId,
+        creatorId: 'creator1',
+        rating,
+        communication,
+        reliability,
+        comments,
+        type: 'creator_to_brand',
+      }),
+    });
+    setComments('');
+    const res = await fetch(`/api/feedback?brandId=${params.brandId}`);
+    const data = await res.json();
+    setExisting(Array.isArray(data) ? data : []);
+  };
+
+  return (
+    <main className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Feedback for {brand?.name ?? params.brandId}</h1>
+      <form onSubmit={submit} className="space-y-3">
+        <label className="block">Overall Rating (1-5)
+          <input type="number" min="1" max="5" value={rating} onChange={e => setRating(Number(e.target.value))} className="w-full p-2 rounded bg-Siora-light text-white" />
+        </label>
+        <label className="block">Communication (1-5)
+          <input type="number" min="1" max="5" value={communication} onChange={e => setCommunication(Number(e.target.value))} className="w-full p-2 rounded bg-Siora-light text-white" />
+        </label>
+        <label className="block">Reliability (1-5)
+          <input type="number" min="1" max="5" value={reliability} onChange={e => setReliability(Number(e.target.value))} className="w-full p-2 rounded bg-Siora-light text-white" />
+        </label>
+        <label className="block">Comments
+          <textarea value={comments} onChange={e => setComments(e.target.value)} className="w-full p-2 rounded bg-Siora-light text-white" />
+        </label>
+        <button type="submit" className="px-4 py-2 bg-Siora-accent rounded">Submit</button>
+      </form>
+      {existing.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="text-xl font-semibold">Previous Feedback</h2>
+          <ul className="space-y-1 text-sm">
+            {existing.map(f => (
+              <li key={f.id} className="border-b border-white/20 pb-1">{f.comments} - {f.rating}/5</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/web/app/brands/[id]/page.tsx
+++ b/apps/web/app/brands/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import Link from "next/link";
 import personas from "@/app/data/mock_creators_200.json";
 import { notFound } from "next/navigation";
 import PerformanceTab from "@/components/PerformanceTab";
@@ -67,6 +68,12 @@ export default function PersonaProfile({ params }: any) {
             </>
           )}
           {tab === 'performance' && <PerformanceTab creatorId={persona.id.toString()} />}
+          <Link
+            href={`/feedback/${persona.id}`}
+            className="mt-4 inline-block px-3 py-1 bg-gray-700 text-white rounded"
+          >
+            Leave/View Feedback
+          </Link>
         </div>
       </div>
     </main>

--- a/apps/web/app/creator/[id]/profile.tsx
+++ b/apps/web/app/creator/[id]/profile.tsx
@@ -2,6 +2,7 @@
 import creators from "@/app/data/mock_creators_200.json";
 import { notFound } from "next/navigation";
 import { useState } from "react";
+import Link from "next/link";
 import PerformanceTab from "@/components/PerformanceTab";
 import ContractModal from "@/components/ContractModal";
 import EvaluationChecklistModal from "@/components/EvaluationChecklistModal";
@@ -77,6 +78,12 @@ export default function CreatorProfile({ params }: Props) {
           >
             Generate Evaluation Checklist
           </button>
+          <Link
+            href={`/feedback/${creator.id}`}
+            className="ml-4 mt-4 px-3 py-1 text-sm rounded bg-gray-700 text-white"
+          >
+            Leave/View Feedback
+          </Link>
         </div>
       </div>
       <ContractModal

--- a/apps/web/app/creator/brand-discovery/[id]/page.tsx
+++ b/apps/web/app/creator/brand-discovery/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useParams } from 'next/navigation';
 import Image from 'next/image';
+import Link from 'next/link';
 import { discoveryBrands } from '@creator/data/discoveryBrands';
 import { getBrandBadges, getBrandTrustScore } from 'shared-utils';
 import { Badge } from 'shared-ui';
@@ -57,6 +58,12 @@ export default function BrandProfile() {
           <li key={c}>{c}</li>
         ))}
       </ul>
+      <Link
+        href={`/creator/feedback/${brand.id}`}
+        className="inline-block mt-4 px-3 py-1 bg-gray-700 text-white rounded"
+      >
+        Leave/View Feedback
+      </Link>
     </main>
   );
 }

--- a/apps/web/app/creator/messages/[id]/page.tsx
+++ b/apps/web/app/creator/messages/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import brands from "@/app/creator/data/mock_brands.json";
 import { ChatPanel, ChatMessage } from "shared-ui";
 
@@ -79,6 +80,12 @@ export default function ChatPage({ params }: { params: { id: string } }) {
           onSend={send}
           sending={sending}
         />
+        <Link
+          href={`/creator/feedback/${brandId}`}
+          className="mt-4 px-3 py-1 text-sm rounded bg-gray-700 text-white self-start"
+        >
+          Leave/View Feedback
+        </Link>
       </div>
     </main>
   );

--- a/apps/web/app/messages/[creatorId]/page.tsx
+++ b/apps/web/app/messages/[creatorId]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import Link from "next/link";
 import creators from "@/app/data/mock_creators_200.json";
 import { ChatPanel, ChatMessage } from "shared-ui";
 
@@ -79,6 +80,12 @@ export default function ChatPage({
           onSend={send}
           sending={sending}
         />
+        <Link
+          href={`/feedback/${params.creatorId}`}
+          className="mt-4 px-3 py-1 text-sm rounded bg-gray-700 text-white self-start"
+        >
+          Leave/View Feedback
+        </Link>
       </div>
     </main>
   );


### PR DESCRIPTION
## Summary
- allow feedback saving via new API routes
- add creator feedback page for brands and brand feedback page for creators
- link feedback pages from profiles and threads

## Testing
- `npm run lint` *(fails: module not found '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_687f62ba84c8832cb79b255ac474504f