### PR TITLE
Refactor web UI with shadcn components

### DIFF
--- a/apps/web/app/creator/onboarding/page.tsx
+++ b/apps/web/app/creator/onboarding/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useRouter } from "next/navigation";
 import styles from "../styles.module.css";
 
@@ -214,17 +215,24 @@ export default function CreatorOnboarding() {
 
   return (
     <div className={styles.wrapper}>
-      <AnimatePresence mode="wait">
-        <motion.div
-          key={step}
-          initial={{ opacity: 0, x: 20 }}
-          animate={{ opacity: 1, x: 0 }}
-          exit={{ opacity: 0, x: -20 }}
-          transition={{ duration: 0.3 }}
-        >
-          {renderStep()}
-        </motion.div>
-      </AnimatePresence>
+      <Tabs value={step.toString()} onValueChange={(v) => setStep(Number(v))}>
+        <TabsList className="mb-4 grid grid-cols-6 gap-1">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <TabsTrigger key={i} value={i.toString()}>{i + 1}</TabsTrigger>
+          ))}
+        </TabsList>
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={step}
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -20 }}
+            transition={{ duration: 0.3 }}
+          >
+            <TabsContent value={step.toString()}>{renderStep()}</TabsContent>
+          </motion.div>
+        </AnimatePresence>
+      </Tabs>
     </div>
   );
 }

--- a/apps/web/app/onboarding/page.tsx
+++ b/apps/web/app/onboarding/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { useRouter } from "next/navigation";
 import type { BrandOnboardResult } from "@/types/onboard";
 import { campaignTemplates, type CampaignTemplate } from "@/app/data/campaignTemplates";
@@ -214,17 +215,24 @@ export default function BrandOnboarding() {
     <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
       <div className="max-w-xl mx-auto bg-Siora-mid p-6 rounded-2xl space-y-4">
         <h1 className="text-2xl font-bold mb-2">Brand Onboarding</h1>
-        <AnimatePresence mode="wait">
-          <motion.div
-            key={step}
-            initial={{ opacity: 0, x: 20 }}
-            animate={{ opacity: 1, x: 0 }}
-            exit={{ opacity: 0, x: -20 }}
-            transition={{ duration: 0.3 }}
-          >
-            {renderStep()}
-          </motion.div>
-        </AnimatePresence>
+        <Tabs value={step.toString()} onValueChange={(v) => setStep(Number(v))}>
+          <TabsList className="mb-4 grid grid-cols-7 gap-1">
+            {Array.from({ length: 7 }).map((_, i) => (
+              <TabsTrigger key={i} value={i.toString()}>{i + 1}</TabsTrigger>
+            ))}
+          </TabsList>
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={step}
+              initial={{ opacity: 0, x: 20 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -20 }}
+              transition={{ duration: 0.3 }}
+            >
+              <TabsContent value={step.toString()}>{renderStep()}</TabsContent>
+            </motion.div>
+          </AnimatePresence>
+        </Tabs>
         <div className="flex justify-between pt-4">
           {step > 0 && step < 6 && (
             <button onClick={prev} className="px-4 py-2 bg-gray-700 rounded">

--- a/apps/web/components/CollabRequestModal.tsx
+++ b/apps/web/components/CollabRequestModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 
 type Props = {
   open: boolean;
@@ -11,7 +12,6 @@ export default function CollabRequestModal({ open, onClose, creator }: Props) {
   const [message, setMessage] = useState("");
   const [budget, setBudget] = useState("");
 
-  if (!open) return null;
 
   const handleSend = () => {
     // In a real app this would POST to an API.
@@ -20,11 +20,13 @@ export default function CollabRequestModal({ open, onClose, creator }: Props) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-Siora-mid border border-Siora-border rounded-xl p-6 w-96 space-y-4 shadow-Siora-hover">
-        <h2 className="text-xl font-semibold">
-          Request Collaboration with {creator}
-        </h2>
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="space-y-4">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-semibold">
+            Request Collaboration with {creator}
+          </DialogTitle>
+        </DialogHeader>
         <textarea
           value={message}
           onChange={(e) => setMessage(e.target.value)}
@@ -51,7 +53,7 @@ export default function CollabRequestModal({ open, onClose, creator }: Props) {
             Send
           </button>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/components/ContractModal.tsx
+++ b/apps/web/components/ContractModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 
 interface Props {
   open: boolean;
@@ -15,7 +16,6 @@ export default function ContractModal({ open, onClose, creatorName }: Props) {
   const [contract, setContract] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  if (!open) return null;
 
   const generate = async () => {
     setLoading(true);
@@ -47,9 +47,11 @@ export default function ContractModal({ open, onClose, creatorName }: Props) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-Siora-mid border border-Siora-border rounded-xl p-6 w-96 space-y-4 shadow-Siora-hover">
-        <h2 className="text-xl font-semibold">Generate Contract</h2>
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="space-y-4">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-semibold">Generate Contract</DialogTitle>
+        </DialogHeader>
         {!contract && (
           <>
             <input
@@ -118,7 +120,7 @@ export default function ContractModal({ open, onClose, creatorName }: Props) {
         >
           Close
         </button>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/components/CreatorCard.tsx
+++ b/apps/web/components/CreatorCard.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
+import { Card } from "@/components/ui/card";
 import type { Creator } from "@/app/data/creators";
 import { useState, useMemo, ReactNode } from "react";
 import { Badge } from "shared-ui";
@@ -107,8 +108,9 @@ export default function CreatorCard({ creator, onShortlist, shortlisted, childre
       whileHover={{ scale: 1.03 }}
       whileTap={{ scale: 0.97 }}
       transition={{ duration: 0.3 }}
-      className="group cursor-pointer bg-white dark:bg-Siora-mid border border-gray-300 dark:border-Siora-border rounded-2xl p-6 shadow-Siora-hover"
+      className="group cursor-pointer"
     >
+      <Card className="p-6">
       <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1 flex items-center gap-2">
         {creator.name}{" "}
         <span className="text-Siora-accent group-hover:text-Siora-accent-soft">
@@ -223,10 +225,7 @@ export default function CreatorCard({ creator, onShortlist, shortlisted, childre
         creatorName={creator.name}
       />
       {toast && <Toast message={toast} onClose={() => setToast('')} />}
+      </Card>
     </motion.div>
   );
 }
-
-
-
-  

--- a/apps/web/components/EvaluationChecklistModal.tsx
+++ b/apps/web/components/EvaluationChecklistModal.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 
 interface Props {
   open: boolean;
@@ -17,7 +18,6 @@ export default function EvaluationChecklistModal({
   const [loading, setLoading] = useState(false);
   const [markdown, setMarkdown] = useState<string | null>(null);
 
-  if (!open) return null;
 
   const generate = async () => {
     setLoading(true);
@@ -77,9 +77,11 @@ export default function EvaluationChecklistModal({
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-Siora-mid border border-Siora-border rounded-xl p-6 w-96 space-y-4 shadow-Siora-hover">
-        <h2 className="text-xl font-semibold">Evaluation Checklist for {creatorName}</h2>
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="space-y-4">
+        <DialogHeader>
+          <DialogTitle className="text-xl font-semibold">Evaluation Checklist for {creatorName}</DialogTitle>
+        </DialogHeader>
         {markdown && (
           <pre className="whitespace-pre-wrap text-sm border border-Siora-border p-2 rounded bg-Siora-light text-white">
             {markdown}
@@ -104,7 +106,7 @@ export default function EvaluationChecklistModal({
             Close
           </button>
         </div>
-      </div>
-    </div>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/components/ui/card.tsx
+++ b/apps/web/components/ui/card.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn('rounded-2xl border border-Siora-border bg-white dark:bg-Siora-mid shadow-Siora-hover', className)}
+    {...props}
+  />
+))
+Card.displayName = 'Card'

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -1,0 +1,50 @@
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+import { cn } from '@/lib/utils'
+
+export const Dialog = DialogPrimitive.Root
+export const DialogTrigger = DialogPrimitive.Trigger
+
+export function DialogPortal({ children }: { children: React.ReactNode }) {
+  return <DialogPrimitive.Portal>{children}</DialogPrimitive.Portal>
+}
+
+export const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn('fixed inset-0 bg-black/50 backdrop-blur-sm', className)}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+export const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'fixed z-50 w-96 max-w-full bg-Siora-mid border border-Siora-border p-6 rounded-xl shadow-Siora-hover text-white top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+export const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
+)
+
+export const DialogTitle = DialogPrimitive.Title
+export const DialogDescription = DialogPrimitive.Description
+export const DialogClose = DialogPrimitive.Close

--- a/apps/web/components/ui/tabs.tsx
+++ b/apps/web/components/ui/tabs.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react'
+import * as TabsPrimitive from '@radix-ui/react-tabs'
+import { cn } from '@/lib/utils'
+
+export const Tabs = TabsPrimitive.Root
+export const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn('inline-flex items-center justify-center rounded-md bg-Siora-light p-1 text-white', className)}
+    {...props}
+  />
+))
+TabsList.displayName = TabsPrimitive.List.displayName
+
+export const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1 text-sm font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-Siora-accent data-[state=active]:text-white',
+      className
+    )}
+    {...props}
+  />
+))
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+
+export const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content ref={ref} className={cn('mt-2 focus-visible:outline-none', className)} {...props} />
+))
+TabsContent.displayName = TabsPrimitive.Content.displayName

--- a/apps/web/creator/components/CampaignCard.tsx
+++ b/apps/web/creator/components/CampaignCard.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import type { Campaign } from '@/app/data/campaigns';
+import { Card } from '@/components/ui/card';
 import { discoveryBrands } from '@creator/data/discoveryBrands';
 import { getBrandTrustScore } from 'shared-utils';
 
@@ -20,7 +21,7 @@ export default function CampaignCard({ campaign }: Props) {
   const trustColor =
     trust.score >= 80 ? 'bg-green-600' : trust.score >= 50 ? 'bg-yellow-500' : 'bg-red-600';
   return (
-    <div className="border border-white/10 bg-background p-4 rounded-lg space-y-2">
+    <Card className="border border-white/10 bg-background p-4 space-y-2">
       <h3 className="text-lg font-semibold">{campaign.title}</h3>
       <p className="text-sm text-foreground/80 flex items-center gap-2">
         {campaign.brand}
@@ -42,6 +43,6 @@ export default function CampaignCard({ campaign }: Props) {
       >
         View Brief
       </Link>
-    </div>
+    </Card>
   );
 }

--- a/apps/web/lib/utils.ts
+++ b/apps/web/lib/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: (string | undefined | null | false)[]): string {
+  return classes.filter(Boolean).join(' ');
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -38,6 +38,8 @@
     "shared-ui": "workspace:*",
     "shared-utils": "workspace:*",
     "stripe": "^18.2.1",
+    "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-tabs": "^1.1.12",
     "superjson": "^2.2.1",
     "zod": "^3.22.4"
   },


### PR DESCRIPTION
## Summary
- add Radix-based Dialog, Tabs and Card components for `shadcn/ui`
- switch CreatorCard and CampaignCard to new Card
- migrate modals to Dialog
- use Tabs for brand and creator onboarding flows
- add helper `cn` utility

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_687f6a557d64832c9fa9292ba5301e06