### PR TITLE
Add feedback link and embedded form

### DIFF
--- a/apps/web/app/feedback/page.tsx
+++ b/apps/web/app/feedback/page.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: 'Feedback - Siora',
+  description: 'Share your feedback with the Siora team.'
+}
+
+export default function FeedbackPage() {
+  return (
+    <main className="min-h-screen p-6">
+      <iframe
+        src="https://tally.so/r/xyz123"
+        className="w-full min-h-[80vh] rounded"
+        allowFullScreen
+      />
+    </main>
+  )
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -22,6 +22,7 @@ const navLinks: NavLink[] = [
   { href: "/billing", label: "Billing" },
   { href: "/privacy", label: "Privacy" },
   { href: "/terms", label: "Terms" },
+  { href: "https://tally.so/r/xyz123", label: "Feedback" },
 ];
 
 export default function RootLayout({ children }: { children: ReactNode }) {


### PR DESCRIPTION
## Summary
- add Feedback link in the dashboard navbar
- embed a Tally form at `/feedback`

## Testing
- `pnpm lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f6e926990832c934646b3277644a7