### PR TITLE
Fix TypeScript client modules

### DIFF
--- a/apps/brand/app/create-brief/page.tsx
+++ b/apps/brand/app/create-brief/page.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 "use client";
+import React from 'react';
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 

--- a/apps/brand/app/dashboard/page.tsx
+++ b/apps/brand/app/dashboard/page.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 "use client";
+import React from 'react';
 import { useEffect, useState } from "react";
 import Link from "next/link";
 

--- a/apps/brand/app/explorer/page.tsx
+++ b/apps/brand/app/explorer/page.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 "use client";
+import React from 'react';
 import { useState, useMemo } from "react";
 import creatorsData from "../../../web/app/data/mock_creators_200.json";
 import PersonaCard from "../../../web/components/PersonaCard";

--- a/apps/brand/app/feedback/[creatorId]/page.tsx
+++ b/apps/brand/app/feedback/[creatorId]/page.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 "use client";
+import React from 'react';
 import { useState, useEffect } from 'react';
 import creators from "../../../../web/app/data/mock_creators_200.json";
 

--- a/apps/brand/app/inbox/page.tsx
+++ b/apps/brand/app/inbox/page.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 "use client";
+import React from 'react';
 
 import { useEffect, useState } from "react";
 import { ChatPanel, ChatMessage } from "shared-ui";

--- a/apps/brand/app/layout.tsx
+++ b/apps/brand/app/layout.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 "use client";
+import React from 'react';
 import "./globals.css";
 import type { ReactNode } from "react";
 import { Nav, NavLink, PageTransition, ThemeToggle } from "shared-ui";

--- a/apps/creator/app/dashboard/page.tsx
+++ b/apps/creator/app/dashboard/page.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 "use client";
+import React from 'react';
 import { useState } from "react";
 
 export default function DashboardPage() {

--- a/apps/creator/app/education/page.tsx
+++ b/apps/creator/app/education/page.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 "use client";
+import React from 'react';
 import { PDFDownloadLink } from '@react-pdf/renderer';
 import PersonaPDF from '../../../../components/pdf/PersonaPDF';
 import Link from 'next/link';

--- a/apps/creator/app/feedback/[brandId]/page.tsx
+++ b/apps/creator/app/feedback/[brandId]/page.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 "use client";
+import React from 'react';
 import { useState, useEffect } from 'react';
 import brands from "../../../../web/app/creator/data/mock_brands.json";
 

--- a/apps/creator/app/persona/page.tsx
+++ b/apps/creator/app/persona/page.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 "use client";
+import React from 'react';
 
 import { useState, useEffect } from "react";
 import { useSession } from "next-auth/react";


### PR DESCRIPTION
## Summary
- ensure `"use client"` appears before all imports
- keep dependencies like `axios` and `lucide-react` available for NextJS apps

## Testing
- `pnpm exec tsc -p apps/brand/tsconfig.json`
- `pnpm exec tsc -p apps/creator/tsconfig.json`
- `pnpm exec tsc -p apps/web/tsconfig.json`
- `pnpm exec tsc -p packages/shared-ui/tsconfig.json`
- `pnpm exec tsc -p packages/shared-utils/tsconfig.json`
- `pnpm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_687fab1d88d4832cb452a0eb7d11e32d