### PR TITLE
Add brand inbox messaging

### DIFF
--- a/apps/brand/app/api/applications/route.ts
+++ b/apps/brand/app/api/applications/route.ts
@@ -1,0 +1,84 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+interface Application {
+  id: string;
+  userId: string;
+  campaignId: string;
+  pitch?: string;
+  personaSummary?: string;
+  status: string;
+  timestamp: string;
+}
+
+const appsPath = path.join(process.cwd(), '..', '..', 'db', 'campaign_applications.json');
+const campaignsPath = path.join(process.cwd(), '..', '..', 'db', 'campaigns.json');
+
+async function readApps(): Promise<Application[]> {
+  try {
+    const file = await fs.readFile(appsPath, 'utf8');
+    const data = JSON.parse(file);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+async function readCampaigns(): Promise<any[]> {
+  try {
+    const file = await fs.readFile(campaignsPath, 'utf8');
+    const data = JSON.parse(file);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const brandId = searchParams.get('brandId');
+    const campaignId = searchParams.get('campaignId');
+    let apps = await readApps();
+
+    if (brandId) {
+      const campaigns = await readCampaigns();
+      const brandCampaignIds = campaigns
+        .map((c, i) => ({ id: (i + 1).toString(), ...c }))
+        .filter((c) => c.brandId === brandId)
+        .map((c) => c.id);
+      apps = apps.filter((a) => brandCampaignIds.includes(a.campaignId));
+    }
+
+    if (campaignId) {
+      apps = apps.filter((a) => a.campaignId === campaignId);
+    }
+
+    return NextResponse.json(apps);
+  } catch (err) {
+    console.error('brand applications GET error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}
+
+export async function PATCH(req: Request) {
+  try {
+    const { id, status } = await req.json();
+    if (!id || !status) {
+      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+    }
+    const apps = await readApps();
+    const idx = apps.findIndex((a) => a.id === id);
+    if (idx === -1) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    apps[idx].status = status;
+    await fs.writeFile(appsPath, JSON.stringify(apps, null, 2));
+    return NextResponse.json(apps[idx]);
+  } catch (err) {
+    console.error('brand applications PATCH error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}
+

--- a/apps/brand/app/api/messages/route.ts
+++ b/apps/brand/app/api/messages/route.ts
@@ -1,0 +1,72 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+interface Message {
+  senderId: string;
+  receiverId: string;
+  message: string;
+  timestamp: string;
+  read: boolean;
+}
+
+type MessageDB = Record<string, Message[]>;
+
+const DB_PATH = path.join(process.cwd(), '..', '..', 'db', 'messages.json');
+
+async function readData(): Promise<MessageDB> {
+  try {
+    const file = await fs.readFile(DB_PATH, 'utf8');
+    const data = JSON.parse(file);
+    return data && typeof data === 'object' ? data as MessageDB : {};
+  } catch {
+    return {};
+  }
+}
+
+async function writeData(data: MessageDB) {
+  await fs.writeFile(DB_PATH, JSON.stringify(data, null, 2));
+}
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const brandId = searchParams.get('brandId');
+    const creatorId = searchParams.get('creatorId');
+    if (!brandId || !creatorId) {
+      return NextResponse.json({ error: 'brandId and creatorId required' }, { status: 400 });
+    }
+    const data = await readData();
+    const key = `${brandId}_${creatorId}`;
+    const messages = data[key] ?? [];
+    return NextResponse.json({ messages });
+  } catch (err) {
+    console.error('messages GET error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}
+
+export async function POST(req: Request) {
+  try {
+    const { brandId, creatorId, senderId, receiverId, message } = await req.json();
+    if (!brandId || !creatorId || !senderId || !receiverId || !message) {
+      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+    }
+    const data = await readData();
+    const key = `${brandId}_${creatorId}`;
+    const entry = data[key] ?? [];
+    const newMessage: Message = {
+      senderId,
+      receiverId,
+      message,
+      timestamp: new Date().toISOString(),
+      read: false,
+    };
+    entry.push(newMessage);
+    data[key] = entry;
+    await writeData(data);
+    return NextResponse.json({ message: newMessage });
+  } catch (err) {
+    console.error('messages POST error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/apps/brand/app/inbox/page.tsx
+++ b/apps/brand/app/inbox/page.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { ChatPanel, ChatMessage } from "shared-ui";
+import { creators } from "../../../web/app/data/creators";
+
+interface Application {
+  id: string;
+  userId: string;
+  campaignId: string;
+  pitch?: string;
+  personaSummary?: string;
+  status: string;
+  timestamp: string;
+}
+
+interface CreatorInfo {
+  id: string;
+  name: string;
+}
+
+const brandId = "brand1"; // placeholder for auth
+
+export default function InboxPage() {
+  const [apps, setApps] = useState<Application[]>([]);
+  const [filter, setFilter] = useState("");
+  const [selected, setSelected] = useState<{ creatorId: string; campaignId: string } | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/applications`);
+        if (res.ok) {
+          const data = await res.json();
+          if (Array.isArray(data)) setApps(data as Application[]);
+        }
+      } catch (err) {
+        console.error("failed to load applications", err);
+      }
+    }
+    load();
+  }, []);
+
+  async function openChat(creatorId: string, campaignId: string) {
+    setSelected({ creatorId, campaignId });
+    try {
+      const res = await fetch(
+        `/api/messages?brandId=${brandId}&creatorId=${creatorId}`
+      );
+      if (res.ok) {
+        const data = await res.json();
+        if (Array.isArray(data.messages)) {
+          const mapped = data.messages.map((m: any, i: number) => ({
+            id: `${brandId}-${creatorId}-${i}`,
+            sender: m.senderId === brandId ? "brand" : "creator",
+            text: m.message,
+            timestamp: m.timestamp,
+            read: m.read,
+          }));
+          setMessages(mapped);
+        }
+      }
+    } catch (err) {
+      console.error("failed to load messages", err);
+    }
+  }
+
+  const send = async (text: string) => {
+    if (!selected) return;
+    const newMessage: ChatMessage = {
+      id: `local-${Date.now()}`,
+      sender: "brand",
+      text,
+      timestamp: new Date().toISOString(),
+      read: true,
+    };
+    setMessages((prev) => [...prev, newMessage]);
+    try {
+      await fetch(`/api/messages`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          brandId,
+          creatorId: selected.creatorId,
+          senderId: brandId,
+          receiverId: selected.creatorId,
+          message: text,
+        }),
+      });
+    } catch (err) {
+      console.error("failed to send", err);
+    }
+  };
+
+  const filtered = apps.filter(
+    (a) => !filter || a.campaignId === filter
+  );
+
+  const uniqueCreators = filtered.map((a) => ({
+    creatorId: a.userId,
+    campaignId: a.campaignId,
+    status: a.status,
+  }));
+
+  function getCreatorInfo(id: string): CreatorInfo | undefined {
+    return (creators as any[]).find((c) => c.id === id) as CreatorInfo | undefined;
+  }
+
+  return (
+    <main className="min-h-screen p-6 space-y-6">
+      <h1 className="text-3xl font-bold">Inbox</h1>
+      <input
+        placeholder="Filter by campaign"
+        value={filter}
+        onChange={(e) => setFilter(e.target.value)}
+        className="p-2 rounded bg-Siora-light text-white border border-Siora-border"
+      />
+      <div className="flex gap-6">
+        <aside className="w-64 space-y-2">
+          {uniqueCreators.map((c) => {
+            const info = getCreatorInfo(c.creatorId);
+            return (
+              <button
+                key={`${c.creatorId}-${c.campaignId}`}
+                onClick={() => openChat(c.creatorId, c.campaignId)}
+                className={`block w-full text-left px-4 py-2 rounded transition-colors ${
+                  selected?.creatorId === c.creatorId && selected.campaignId === c.campaignId
+                    ? "bg-Siora-accent"
+                    : "bg-Siora-light"
+                }`}
+              >
+                {info ? info.name : c.creatorId} - {c.status}
+              </button>
+            );
+          })}
+        </aside>
+        <section className="flex-1">
+          {selected ? (
+            <>
+              <h2 className="text-xl font-semibold mb-4">
+                Chat with {getCreatorInfo(selected.creatorId)?.name ?? selected.creatorId}
+              </h2>
+              <ChatPanel
+                messages={messages}
+                currentUser="brand"
+                onSend={send}
+              />
+            </>
+          ) : (
+            <p className="text-zinc-300">Select a creator to view messages.</p>
+          )}
+        </section>
+      </div>
+    </main>
+  );
+}
+

--- a/apps/brand/app/layout.tsx
+++ b/apps/brand/app/layout.tsx
@@ -6,6 +6,7 @@ import { Nav, NavLink, PageTransition, ThemeToggle } from "shared-ui";
 const navLinks: NavLink[] = [
   { href: "/dashboard", label: "Dashboard" },
   { href: "/create-brief", label: "Create Brief" },
+  { href: "/inbox", label: "Inbox" },
 ];
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/packages/shared-ui/src/ChatPanel.tsx
+++ b/packages/shared-ui/src/ChatPanel.tsx
@@ -8,6 +8,7 @@ export type ChatMessage = {
   text: string;
   timestamp: string;
   campaign?: string;
+  read?: boolean;
 };
 
 export interface ChatPanelProps {
@@ -48,6 +49,11 @@ export function ChatPanel({ messages, onSend, sending, currentUser }: ChatPanelP
                 className={`inline-block px-4 py-2 rounded-2xl border border-Siora-border ${m.sender === currentUser ? 'bg-Siora-accent' : 'bg-gray-700'}`}
               >
                 {m.text}
+                {m.sender === currentUser && (
+                  <span className="ml-2 text-xs">
+                    {m.read ? '✓' : '•'}
+                  </span>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- add brand inbox page with messaging and filtering
- show read/unread indicators in chat
- expose messages and applications API routes for brand
- link Inbox from brand navigation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_687f62c3e6f8832c93f26fe031337093