### PR TITLE
Introduce Inter font and hero layout

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -11,19 +11,29 @@ import { ThemeProvider } from "./providers";
 import PostHogProvider from '../components/PostHogProvider'
 import { Analytics } from '@vercel/analytics/react'
 import * as React from "react";
+import { Inter } from "next/font/google";
+import {
+  LayoutDashboard,
+  Heart,
+  Users2,
+  BarChart,
+  Mail,
+  CreditCard,
+  ShieldCheck,
+  ScrollText,
+} from "lucide-react";
 
-// Use system fonts to avoid build-time Google font download
-const inter = { className: "" };
+const inter = Inter({ subsets: ["latin"] });
 
 const navLinks: NavLink[] = [
-  { href: "/dashboard", label: "Dashboard" },
-  { href: "/shortlist", label: "Shortlist" },
-  { href: "/matches", label: "Matches" },
-  { href: "/analytics", label: "Analytics" },
-  { href: "/inbox", label: "Inbox" },
-  { href: "/billing", label: "Billing" },
-  { href: "/privacy", label: "Privacy" },
-  { href: "/terms", label: "Terms" },
+  { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
+  { href: "/shortlist", label: "Shortlist", icon: Heart },
+  { href: "/matches", label: "Matches", icon: Users2 },
+  { href: "/analytics", label: "Analytics", icon: BarChart },
+  { href: "/inbox", label: "Inbox", icon: Mail },
+  { href: "/billing", label: "Billing", icon: CreditCard },
+  { href: "/privacy", label: "Privacy", icon: ShieldCheck },
+  { href: "/terms", label: "Terms", icon: ScrollText },
   { href: "https://tally.so/r/xyz123", label: "Feedback" },
 ];
 
@@ -35,19 +45,23 @@ export default function RootLayout({ children }: { children: ReactNode }) {
         <meta name="description" content="Siora brand dashboard" />
         <link rel="icon" href="/favicon-32x32.png" sizes="32x32" />
       </head>
-      <body className="min-h-screen bg-gradient-to-b from-Siora-dark via-Siora-mid to-Siora-light text-white font-sans antialiased">
+      <body className="min-h-screen bg-[#0D0F12] text-white font-sans antialiased">
         <ThemeProvider>
           <PostHogProvider />
           <Analytics />
           <SessionProvider>
             <BrandUserProvider>
               <TrpcProvider>
-                <main className="max-w-7xl mx-auto px-6 sm:px-8 py-10">
-                  <div className="flex justify-between mb-4">
+                <header className="sticky top-0 z-50 bg-[#0D0F12]/80 backdrop-blur border-b border-Siora-border">
+                  <div className="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex justify-between items-center">
                     <AuthStatus />
-                    <ThemeToggle />
+                    <div className="flex items-center gap-4">
+                      <Nav links={navLinks} />
+                      <ThemeToggle />
+                    </div>
                   </div>
-                  <Nav links={navLinks} />
+                </header>
+                <main className="max-w-7xl mx-auto px-6 sm:px-8 py-10">
                   <PageTransition>{children}</PageTransition>
                 </main>
               </TrpcProvider>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,25 +1,14 @@
-import Link from "next/link";
+import { Hero } from "shared-ui";
 
 export default function Page() {
   return (
-    <main className="min-h-screen flex items-center justify-center bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white">
-      <div className="text-center space-y-6">
-        <h1 className="text-4xl font-extrabold">Welcome to Siora</h1>
-        <div className="flex justify-center gap-4">
-          <Link
-            href="/brand"
-            className="px-6 py-3 rounded-md bg-white text-black font-semibold"
-          >
-            I'm a Brand
-          </Link>
-          <Link
-            href="/creator"
-            className="px-6 py-3 rounded-md bg-white text-black font-semibold"
-          >
-            I'm a Creator
-          </Link>
-        </div>
-      </div>
+    <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white">
+      <Hero
+        title="Welcome to Siora"
+        subtitle="An AI-powered marketplace connecting brands and creators."
+        ctaLabel="Get Started"
+        ctaHref="/signup"
+      />
     </main>
   );
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "next": "^15.3.4",
     "pdfkit": "^0.15.2",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "lucide-react": "^0.525.0"
   },
   "prisma": {
     "schema": "./prisma/schema.prisma",

--- a/packages/shared-ui/src/Hero.tsx
+++ b/packages/shared-ui/src/Hero.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+"use client";
+import { motion } from 'framer-motion';
+
+interface HeroProps {
+  title: string;
+  subtitle?: string;
+  ctaLabel?: string;
+  ctaHref?: string;
+}
+
+export function Hero({ title, subtitle, ctaLabel, ctaHref }: HeroProps) {
+  return (
+    <section className="max-w-7xl mx-auto px-6 sm:px-8 py-24 text-center space-y-6">
+      <motion.h1
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
+        className="text-5xl font-extrabold tracking-tight"
+      >
+        {title}
+      </motion.h1>
+      {subtitle && (
+        <motion.p
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.1, duration: 0.5 }}
+          className="text-zinc-300 max-w-2xl mx-auto"
+        >
+          {subtitle}
+        </motion.p>
+      )}
+      {ctaLabel && ctaHref && (
+        <motion.a
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.2, duration: 0.5 }}
+          href={ctaHref}
+          className="inline-block px-6 py-3 rounded-md bg-Siora-accent text-white hover:bg-Siora-hover transition-all duration-300 ease-in-out"
+        >
+          {ctaLabel}
+        </motion.a>
+      )}
+    </section>
+  );
+}

--- a/packages/shared-ui/src/Nav.tsx
+++ b/packages/shared-ui/src/Nav.tsx
@@ -2,29 +2,33 @@ import React from 'react';
 "use client";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import type { LucideIcon } from "lucide-react";
 
 export interface NavLink {
   href: string;
   label: string;
+  icon?: LucideIcon;
 }
 
 export function Nav({ links }: { links: NavLink[] }) {
   const pathname = usePathname();
   return (
-    <nav className="flex items-center gap-4 mb-6">
+    <nav className="flex items-center gap-4">
       {links.map((l) => {
         const active = pathname === l.href;
+        const Icon = l.icon;
         return (
           <Link
             key={l.href}
             href={l.href}
-            className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+            className={`flex items-center gap-2 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
               active
                 ? 'bg-Siora-accent text-white shadow-Siora-hover'
                 : 'text-gray-300 hover:text-white hover:bg-Siora-light'
             }`}
           >
-            {l.label}
+            {Icon && <Icon className="w-4 h-4" />}
+            <span>{l.label}</span>
           </Link>
         );
       })}

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -5,6 +5,7 @@ export { default as ThemeToggle } from './ThemeToggle'
 export { default as Spinner } from './Spinner'
 export { ChatPanel } from './ChatPanel'
 export { Badge } from './Badge'
+export { Hero } from './Hero'
 
 // Re-export types
 export type { NavLink } from './Nav'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       iconv-lite:
         specifier: ^0.6.3
         version: 0.6.3
+      lucide-react:
+        specifier: ^0.525.0
+        version: 0.525.0(react@19.1.0)
       next:
         specifier: ^15.3.4
         version: 15.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -3189,6 +3192,11 @@ packages:
   lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
     engines: {node: '>=12'}
+
+  lucide-react@0.525.0:
+    resolution: {integrity: sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
@@ -7200,6 +7208,10 @@ snapshots:
       yallist: 4.0.0
 
   lru-cache@7.18.3: {}
+
+  lucide-react@0.525.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   magic-string@0.30.17:
     dependencies:


### PR DESCRIPTION
## Summary
- add Inter font with `next/font`
- integrate lucide-react icons in navigation
- create `Hero` component for marketing pages
- add sticky nav

## Testing
- `npm run lint` *(fails: 254 errors)*
- `npm run build:web` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_687f76c233e8832cb931639c3f7d6bd4