### PR TITLE
Add creator explorer filters with Prisma

### DIFF
--- a/apps/web/app/explorer/actions.ts
+++ b/apps/web/app/explorer/actions.ts
@@ -1,0 +1,40 @@
+'use server'
+
+import { prisma } from '@/lib/auth'
+
+export async function getFilterOptions() {
+  const tones = await prisma.creatorProfile.findMany({
+    distinct: ['tone'],
+    select: { tone: true },
+  })
+  const personas = await prisma.creatorProfile.findMany({
+    distinct: ['brandPersona'],
+    select: { brandPersona: true },
+  })
+  return {
+    tones: tones.map(t => t.tone).filter(Boolean),
+    personaTypes: personas.map(p => p.brandPersona).filter(Boolean)
+  }
+}
+
+export interface FetchParams {
+  tone?: string
+  personaTypes?: string[]
+  sort?: 'match' | 'name'
+  page?: number
+}
+
+export async function fetchCreators({ tone, personaTypes, sort = 'match', page = 1 }: FetchParams) {
+  const where: any = {}
+  if (tone) where.tone = tone
+  if (personaTypes && personaTypes.length > 0) where.brandPersona = { in: personaTypes }
+
+  const orderBy = sort === 'name' ? { name: 'asc' } : { followers: 'desc' }
+
+  const [creators, total] = await Promise.all([
+    prisma.creatorProfile.findMany({ where, orderBy, take: 10, skip: (page - 1) * 10 }),
+    prisma.creatorProfile.count({ where })
+  ])
+
+  return { creators, total }
+}

--- a/apps/web/components/CreatorFilters.tsx
+++ b/apps/web/components/CreatorFilters.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { useEffect, useState } from "react";
+import Dropdown from "@/components/ui/dropdown";
+import Checkbox from "@/components/ui/checkbox";
+
+type Props = {
+  tones: string[];
+  personaTypes: string[];
+  onChange: (f: { tone: string; personaTypes: string[] }) => void;
+};
+
+export default function CreatorFilters({ tones, personaTypes, onChange }: Props) {
+  const [tone, setTone] = useState("");
+  const [types, setTypes] = useState<string[]>([]);
+
+  useEffect(() => {
+    onChange({ tone, personaTypes: types });
+  }, [tone, types, onChange]);
+
+  const toggleType = (t: string, checked: boolean) => {
+    setTypes((prev) =>
+      checked ? [...prev, t] : prev.filter((v) => v !== t)
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <Dropdown
+        value={tone}
+        onChange={(e) => setTone(e.target.value)}
+        className="w-full"
+      >
+        <option value="">All Tones</option>
+        {tones.map((t) => (
+          <option key={t} value={t}>
+            {t}
+          </option>
+        ))}
+      </Dropdown>
+      <div className="flex flex-wrap gap-2">
+        {personaTypes.map((p) => (
+          <label key={p} className="flex items-center gap-2 text-sm">
+            <Checkbox
+              checked={types.includes(p)}
+              onChange={(e) => toggleType(p, e.target.checked)}
+            />
+            {p}
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/ui/checkbox.tsx
+++ b/apps/web/components/ui/checkbox.tsx
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+export type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+  ({ className = "", ...props }, ref) => (
+    <input
+      ref={ref}
+      type="checkbox"
+      className={`h-4 w-4 rounded border border-Siora-border bg-Siora-light text-Siora-accent ${className}`}
+      {...props}
+    />
+  )
+);
+Checkbox.displayName = "Checkbox";
+
+export default Checkbox;

--- a/apps/web/components/ui/dropdown.tsx
+++ b/apps/web/components/ui/dropdown.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+export type DropdownProps = React.SelectHTMLAttributes<HTMLSelectElement>;
+
+export const Dropdown = React.forwardRef<HTMLSelectElement, DropdownProps>(
+  ({ className = "", children, ...props }, ref) => (
+    <select
+      ref={ref}
+      className={`p-2 rounded-lg bg-Siora-light text-white border border-Siora-border ${className}`}
+      {...props}
+    >
+      {children}
+    </select>
+  )
+);
+Dropdown.displayName = "Dropdown";
+
+export default Dropdown;


### PR DESCRIPTION
## Summary
- add minimal shadcn style checkbox and dropdown components
- create `CreatorFilters` component
- add server actions for querying creators via Prisma
- implement filtering, sorting and pagination in explorer

## Testing
- `pnpm install`
- `npm run lint -w apps/web`

------
https://chatgpt.com/codex/tasks/task_e_687f6668576c832c9649337336033c25