### PR TITLE
Add tabs-based onboarding with autosave

### DIFF
--- a/apps/creator/app/api/onboarding-complete/route.ts
+++ b/apps/creator/app/api/onboarding-complete/route.ts
@@ -1,0 +1,94 @@
+import { getServerSession } from 'next-auth';
+import { NextResponse } from 'next/server';
+import { authOptions, prisma } from '@lib/auth';
+import path from 'path';
+import { promises as fs } from 'fs';
+
+const DB_PATH = path.join(process.cwd(), '..', '..', 'db', 'creator_onboarding_drafts.json');
+
+interface Draft {
+  id: string;
+  userId: string;
+  progress: Record<string, any>;
+  updatedAt: string;
+}
+
+async function readDrafts(): Promise<Draft[]> {
+  try {
+    const file = await fs.readFile(DB_PATH, 'utf8');
+    const data = JSON.parse(file);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeDrafts(data: Draft[]) {
+  await fs.writeFile(DB_PATH, JSON.stringify(data, null, 2));
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { progress } = await req.json();
+  if (!progress || typeof progress !== 'object') {
+    return NextResponse.json({ error: 'Missing progress' }, { status: 400 });
+  }
+
+  const messages = [
+    {
+      role: 'system',
+      content:
+        'You are a branding expert that crafts short creator personas for brand collaborations.'
+    },
+    { role: 'user', content: JSON.stringify(progress) }
+  ];
+
+  const aiRes = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
+    },
+    body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.7 })
+  });
+
+  if (!aiRes.ok) {
+    const text = await aiRes.text();
+    return NextResponse.json({ error: 'OpenAI error', details: text }, { status: aiRes.status });
+  }
+
+  const data = await aiRes.json();
+  const persona = data.choices?.[0]?.message?.content ?? '';
+
+  await prisma.creatorProfile.create({
+    data: {
+      userId: session.user.id,
+      name: progress.name,
+      handle: progress.handle,
+      followers: Number(progress.followers) || 0,
+      niche: progress.niche,
+      tone: progress.tone,
+      values: progress.values ?? [],
+      contentType: progress.contentType,
+      brandPersona: persona
+    }
+  });
+
+  await prisma.persona.create({
+    data: {
+      userId: session.user.id,
+      title: 'Persona',
+      data: persona
+    }
+  });
+
+  const drafts = await readDrafts();
+  const filtered = drafts.filter(d => d.userId !== session.user.id);
+  await writeDrafts(filtered);
+
+  return NextResponse.json({ persona });
+}

--- a/apps/creator/app/api/onboarding-draft/route.ts
+++ b/apps/creator/app/api/onboarding-draft/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+import path from 'path';
+import { promises as fs } from 'fs';
+import { randomUUID } from 'crypto';
+
+interface Draft {
+  id: string;
+  userId: string;
+  progress: Record<string, any>;
+  updatedAt: string;
+}
+
+const DB_PATH = path.join(process.cwd(), '..', '..', 'db', 'creator_onboarding_drafts.json');
+
+async function readData(): Promise<Draft[]> {
+  try {
+    const file = await fs.readFile(DB_PATH, 'utf8');
+    const data = JSON.parse(file);
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+async function writeData(data: Draft[]) {
+  await fs.writeFile(DB_PATH, JSON.stringify(data, null, 2));
+}
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const userId = searchParams.get('userId');
+  if (!userId) {
+    return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
+  }
+
+  const data = await readData();
+  const draft = data.find((d) => d.userId === userId) || null;
+  return NextResponse.json({ draft });
+}
+
+export async function POST(req: Request) {
+  try {
+    const { userId, progress } = await req.json();
+    if (!userId || typeof progress !== 'object') {
+      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+    }
+
+    const data = await readData();
+    let draft = data.find((d) => d.userId === userId);
+    if (draft) {
+      draft.progress = progress;
+      draft.updatedAt = new Date().toISOString();
+    } else {
+      draft = { id: randomUUID(), userId, progress, updatedAt: new Date().toISOString() };
+      data.push(draft);
+    }
+    await writeData(data);
+    return NextResponse.json({ id: draft.id });
+  } catch (err) {
+    console.error('draft save error', err);
+    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+  }
+}

--- a/apps/creator/app/onboarding/page.tsx
+++ b/apps/creator/app/onboarding/page.tsx
@@ -1,0 +1,233 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import styles from "../styles.module.css";
+import { saveOnboardingDraft, loadOnboardingDraft } from "@/lib/localOnboarding";
+
+interface OnboardData {
+  name: string;
+  handle: string;
+  followers: number;
+  niche: string;
+  tone: string;
+  values: string[];
+  contentType: string;
+  brandPersona: string;
+}
+
+const toneOptions = ["Casual", "Professional", "Playful", "Bold"];
+const valueOptions = ["Authenticity", "Community", "Innovation", "Sustainability"];
+const steps = ["Start", "Basics", "Tone", "Values", "Persona", "Review"];
+
+export default function CreatorOnboarding() {
+  const router = useRouter();
+  const { data: session } = useSession();
+  const [step, setStep] = useState("0");
+  const [data, setData] = useState<OnboardData>({
+    name: "",
+    handle: "",
+    followers: 0,
+    niche: "",
+    tone: "",
+    values: [],
+    contentType: "",
+    brandPersona: "",
+  });
+
+  useEffect(() => {
+    const local = loadOnboardingDraft();
+    if (local) setData((d) => ({ ...d, ...local }));
+    if (session?.user?.id) {
+      fetch(`/api/onboarding-draft?userId=${session.user.id}`)
+        .then((res) => (res.ok ? res.json() : null))
+        .then((res) => {
+          if (res?.draft?.progress) {
+            setData((d) => ({ ...d, ...res.draft.progress }));
+          }
+        })
+        .catch(() => {});
+    }
+  }, [session]);
+
+  useEffect(() => {
+    saveOnboardingDraft(data);
+    if (session?.user?.id) {
+      fetch("/api/onboarding-draft", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: session.user.id, progress: data }),
+      }).catch(() => {});
+    }
+  }, [data, session]);
+
+  const handleConfirm = async () => {
+    const res = await fetch("/api/onboarding-complete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ progress: data }),
+    });
+    if (res.ok) {
+      localStorage.removeItem("onboardingProgress");
+      router.push("/dashboard");
+    }
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <Tabs value={step} onChange={setStep}>
+        <TabsList className="mb-4">
+          {steps.map((_, idx) => (
+            <TabsTrigger
+              key={idx}
+              value={idx.toString()}
+              current={step}
+              onChange={setStep}
+              className="flex-1"
+            >
+              {idx + 1}
+            </TabsTrigger>
+          ))}
+        </TabsList>
+
+        <TabsContent value="0" current={step}>
+          <div className={styles.formBox}>
+            <h1 className={styles.title}>Welcome to Siora</h1>
+            <p className={styles.subtitle}>Let's set up your creator profile.</p>
+            <div className={styles.controls}>
+              <button className={styles.submitButton} onClick={() => setStep("1")}>Get Started</button>
+            </div>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="1" current={step}>
+          <div className={styles.formBox}>
+            <h2 className={styles.title}>Profile Basics</h2>
+            <input
+              className={styles.input}
+              placeholder="Name"
+              value={data.name}
+              onChange={(e) => setData({ ...data, name: e.target.value })}
+            />
+            <input
+              className={styles.input}
+              placeholder="Handle"
+              value={data.handle}
+              onChange={(e) => setData({ ...data, handle: e.target.value })}
+            />
+            <input
+              className={styles.input}
+              placeholder="Follower count"
+              type="number"
+              value={data.followers || ""}
+              onChange={(e) => setData({ ...data, followers: Number(e.target.value) })}
+            />
+            <input
+              className={styles.input}
+              placeholder="Niche"
+              value={data.niche}
+              onChange={(e) => setData({ ...data, niche: e.target.value })}
+            />
+            <div className={styles.controls}>
+              <button className={styles.navButton} onClick={() => setStep("0")}>Back</button>
+              <button className={styles.submitButton} onClick={() => setStep("2")}>Next</button>
+            </div>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="2" current={step}>
+          <div className={styles.formBox}>
+            <h2 className={styles.title}>Choose Your Tone</h2>
+            <div className="flex flex-wrap gap-2 mb-4">
+              {toneOptions.map((t) => (
+                <button
+                  key={t}
+                  className={`${styles.navButton} ${data.tone === t ? styles.submitButton : ""}`}
+                  onClick={() => setData({ ...data, tone: t })}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+            <div className={styles.controls}>
+              <button className={styles.navButton} onClick={() => setStep("1")}>Back</button>
+              <button className={styles.submitButton} onClick={() => setStep("3")} disabled={!data.tone}>Next</button>
+            </div>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="3" current={step}>
+          <div className={styles.formBox}>
+            <h2 className={styles.title}>Values & Content</h2>
+            <div className="space-y-2 mb-4">
+              {valueOptions.map((v) => (
+                <label key={v} className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={data.values.includes(v)}
+                    onChange={(e) => {
+                      setData((d) => ({
+                        ...d,
+                        values: e.target.checked ? [...d.values, v] : d.values.filter((val) => val !== v),
+                      }));
+                    }}
+                  />
+                  {v}
+                </label>
+              ))}
+            </div>
+            <input
+              className={styles.input}
+              placeholder="Primary content type"
+              value={data.contentType}
+              onChange={(e) => setData({ ...data, contentType: e.target.value })}
+            />
+            <div className={styles.controls}>
+              <button className={styles.navButton} onClick={() => setStep("2")}>Back</button>
+              <button className={styles.submitButton} onClick={() => setStep("4")}>Next</button>
+            </div>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="4" current={step}>
+          <div className={styles.formBox}>
+            <h2 className={styles.title}>Brand Persona</h2>
+            <textarea
+              className={styles.input}
+              rows={4}
+              placeholder="Describe your brand persona"
+              value={data.brandPersona}
+              onChange={(e) => setData({ ...data, brandPersona: e.target.value })}
+            />
+            <div className={styles.controls}>
+              <button className={styles.navButton} onClick={() => setStep("3")}>Back</button>
+              <button className={styles.submitButton} onClick={() => setStep("5")} disabled={!data.brandPersona}>Next</button>
+            </div>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="5" current={step}>
+          <div className={styles.formBox}>
+            <h2 className={styles.title}>Review & Confirm</h2>
+            <div className="text-sm space-y-2 mb-4">
+              <p><strong>Name:</strong> {data.name}</p>
+              <p><strong>Handle:</strong> {data.handle}</p>
+              <p><strong>Followers:</strong> {data.followers}</p>
+              <p><strong>Niche:</strong> {data.niche}</p>
+              <p><strong>Tone:</strong> {data.tone}</p>
+              <p><strong>Values:</strong> {data.values.join(', ') || '-'}</p>
+              <p><strong>Content Type:</strong> {data.contentType}</p>
+              <p><strong>Brand Persona:</strong> {data.brandPersona}</p>
+            </div>
+            <div className={styles.controls}>
+              <button className={styles.navButton} onClick={() => setStep("4")}>Back</button>
+              <button className={styles.submitButton} onClick={handleConfirm}>Confirm</button>
+            </div>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/creator/components/ui/tabs.tsx
+++ b/apps/creator/components/ui/tabs.tsx
@@ -1,0 +1,51 @@
+"use client";
+import { ReactNode } from "react";
+
+interface TabsProps {
+  value: string;
+  onChange: (v: string) => void;
+  children: ReactNode;
+}
+
+export function Tabs({ value, onChange, children }: TabsProps) {
+  return <div data-current={value}>{children}</div>;
+}
+
+interface TabsListProps {
+  children: ReactNode;
+  className?: string;
+}
+export function TabsList({ children, className = "" }: TabsListProps) {
+  return <div className={`flex gap-2 ${className}`}>{children}</div>;
+}
+
+interface TabsTriggerProps {
+  value: string;
+  current: string;
+  onChange: (v: string) => void;
+  children: ReactNode;
+  className?: string;
+}
+export function TabsTrigger({ value, current, onChange, children, className = "" }: TabsTriggerProps) {
+  const active = current === value;
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(value)}
+      className={`${active ? "bg-indigo-600" : "bg-gray-700"} px-3 py-1 text-sm rounded-md text-white ${className}`}
+    >
+      {children}
+    </button>
+  );
+}
+
+interface TabsContentProps {
+  value: string;
+  current: string;
+  children: ReactNode;
+  className?: string;
+}
+export function TabsContent({ value, current, children, className = "" }: TabsContentProps) {
+  if (value !== current) return null;
+  return <div className={className}>{children}</div>;
+}

--- a/apps/creator/lib/localOnboarding.ts
+++ b/apps/creator/lib/localOnboarding.ts
@@ -1,0 +1,21 @@
+const STORAGE_KEY = 'onboardingProgress';
+
+export function saveOnboardingDraft(progress: Record<string, any>) {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(progress));
+  } catch (err) {
+    console.error('Failed to save onboarding draft', err);
+  }
+}
+
+export function loadOnboardingDraft(): Record<string, any> | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) return JSON.parse(stored) as Record<string, any>;
+  } catch (err) {
+    console.error('Failed to load onboarding draft', err);
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- integrate shadcn-like Tabs component for creator onboarding
- autosave onboarding progress locally and to `/db/creator_onboarding_drafts.json`
- create API route for saving drafts
- finalize onboarding by generating a GPT persona and creating the profile

## Testing
- `pnpm install`
- `npm run lint` *(fails: many repo-wide lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f69c3a914832c94683b12e1a5b848