### PR TITLE
Add partnership questions to creator onboarding

### DIFF
--- a/apps/creator/app/api/onboarding-complete/route.ts
+++ b/apps/creator/app/api/onboarding-complete/route.ts
@@ -74,7 +74,10 @@ export async function POST(req: Request) {
       tone: progress.tone,
       values: progress.values ?? [],
       contentType: progress.contentType,
-      brandPersona: persona
+      brandPersona: persona,
+      partnershipPreference: progress.partnershipValue,
+      undervaluedExperience: progress.undervaluedExperience,
+      supportWish: progress.supportWish
     }
   });
 

--- a/apps/creator/app/onboarding/page.tsx
+++ b/apps/creator/app/onboarding/page.tsx
@@ -16,11 +16,22 @@ interface OnboardData {
   values: string[];
   contentType: string;
   brandPersona: string;
+  partnershipValue: string;
+  undervaluedExperience: string;
+  supportWish: string;
 }
 
 const toneOptions = ["Casual", "Professional", "Playful", "Bold"];
 const valueOptions = ["Authenticity", "Community", "Innovation", "Sustainability"];
-const steps = ["Start", "Basics", "Tone", "Values", "Persona", "Review"];
+const steps = [
+  "Start",
+  "Basics",
+  "Tone",
+  "Values",
+  "Persona",
+  "Partnership",
+  "Review",
+];
 
 export default function CreatorOnboarding() {
   const router = useRouter();
@@ -35,6 +46,9 @@ export default function CreatorOnboarding() {
     values: [],
     contentType: "",
     brandPersona: "",
+    partnershipValue: "",
+    undervaluedExperience: "",
+    supportWish: "",
   });
 
   useEffect(() => {
@@ -210,6 +224,41 @@ export default function CreatorOnboarding() {
 
         <TabsContent value="5" current={step}>
           <div className={styles.formBox}>
+            <h2 className={styles.title}>Partnership Preferences</h2>
+            <textarea
+              className={styles.input}
+              rows={3}
+              placeholder="What do you value most in a brand partnership?"
+              value={data.partnershipValue}
+              onChange={(e) =>
+                setData({ ...data, partnershipValue: e.target.value })
+              }
+            />
+            <textarea
+              className={styles.input}
+              rows={3}
+              placeholder="Have you ever been undervalued by a brand? What happened?"
+              value={data.undervaluedExperience}
+              onChange={(e) =>
+                setData({ ...data, undervaluedExperience: e.target.value })
+              }
+            />
+            <textarea
+              className={styles.input}
+              rows={3}
+              placeholder="What kind of support or recognition do you wish brands offered?"
+              value={data.supportWish}
+              onChange={(e) => setData({ ...data, supportWish: e.target.value })}
+            />
+            <div className={styles.controls}>
+              <button className={styles.navButton} onClick={() => setStep("4")}>Back</button>
+              <button className={styles.submitButton} onClick={() => setStep("6")} disabled={!data.partnershipValue}>Next</button>
+            </div>
+          </div>
+        </TabsContent>
+
+        <TabsContent value="6" current={step}>
+          <div className={styles.formBox}>
             <h2 className={styles.title}>Review & Confirm</h2>
             <div className="text-sm space-y-2 mb-4">
               <p><strong>Name:</strong> {data.name}</p>
@@ -220,9 +269,12 @@ export default function CreatorOnboarding() {
               <p><strong>Values:</strong> {data.values.join(', ') || '-'}</p>
               <p><strong>Content Type:</strong> {data.contentType}</p>
               <p><strong>Brand Persona:</strong> {data.brandPersona}</p>
+              <p><strong>Partnership Value:</strong> {data.partnershipValue}</p>
+              <p><strong>Undervalued:</strong> {data.undervaluedExperience}</p>
+              <p><strong>Support Wish:</strong> {data.supportWish}</p>
             </div>
             <div className={styles.controls}>
-              <button className={styles.navButton} onClick={() => setStep("4")}>Back</button>
+              <button className={styles.navButton} onClick={() => setStep("5")}>Back</button>
               <button className={styles.submitButton} onClick={handleConfirm}>Confirm</button>
             </div>
           </div>

--- a/apps/web/app/creator/onboarding/page.tsx
+++ b/apps/web/app/creator/onboarding/page.tsx
@@ -16,6 +16,9 @@ interface OnboardData {
   values: string[];
   contentType: string;
   brandPersona: string;
+  partnershipValue: string;
+  undervaluedExperience: string;
+  supportWish: string;
 }
 
 const toneOptions = ["Casual", "Professional", "Playful", "Bold"];
@@ -33,6 +36,9 @@ export default function CreatorOnboarding() {
     values: [],
     contentType: "",
     brandPersona: "",
+    partnershipValue: "",
+    undervaluedExperience: "",
+    supportWish: "",
   });
 
   useEffect(() => {
@@ -50,14 +56,14 @@ export default function CreatorOnboarding() {
     } catch {}
   }, [data]);
 
-  const next = () => setStep((s) => Math.min(5, s + 1));
+  const next = () => setStep((s) => Math.min(7, s + 1));
   const prev = () => setStep((s) => Math.max(0, s - 1));
 
   async function handleConfirm() {
     try {
       // TODO: send data to API
       localStorage.removeItem("creatorOnboarding");
-      setStep(6);
+      setStep(7);
     } catch (err) {
       console.error(err);
     }
@@ -184,6 +190,39 @@ export default function CreatorOnboarding() {
       case 5:
         return (
           <div className={styles.formBox}>
+            <h2 className={styles.title}>Partnership Preferences</h2>
+            <textarea
+              className={styles.input}
+              rows={3}
+              placeholder="What do you value most in a brand partnership?"
+              value={data.partnershipValue}
+              onChange={(e) => setData({ ...data, partnershipValue: e.target.value })}
+            />
+            <textarea
+              className={styles.input}
+              rows={3}
+              placeholder="Have you ever been undervalued by a brand? What happened?"
+              value={data.undervaluedExperience}
+              onChange={(e) =>
+                setData({ ...data, undervaluedExperience: e.target.value })
+              }
+            />
+            <textarea
+              className={styles.input}
+              rows={3}
+              placeholder="What kind of support or recognition do you wish brands offered?"
+              value={data.supportWish}
+              onChange={(e) => setData({ ...data, supportWish: e.target.value })}
+            />
+            <div className={styles.controls}>
+              <button className={styles.navButton} onClick={prev}>Back</button>
+              <button className={styles.submitButton} onClick={next} disabled={!data.partnershipValue}>Next</button>
+            </div>
+          </div>
+        );
+      case 6:
+        return (
+          <div className={styles.formBox}>
             <h2 className={styles.title}>Review & Confirm</h2>
             <div className="text-sm space-y-2 mb-4">
               <p><strong>Name:</strong> {data.name}</p>
@@ -194,6 +233,9 @@ export default function CreatorOnboarding() {
               <p><strong>Values:</strong> {data.values.join(', ') || '-'}</p>
               <p><strong>Content Type:</strong> {data.contentType}</p>
               <p><strong>Brand Persona:</strong> {data.brandPersona}</p>
+              <p><strong>Partnership Value:</strong> {data.partnershipValue}</p>
+              <p><strong>Undervalued:</strong> {data.undervaluedExperience}</p>
+              <p><strong>Support Wish:</strong> {data.supportWish}</p>
             </div>
             <div className={styles.controls}>
               <button className={styles.navButton} onClick={prev}>Back</button>
@@ -201,7 +243,7 @@ export default function CreatorOnboarding() {
             </div>
           </div>
         );
-      case 6:
+      case 7:
         return (
           <div className={styles.formBox}>
             <h2 className={styles.title}>All set!</h2>
@@ -217,8 +259,8 @@ export default function CreatorOnboarding() {
   return (
     <div className={styles.wrapper}>
       <Tabs value={step.toString()} onValueChange={(v) => setStep(Number(v))}>
-        <TabsList className="mb-4 grid grid-cols-6 gap-1">
-          {Array.from({ length: 6 }).map((_, i) => (
+        <TabsList className="mb-4 grid grid-cols-8 gap-1">
+          {Array.from({ length: 8 }).map((_, i) => (
             <TabsTrigger key={i} value={i.toString()}>{i + 1}</TabsTrigger>
           ))}
         </TabsList>

--- a/apps/web/creator/prisma/schema.prisma
+++ b/apps/web/creator/prisma/schema.prisma
@@ -81,6 +81,9 @@ model CreatorProfile {
   values       Json
   contentType  String
   brandPersona String
+  partnershipPreference String?
+  undervaluedExperience String?
+  supportWish          String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 

--- a/packages/shared-utils/src/fitScoreEngine.ts
+++ b/packages/shared-utils/src/fitScoreEngine.ts
@@ -13,6 +13,9 @@ export interface CreatorPersona {
   /** Goals or aspirations of the creator */
   goals?: string[];
   pastCollabs?: string[];
+  partnershipPreference?: string;
+  undervaluedExperience?: string;
+  supportWish?: string;
 }
 
 export interface BrandProfile {
@@ -94,6 +97,27 @@ export function getFitScore(
   if (collabCommon.length > 0)
     reasons.push(`Past experience with ${collabCommon.join(', ')}`);
   else reasons.push('No related past collaborations');
+
+  // Partnership values (10)
+  if (creator.partnershipPreference && brand.values) {
+    const prefs = creator.partnershipPreference.split(/[,\s]+/);
+    const prefOverlap = arrayOverlap(prefs, brand.values);
+    const prefScore = (prefOverlap.length / prefs.length) * 10;
+    score += prefScore;
+    if (prefOverlap.length > 0)
+      reasons.push(`Partnership focus on ${prefOverlap.join(', ')}`);
+    else reasons.push('Partnership priorities differ');
+  }
+
+  // Desired support (5)
+  if (creator.supportWish && brand.values) {
+    const wishes = creator.supportWish.split(/[,\s]+/);
+    const wishOverlap = arrayOverlap(wishes, brand.values);
+    const wishScore = (wishOverlap.length / wishes.length) * 5;
+    score += wishScore;
+    if (wishOverlap.length > 0)
+      reasons.push('Supports creator needs');
+  }
 
   const finalScore = Math.round(Math.max(0, Math.min(100, score)));
   return { score: finalScore, reason: reasons.join('; ') };

--- a/packages/shared-utils/src/generateMatchExplanation.ts
+++ b/packages/shared-utils/src/generateMatchExplanation.ts
@@ -40,5 +40,23 @@ export function generateMatchExplanation(
     notes.push('Audience fits your target age');
   }
 
+  if (creator.partnershipPreference && brand.values) {
+    const prefs = creator.partnershipPreference
+      .split(/[,\s]+/)
+      .filter(Boolean);
+    const overlap = prefs.filter((p) =>
+      brand.values!.some((v) => v.toLowerCase() === p.toLowerCase())
+    );
+    if (overlap.length > 0) notes.push('Shares partnership priorities');
+  }
+
+  if (creator.supportWish && brand.values) {
+    const wishes = creator.supportWish.split(/[,\s]+/).filter(Boolean);
+    const match = wishes.filter((w) =>
+      brand.values!.some((v) => v.toLowerCase() === w.toLowerCase())
+    );
+    if (match.length > 0) notes.push('Offers desired creator support');
+  }
+
   return notes;
 }

--- a/packages/shared-utils/src/matchScore.ts
+++ b/packages/shared-utils/src/matchScore.ts
@@ -74,6 +74,23 @@ export function matchScore(
     reasons.push(`Preferred formats: ${formatOverlap.join(', ')}`);
   else reasons.push('Formats differ');
 
+  if (creator.partnershipPreference && brand.values) {
+    const prefs = creator.partnershipPreference.split(/[,\s]+/);
+    const prefOverlap = overlap(prefs, brand.values);
+    const prefScore = (prefOverlap.length / prefs.length) * 10;
+    score += prefScore;
+    if (prefOverlap.length > 0)
+      reasons.push(`Partnership focus: ${prefOverlap.join(', ')}`);
+  }
+
+  if (creator.supportWish && brand.values) {
+    const wishes = creator.supportWish.split(/[,\s]+/);
+    const wishOverlap = overlap(wishes, brand.values);
+    const wishScore = (wishOverlap.length / wishes.length) * 5;
+    score += wishScore;
+    if (wishOverlap.length > 0) reasons.push('Meets support needs');
+  }
+
   const finalScore = Math.round(Math.max(0, Math.min(100, score)));
   return { score: finalScore, reasons };
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,6 +101,9 @@ model CreatorProfile {
   values       Json
   contentType  String
   brandPersona String
+  partnershipPreference String?
+  undervaluedExperience String?
+  supportWish          String?
   createdAt    DateTime @default(now())
   updatedAt    DateTime @updatedAt
 


### PR DESCRIPTION
## Summary
- extend `CreatorProfile` schema with partnership fields
- collect new answers during creator onboarding
- store preferences on onboarding completion
- factor these answers into matching algorithms

## Testing
- `pnpm install --frozen-lockfile`
- `npm run lint` *(fails: 173 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687fe8aebf38832c9a16d581bc4397d9