### PR TITLE
Improve GPT handling with shared util

### DIFF
--- a/apps/web/app/api/ai/feedback-summary/route.ts
+++ b/apps/web/app/api/ai/feedback-summary/route.ts
@@ -23,6 +23,8 @@ async function writeData(data: any[]) {
   await fs.writeFile(DB_PATH, JSON.stringify(data, null, 2));
 }
 
+import { callOpenAI } from 'shared-utils';
+
 export async function POST(req: Request) {
   try {
     const { id, text } = await req.json();
@@ -45,25 +47,7 @@ export async function POST(req: Request) {
       { role: 'user', content: text },
     ];
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-      },
-      body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.7 }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return new Response(
-        JSON.stringify({ error: 'OpenAI error', details: errorText }),
-        { status: response.status, headers: { 'Content-Type': 'application/json' } }
-      );
-    }
-
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content ?? '{}';
+    const content = await callOpenAI({ messages, temperature: 0.7, fallback: '{}' });
     const summary: FeedbackSummary = JSON.parse(content);
 
     const db = await readData();

--- a/apps/web/app/api/ai/generateBrief/route.ts
+++ b/apps/web/app/api/ai/generateBrief/route.ts
@@ -1,3 +1,5 @@
+import { callOpenAI } from 'shared-utils';
+
 export async function POST(req: Request) {
   try {
     const { goal, audience, budget } = await req.json();
@@ -29,25 +31,7 @@ export async function POST(req: Request) {
       { role: 'user', content: userPrompt },
     ];
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-      },
-      body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.7 }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return new Response(
-        JSON.stringify({ error: 'OpenAI error', details: errorText }),
-        { status: response.status, headers: { 'Content-Type': 'application/json' } }
-      );
-    }
-
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content ?? '{}';
+    const content = await callOpenAI({ messages, temperature: 0.7, fallback: '{}' });
     const brief = JSON.parse(content);
 
     return new Response(JSON.stringify(brief), {

--- a/apps/web/app/api/ai/generatePersona/route.ts
+++ b/apps/web/app/api/ai/generatePersona/route.ts
@@ -1,3 +1,5 @@
+import { callOpenAI } from 'shared-utils';
+
 export async function POST(req: Request) {
   try {
     const { name, tone, values } = await req.json();
@@ -30,25 +32,7 @@ export async function POST(req: Request) {
       { role: 'user', content: userPrompt },
     ];
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-      },
-      body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.7 }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return new Response(
-        JSON.stringify({ error: 'OpenAI error', details: errorText }),
-        { status: response.status, headers: { 'Content-Type': 'application/json' } }
-      );
-    }
-
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content ?? '{}';
+    const content = await callOpenAI({ messages, temperature: 0.7, fallback: '{}' });
     const persona = JSON.parse(content);
 
     return new Response(JSON.stringify(persona), {

--- a/apps/web/app/api/brand-onboard/route.ts
+++ b/apps/web/app/api/brand-onboard/route.ts
@@ -1,3 +1,5 @@
+import { callOpenAI } from 'shared-utils';
+
 export async function POST(req: Request) {
   try {
     const {
@@ -42,25 +44,7 @@ export async function POST(req: Request) {
       { role: "user", content: details },
     ];
 
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-      },
-      body: JSON.stringify({ model: "gpt-4", messages, temperature: 0.7 }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return new Response(
-        JSON.stringify({ error: "OpenAI error", details: errorText }),
-        { status: response.status, headers: { "Content-Type": "application/json" } }
-      );
-    }
-
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content ?? "{}";
+    const content = await callOpenAI({ messages, temperature: 0.7, fallback: '{}' });
     const result = JSON.parse(content);
 
     return new Response(JSON.stringify(result), {

--- a/apps/web/app/api/checklist/route.ts
+++ b/apps/web/app/api/checklist/route.ts
@@ -1,3 +1,5 @@
+import { callOpenAI } from 'shared-utils';
+
 export async function POST(req: Request) {
   try {
     const { description } = await req.json();
@@ -20,25 +22,7 @@ export async function POST(req: Request) {
       { role: 'user', content: description }
     ];
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
-      },
-      body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.7 })
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return new Response(
-        JSON.stringify({ error: 'OpenAI error', details: errorText }),
-        { status: response.status, headers: { 'Content-Type': 'application/json' } }
-      );
-    }
-
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content ?? '[]';
+    const content = await callOpenAI({ messages, temperature: 0.7, fallback: '[]' });
     const checklist = JSON.parse(content);
 
     return new Response(JSON.stringify({ checklist }), {

--- a/apps/web/app/api/contracts/generate/route.ts
+++ b/apps/web/app/api/contracts/generate/route.ts
@@ -1,3 +1,5 @@
+import { callOpenAI } from 'shared-utils';
+
 export async function POST(req: Request) {
   try {
     const {
@@ -46,25 +48,7 @@ export async function POST(req: Request) {
       { role: 'user', content: userPrompt },
     ];
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-      },
-      body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.5 }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return new Response(
-        JSON.stringify({ error: 'OpenAI error', details: errorText }),
-        { status: response.status, headers: { 'Content-Type': 'application/json' } }
-      );
-    }
-
-    const data = await response.json();
-    const contract = data.choices?.[0]?.message?.content ?? '';
+    const contract = await callOpenAI({ messages, temperature: 0.5, fallback: '' });
 
     return new Response(JSON.stringify({ contract }), {
       status: 200,

--- a/apps/web/app/api/evaluationChecklist/route.ts
+++ b/apps/web/app/api/evaluationChecklist/route.ts
@@ -1,3 +1,5 @@
+import { callOpenAI } from 'shared-utils';
+
 export async function POST(req: Request) {
   try {
     const { persona, campaign } = await req.json();
@@ -46,25 +48,7 @@ export async function POST(req: Request) {
       }
     ];
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
-      },
-      body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.7 })
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return new Response(
-        JSON.stringify({ error: 'OpenAI error', details: errorText }),
-        { status: response.status, headers: { 'Content-Type': 'application/json' } }
-      );
-    }
-
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content ?? '';
+    const content = await callOpenAI({ messages, temperature: 0.7, fallback: '' });
 
     return new Response(JSON.stringify({ checklist: content }), {
       status: 200,

--- a/apps/web/app/api/goal-match/route.ts
+++ b/apps/web/app/api/goal-match/route.ts
@@ -1,5 +1,6 @@
 import creators from '@/app/data/mock_creators_200.json';
 import { NextResponse } from 'next/server';
+import { callOpenAI } from 'shared-utils';
 
 interface GoalRequest {
   goals?: string;
@@ -72,17 +73,8 @@ export async function POST(req: Request) {
           content: `Campaign goals: ${body.goals || ''}; Tone: ${body.tone || ''}; Platform: ${body.platform || ''}; Audience: ${body.audience || ''}. Creators: ${top.map(t => `${t.creator.id}:${t.creator.name}`).join(', ')}`
         }
       ];
-      const res = await fetch('https://api.openai.com/v1/chat/completions', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
-        },
-        body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.7 })
-      });
-      if (res.ok) {
-        const data = await res.json();
-        const content = data.choices?.[0]?.message?.content || '[]';
+      const content = await callOpenAI({ messages, temperature: 0.7, fallback: '[]' });
+      if (content) {
         const arr = JSON.parse(content);
         if (Array.isArray(arr)) {
           for (const item of arr) {

--- a/apps/web/app/api/pitch/route.ts
+++ b/apps/web/app/api/pitch/route.ts
@@ -1,4 +1,5 @@
 import type { PitchResult } from "@/types/pitch";
+import { callOpenAI } from 'shared-utils';
 
 export async function POST(req: Request) {
   try {
@@ -36,25 +37,7 @@ export async function POST(req: Request) {
       },
     ];
 
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-      },
-      body: JSON.stringify({ model: "gpt-4", messages, temperature: 0.7 }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return new Response(
-        JSON.stringify({ error: "OpenAI error", details: errorText }),
-        { status: response.status, headers: { "Content-Type": "application/json" } }
-      );
-    }
-
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content ?? "{}";
+    const content = await callOpenAI({ messages, temperature: 0.7, fallback: '{}' });
     const pitch: PitchResult = JSON.parse(content);
 
     return new Response(JSON.stringify(pitch), {

--- a/apps/web/app/creator/api/analyzeCaptions/route.ts
+++ b/apps/web/app/creator/api/analyzeCaptions/route.ts
@@ -1,4 +1,5 @@
 import type { CaptionAnalysis } from "@creator/types/captionAnalysis";
+import { callOpenAI } from 'shared-utils';
 
 export async function POST(req: Request) {
   try {
@@ -24,25 +25,7 @@ export async function POST(req: Request) {
       { role: "user", content: captions.join("\n") },
     ];
 
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-      },
-      body: JSON.stringify({ model: "gpt-4", messages, temperature: 0.7 }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return new Response(
-        JSON.stringify({ error: "OpenAI error", details: errorText }),
-        { status: response.status, headers: { "Content-Type": "application/json" } }
-      );
-    }
-
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content ?? "{}";
+    const content = await callOpenAI({ messages, temperature: 0.7, fallback: '{}' });
     const analysis: CaptionAnalysis = JSON.parse(content);
 
     return new Response(JSON.stringify(analysis), {

--- a/apps/web/app/creator/api/contentIdeas/route.ts
+++ b/apps/web/app/creator/api/contentIdeas/route.ts
@@ -1,3 +1,5 @@
+import { callOpenAI } from 'shared-utils';
+
 export async function POST(req: Request) {
   try {
     const { topic } = await req.json();
@@ -19,25 +21,7 @@ export async function POST(req: Request) {
       { role: 'user', content: topic }
     ];
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
-      },
-      body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.7 })
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return new Response(
-        JSON.stringify({ error: 'OpenAI error', details: errorText }),
-        { status: response.status, headers: { 'Content-Type': 'application/json' } }
-      );
-    }
-
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content ?? '{}';
+    const content = await callOpenAI({ messages, temperature: 0.7, fallback: '{}' });
     const result = JSON.parse(content) as { ideas: string[] };
 
     return new Response(JSON.stringify(result), {

--- a/apps/web/app/creator/api/generatePersona/route.ts
+++ b/apps/web/app/creator/api/generatePersona/route.ts
@@ -1,3 +1,5 @@
+import { callOpenAI } from 'shared-utils';
+
 export async function POST(req: Request) {
   try {
     const { captions } = await req.json();
@@ -24,25 +26,7 @@ export async function POST(req: Request) {
       { role: "user", content: captions.join("\n") },
     ];
 
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-      },
-      body: JSON.stringify({ model: "gpt-4", messages, temperature: 0.7 }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return new Response(
-        JSON.stringify({ error: "OpenAI error", details: errorText }),
-        { status: response.status, headers: { "Content-Type": "application/json" } }
-      );
-    }
-
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content ?? "{}";
+    const content = await callOpenAI({ messages, temperature: 0.7, fallback: '{}' });
 
     return new Response(content, { status: 200, headers: { "Content-Type": "application/json" } });
   } catch (error) {

--- a/apps/web/app/creator/api/generatePitch/route.ts
+++ b/apps/web/app/creator/api/generatePitch/route.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 import type { PitchResult } from "@creator/types/pitch";
+import { callOpenAI } from 'shared-utils';
 
 export async function POST(req: Request) {
   try {
@@ -39,25 +40,7 @@ export async function POST(req: Request) {
       { role: 'user', content: JSON.stringify(data) },
     ];
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
-      },
-      body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.8 }),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return new Response(
-        JSON.stringify({ error: 'OpenAI error', details: errorText }),
-        { status: response.status, headers: { 'Content-Type': 'application/json' } }
-      );
-    }
-
-    const result = await response.json();
-    const content = result.choices?.[0]?.message?.content ?? '';
+    const content = await callOpenAI({ messages, temperature: 0.8, fallback: '' });
     const pitch: PitchResult = { pitch: content };
 
     return new Response(JSON.stringify(pitch), {

--- a/apps/web/app/home/api/growthEdge/route.ts
+++ b/apps/web/app/home/api/growthEdge/route.ts
@@ -1,3 +1,5 @@
+import { callOpenAI } from 'shared-utils';
+
 export async function POST(req: Request) {
   try {
     const { persona } = await req.json();
@@ -21,25 +23,7 @@ export async function POST(req: Request) {
       { role: 'user', content: persona }
     ];
 
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`
-      },
-      body: JSON.stringify({ model: 'gpt-4', messages, temperature: 0.7 })
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      return new Response(
-        JSON.stringify({ error: 'OpenAI error', details: errorText }),
-        { status: response.status, headers: { 'Content-Type': 'application/json' } }
-      );
-    }
-
-    const data = await response.json();
-    const content = data.choices?.[0]?.message?.content ?? '{}';
+    const content = await callOpenAI({ messages, temperature: 0.7, fallback: '{}' });
     const result = JSON.parse(content);
 
     return new Response(JSON.stringify(result), {

--- a/packages/shared-utils/src/index.ts
+++ b/packages/shared-utils/src/index.ts
@@ -7,3 +7,4 @@ export * from './badges';
 export * from './trustScore';
 export * from './briefPersonaMatch';
 export * from './generateMatchExplanation';
+export * from './openai';

--- a/packages/shared-utils/src/openai.ts
+++ b/packages/shared-utils/src/openai.ts
@@ -1,0 +1,54 @@
+export interface ChatCompletionParams {
+  messages: { role: string; content: string }[];
+  model?: string;
+  temperature?: number;
+  maxRetries?: number;
+  fallback?: string;
+}
+
+export async function callOpenAI({
+  messages,
+  model = 'gpt-4',
+  temperature = 0.7,
+  maxRetries = 2,
+  fallback,
+}: ChatCompletionParams): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({ model, messages, temperature }),
+      });
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+      const data = await res.json();
+      const content = data.choices?.[0]?.message?.content ?? '';
+      logPromptResponse(messages, content);
+      return content;
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  console.error('OpenAI call failed', lastError);
+  if (fallback !== undefined) return fallback;
+  throw lastError;
+}
+
+async function logPromptResponse(messages: any, content: string) {
+  const key = process.env.POSTHOG_API_KEY;
+  const host = process.env.POSTHOG_HOST;
+  if (!key || !host) return;
+  try {
+    await fetch(`${host}/capture/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ api_key: key, event: 'gpt_interaction', properties: { messages, content } }),
+    });
+  } catch {}
+}


### PR DESCRIPTION
## Summary
- add `callOpenAI` helper with retries and Posthog logging
- use the new helper in several API routes

## Testing
- `pnpm lint` *(fails: 254 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f6e9e8efc832c9900a4fcaff367f8