### PR TITLE
Add NextAuth with role support

### DIFF
--- a/apps/web/app/api/set-role/route.ts
+++ b/apps/web/app/api/set-role/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions, prisma } from "@/lib/auth";
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const { role } = await req.json();
+  if (role !== "creator" && role !== "brand") {
+    return new NextResponse("Invalid role", { status: 400 });
+  }
+
+  await prisma.user.update({ where: { id: session.user.id }, data: { role } });
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { creators } from "@/app/data/creators";
 import AdvancedFilterBar, { Filters } from "@/components/AdvancedFilterBar";
 import CreatorCard from "@/components/CreatorCard";
-import { useSession } from "next-auth/react";
+import { useSession, signIn } from "next-auth/react";
+import { useRouter } from "next/navigation";
 import { useShortlist } from "@/lib/shortlist";
 
 export default function Dashboard() {
@@ -22,8 +23,18 @@ export default function Dashboard() {
   });
   const [currentPage, setCurrentPage] = useState(1);
   const perPage = 12;
-  const { data: session } = useSession();
+  const router = useRouter();
+  const { data: session, status } = useSession();
   const user = session?.user?.email ?? null;
+
+  useEffect(() => {
+    if (status === "loading") return;
+    if (!session) {
+      signIn();
+    } else if ((session.user as { role?: string }).role !== "brand") {
+      router.replace("/select-role");
+    }
+  }, [status, session, router]);
   const { toggle, inShortlist } = useShortlist(user);
 
   const unique = (arr: (string | undefined)[]) =>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -5,6 +5,7 @@ import { SessionProvider } from "next-auth/react";
 import { BrandUserProvider } from "../lib/brandUser";
 import TrpcProvider from "./trpcProvider";
 import { PageTransition, Nav, NavLink, ThemeToggle } from 'shared-ui'
+import AuthStatus from '../components/AuthStatus'
 import { ThemeProvider } from "./providers";
 import * as React from "react";
 
@@ -34,7 +35,8 @@ export default function RootLayout({ children }: { children: ReactNode }) {
             <BrandUserProvider>
               <TrpcProvider>
                 <main className="max-w-7xl mx-auto px-6 sm:px-8 py-10">
-                  <div className="flex justify-end mb-4">
+                  <div className="flex justify-between mb-4">
+                    <AuthStatus />
                     <ThemeToggle />
                   </div>
                   <Nav links={navLinks} />

--- a/apps/web/app/signin/page.tsx
+++ b/apps/web/app/signin/page.tsx
@@ -16,6 +16,10 @@ export default function SignInPage() {
     signIn("google", { callbackUrl: "/select-role" });
   };
 
+  const handleGitHub = () => {
+    signIn("github", { callbackUrl: "/select-role" });
+  };
+
   const handleTemp = () => {
     if (submitting) return;
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -37,6 +41,12 @@ export default function SignInPage() {
         className="bg-Siora-accent text-white px-4 py-2 rounded"
       >
         Sign in with Google
+      </button>
+      <button
+        onClick={handleGitHub}
+        className="bg-Siora-accent text-white px-4 py-2 rounded"
+      >
+        Sign in with GitHub
       </button>
       <div className="flex items-center gap-2">
         <input

--- a/apps/web/components/AuthStatus.tsx
+++ b/apps/web/components/AuthStatus.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { signIn, signOut, useSession } from "next-auth/react";
+import { Spinner } from "shared-ui";
+
+export default function AuthStatus() {
+  const { data: session, status } = useSession();
+
+  if (status === "loading") return <Spinner />;
+
+  if (!session) {
+    return (
+      <button type="button" onClick={() => signIn()} className="text-sm underline">
+        Sign In
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <span>{session.user?.email}</span>
+      <button type="button" onClick={() => signOut()} className="underline">
+        Sign Out
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- configure NextAuth with Google and GitHub providers
- store session data in Prisma and persist user profile information
- add `/api/set-role` endpoint for role selection
- add AuthStatus component and show in layout
- gate dashboard route and show sign in/out options
- update sign-in page with GitHub button

## Testing
- `pnpm lint` *(fails: Unexpected any errors)*
- `npm run build:web`

------
https://chatgpt.com/codex/tasks/task_e_687f66910040832cbe2ce4299e956583