### PR TITLE
Add persona & campaign AI generation endpoints

### DIFF
--- a/apps/web/app/api/ai/generateBrief/route.ts
+++ b/apps/web/app/api/ai/generateBrief/route.ts
@@ -1,0 +1,65 @@
+export async function POST(req: Request) {
+  try {
+    const { goal, audience, budget } = await req.json();
+
+    if (!goal || !audience) {
+      return new Response(
+        JSON.stringify({ error: 'Goal and audience are required' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const userPrompt = [
+      `Goal: ${goal}`,
+      `Audience: ${audience}`,
+      budget ? `Budget: ${budget}` : undefined,
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    const messages = [
+      {
+        role: 'system',
+        content: [
+          'You generate short influencer campaign briefs.',
+          'Return ONLY JSON matching this TypeScript interface:',
+          '{ blurb: string; deliverables: string[]; kpis: string[] }',
+        ].join('\n'),
+      },
+      { role: 'user', content: userPrompt },
+    ];
+
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.7 }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return new Response(
+        JSON.stringify({ error: 'OpenAI error', details: errorText }),
+        { status: response.status, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const data = await response.json();
+    const content = data.choices?.[0]?.message?.content ?? '{}';
+    const brief = JSON.parse(content);
+
+    return new Response(JSON.stringify(brief), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    console.error('generateBrief error:', error);
+    return new Response(
+      JSON.stringify({ error: 'Unexpected error', details: message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/apps/web/app/api/ai/generatePersona/route.ts
+++ b/apps/web/app/api/ai/generatePersona/route.ts
@@ -1,0 +1,66 @@
+export async function POST(req: Request) {
+  try {
+    const { name, tone, values } = await req.json();
+
+    if (!tone || !values) {
+      return new Response(
+        JSON.stringify({ error: 'Values and tone are required' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const valuesStr = Array.isArray(values) ? values.join(', ') : String(values);
+    const userPrompt = [
+      name ? `Name: ${name}` : undefined,
+      `Tone: ${tone}`,
+      `Core values: ${valuesStr}`,
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    const messages = [
+      {
+        role: 'system',
+        content: [
+          'You craft concise brand personas for marketing teams.',
+          'Return ONLY JSON matching this TypeScript interface:',
+          '{ bio: string; tone: string; values: string[]; dos: string[]; donts: string[] }',
+        ].join('\n'),
+      },
+      { role: 'user', content: userPrompt },
+    ];
+
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.7 }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return new Response(
+        JSON.stringify({ error: 'OpenAI error', details: errorText }),
+        { status: response.status, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const data = await response.json();
+    const content = data.choices?.[0]?.message?.content ?? '{}';
+    const persona = JSON.parse(content);
+
+    return new Response(JSON.stringify(persona), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    console.error('generatePersona error:', error);
+    return new Response(
+      JSON.stringify({ error: 'Unexpected error', details: message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/apps/web/app/creator/page.tsx
+++ b/apps/web/app/creator/page.tsx
@@ -62,7 +62,7 @@ export default function Home() {
     
   
     try {
-      const res = await fetch("/api/generate", {
+      const res = await fetch("/api/ai/generatePersona", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/apps/web/app/creator/persona/[id]/edit/page.tsx
+++ b/apps/web/app/creator/persona/[id]/edit/page.tsx
@@ -82,7 +82,7 @@ export default function EditPersonaPage() {
     };
 
     try {
-      const res = await fetch('/api/generate', {
+      const res = await fetch('/api/ai/generatePersona', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -42,7 +42,7 @@ export default function BrandOnboarding() {
   const generateBrief = async () => {
     setLoading(true);
     try {
-      const res = await fetch("/api/brand-onboard", {
+      const res = await fetch("/api/ai/generateBrief", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/apps/web/types/ai.ts
+++ b/apps/web/types/ai.ts
@@ -1,0 +1,13 @@
+export type GeneratedPersona = {
+  bio: string;
+  tone: string;
+  values: string[];
+  dos: string[];
+  donts: string[];
+};
+
+export type GeneratedBrief = {
+  blurb: string;
+  deliverables: string[];
+  kpis: string[];
+};


### PR DESCRIPTION
## Summary
- add AI routes for persona and brief generation
- wire creator and onboarding forms to use new endpoints
- add `GeneratedPersona` and `GeneratedBrief` types

## Testing
- `pnpm install`
- `npm run lint` *(fails: numerous lint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_687f62e16de4832c95ea0192393f6477