### PR TITLE
Add landing redirect and env-based URLs

### DIFF
--- a/apps/brand/next.config.ts
+++ b/apps/brand/next.config.ts
@@ -13,12 +13,15 @@ const nextConfig: NextConfig = {
   // Allow Next.js to transpile internal packages written in TypeScript.
   transpilePackages: ["shared-ui", "shared-utils"],
   async rewrites() {
-    return [
-      {
-        source: "/creator/:path*",
-        destination: `http://localhost:3001/:path*`,
-      },
-    ];
+    if (process.env.CREATOR_APP_URL) {
+      return [
+        {
+          source: "/creator/:path*",
+          destination: `${process.env.CREATOR_APP_URL}/:path*`,
+        },
+      ];
+    }
+    return [];
   },
 };
 

--- a/apps/web/app/api/instagram/auth/route.ts
+++ b/apps/web/app/api/instagram/auth/route.ts
@@ -7,7 +7,7 @@ export async function POST(req: Request) {
     if (!code) {
       return NextResponse.json({ error: "Missing code" }, { status: 400 });
     }
-    const redirectUri = "http://localhost:3000/instagram/callback";
+    const redirectUri = `${process.env.NEXTAUTH_URL}/instagram/callback`;
     const token = await exchangeCodeForToken(code, redirectUri);
     const profile = await fetchInstagramUserProfile(token.access_token);
     return NextResponse.json({ profile });

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,6 +1,29 @@
+"use client";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
 import { Hero } from "shared-ui";
 
 export default function Page() {
+  const router = useRouter();
+  const { data: session, status } = useSession();
+
+  useEffect(() => {
+    if (status !== "loading" && session?.user) {
+      const role = (session.user as { role?: string }).role;
+      if (role === "creator") router.replace("/creator/dashboard");
+      else if (role === "brand") router.replace("/dashboard");
+    }
+  }, [session, status, router]);
+
+  if (session && status === "authenticated") {
+    return (
+      <main className="min-h-screen flex items-center justify-center text-white">
+        Redirecting...
+      </main>
+    );
+  }
+
   return (
     <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white">
       <Hero

--- a/apps/web/lib/instagram/index.ts
+++ b/apps/web/lib/instagram/index.ts
@@ -1,6 +1,6 @@
 import type { InstagramAccessTokenResponse, InstagramUserProfile } from "@/types/instagram";
 
-export const INSTAGRAM_REDIRECT_URI = "http://localhost:3000/instagram/callback";
+export const INSTAGRAM_REDIRECT_URI = `${process.env.NEXTAUTH_URL}/instagram/callback`;
 
 export function generateInstagramAuthUrl() {
   const appId = process.env.NEXT_PUBLIC_IG_APP_ID;

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -14,11 +14,11 @@ const nextConfig: NextConfig = {
   // Allow Next.js to transpile internal packages written in TypeScript.
   transpilePackages: ["shared-ui", "shared-utils"],
   async rewrites() {
-    if (process.env.LOCAL_CREATOR_APP === "true") {
+    if (process.env.CREATOR_APP_URL) {
       return [
         {
           source: "/creator/:path*",
-          destination: `http://localhost:3001/:path*`,
+          destination: `${process.env.CREATOR_APP_URL}/:path*`,
         },
       ];
     }

--- a/components/ConnectInstagram.tsx
+++ b/components/ConnectInstagram.tsx
@@ -4,7 +4,8 @@ import React from 'react';
 export function ConnectInstagramButton() {
   const handleClick = () => {
     const clientId = process.env.NEXT_PUBLIC_IG_APP_ID!;
-    const redirectUri = encodeURIComponent('http://localhost:3000/api/instagram/callback');
+    const baseUrl = process.env.NEXTAUTH_URL || '';
+    const redirectUri = encodeURIComponent(`${baseUrl}/api/instagram/callback`);
 
     const oauthUrl = `https://www.facebook.com/v19.0/dialog/oauth?client_id=${clientId}&redirect_uri=${redirectUri}&scope=instagram_basic,user_profile&response_type=code`;
 

--- a/pages/api/instagram/callback.ts
+++ b/pages/api/instagram/callback.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { code } = req.query;
-  const redirectUri = 'http://localhost:3000/api/instagram/callback';
+  const redirectUri = `${process.env.NEXTAUTH_URL}/api/instagram/callback`;
 
   try {
     const { data } = await axios.get(


### PR DESCRIPTION
## Summary
- redirect logged-in users on `/` to their dashboard based on role
- use `NEXTAUTH_URL` or `CREATOR_APP_URL` instead of hardcoded localhost URLs
- keep Instagram OAuth functions compatible with env based URLs

## Testing
- `pnpm install`
- `npm run build:web`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687fab249944832caeb402a5ee13b2ae