### PR TITLE
Improve GPT prompt handling

### DIFF
--- a/apps/web/app/creator/api/generatePersona/route.ts
+++ b/apps/web/app/creator/api/generatePersona/route.ts
@@ -1,8 +1,8 @@
-import { callOpenAI } from 'shared-utils';
+import { callOpenAI, safeJson } from 'shared-utils';
 
 export async function POST(req: Request) {
   try {
-    const { captions } = await req.json();
+    const { captions, tone, audience, platform } = await req.json();
 
     // Validate that captions is an array of strings
     if (!Array.isArray(captions) || !captions.every((c) => typeof c === "string")) {
@@ -14,21 +14,44 @@ export async function POST(req: Request) {
 
     const messages = [
       {
-        role: "system",
-        content:
-          [
-            "You are a branding expert helping analyze a creator's content.",
-            "Review the captions provided and identify the overall tone, recurring themes, and values expressed.",
-            "Infer what type of creator they are and highlight their strengths.",
-            "Respond ONLY with valid JSON that matches the PersonaProfile interface (name, personality, interests, summary).",
-          ].join(" "),
+        role: 'system',
+        content: [
+          "You are an influencer coach analyzing creator content to craft a concise persona.",
+          "Use the tone, audience and platform hints when provided to refine your analysis.",
+          "Return ONLY JSON that matches the PersonaProfile interface (name, personality, interests, summary).",
+        ].join('\n'),
       },
-      { role: "user", content: captions.join("\n") },
+      {
+        role: 'user',
+        content: [
+          'Captions: Just posted my new recipe! #vegan #health',
+          'Tone hint: upbeat',
+          'Audience: foodies',
+          'Platform: Instagram',
+        ].join('\n'),
+      },
+      {
+        role: 'assistant',
+        content:
+          '{"name":"HealthyFoodie","personality":"energetic","interests":["cooking"],"summary":"Shares vibrant vegan recipes"}',
+      },
+      {
+        role: 'user',
+        content: [
+          captions.join('\n'),
+          tone ? `Tone hint: ${tone}` : undefined,
+          audience ? `Audience: ${audience}` : undefined,
+          platform ? `Platform: ${platform}` : undefined,
+        ]
+          .filter(Boolean)
+          .join('\n'),
+      },
     ];
 
     const content = await callOpenAI({ messages, temperature: 0.7, fallback: '{}' });
+    const parsed = safeJson(content, {});
 
-    return new Response(content, { status: 200, headers: { "Content-Type": "application/json" } });
+    return new Response(JSON.stringify(parsed), { status: 200, headers: { 'Content-Type': 'application/json' } });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unexpected error";
     console.error("Unexpected error:", error);

--- a/packages/shared-utils/src/openai.ts
+++ b/packages/shared-utils/src/openai.ts
@@ -40,6 +40,14 @@ export async function callOpenAI({
   throw lastError;
 }
 
+export function safeJson<T>(text: string, fallback: T): T {
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return fallback;
+  }
+}
+
 async function logPromptResponse(messages: any, content: string) {
   const key = process.env.POSTHOG_API_KEY;
   const host = process.env.POSTHOG_HOST;


### PR DESCRIPTION
## Summary
- add safe JSON helper for OpenAI responses
- enrich brand persona generation with example and extra context
- refine creator persona generation flow and add few-shot data
- expand campaign brief generation with better prompt engineering
- upgrade feedback summary and persona feedback APIs to use safe prompts

## Testing
- `pnpm install`
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fe92667d0832c8c58a9bc8baa52d9