### PR TITLE
Add GPT-based pitch feedback

### DIFF
--- a/apps/web/app/api/pitchFeedback/route.ts
+++ b/apps/web/app/api/pitchFeedback/route.ts
@@ -1,0 +1,43 @@
+import { callOpenAI } from 'shared-utils';
+import type { PitchFeedback } from '@/types/pitch';
+
+export async function POST(req: Request) {
+  try {
+    const { pitch, personaSummary, brand } = await req.json();
+    if (!pitch || !personaSummary || !brand) {
+      return new Response(
+        JSON.stringify({ error: 'pitch, personaSummary and brand required' }),
+        { status: 400, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const messages = [
+      {
+        role: 'system',
+        content: [
+          'You evaluate influencer pitches for brand collaborations.',
+          'Summarize creator-brand fit and suggest any content or tone adjustments.',
+          'Rate the pitch from the brand\'s perspective on a 1-5 scale for strength, clarity and uniqueness.',
+          'Tag issues like "too vague" or "not tailored" if relevant.',
+          'Respond ONLY with JSON matching this TypeScript interface:',
+          '{ fitSummary: string; adjustments: string[]; ratings: { strength: number; clarity: number; uniqueness: number }; tags: string[] }'
+        ].join('\n')
+      },
+      { role: 'user', content: JSON.stringify({ pitch, personaSummary, brand }) }
+    ];
+
+    const content = await callOpenAI({ messages, temperature: 0.7, fallback: '{}' });
+    const feedback: PitchFeedback = JSON.parse(content);
+    return new Response(JSON.stringify(feedback), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' }
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    console.error('pitchFeedback error', error);
+    return new Response(
+      JSON.stringify({ error: 'Unexpected error', details: message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/apps/web/app/campaigns/[id]/applications/page.tsx
+++ b/apps/web/app/campaigns/[id]/applications/page.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import Toast from '@/components/Toast';
 import { creators } from '@/app/data/creators';
+import { campaigns } from '@/app/data/campaigns';
+import type { PitchFeedback } from '@/types/pitch';
 
 interface Application {
   id: string;
@@ -19,9 +21,11 @@ interface Application {
 export default function ApplicationsPage() {
   const params = useParams<{ id: string }>();
   const campaignId = params.id;
+  const campaign = campaigns.find((c) => c.id === campaignId);
   const router = useRouter();
   const [apps, setApps] = useState<Application[]>([]);
   const [toast, setToast] = useState('');
+  const [feedback, setFeedback] = useState<Record<string, PitchFeedback | null>>({});
 
   useEffect(() => {
     async function load() {
@@ -62,6 +66,28 @@ export default function ApplicationsPage() {
     setToast('Application rejected');
   }
 
+  async function analyze(app: Application) {
+    if (!campaign) return;
+    setFeedback((prev) => ({ ...prev, [app.id]: null }));
+    try {
+      const res = await fetch('/api/pitchFeedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          pitch: app.pitch,
+          personaSummary: app.personaSummary,
+          brand: campaign,
+        }),
+      });
+      if (res.ok) {
+        const data: PitchFeedback = await res.json();
+        setFeedback((prev) => ({ ...prev, [app.id]: data }));
+      }
+    } catch (err) {
+      console.error('analysis error', err);
+    }
+  }
+
   return (
     <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
       <div className="max-w-4xl mx-auto space-y-6">
@@ -90,7 +116,33 @@ export default function ApplicationsPage() {
                   <div className="flex gap-4">
                     <button onClick={() => accept(app)} className="px-3 py-1 text-sm rounded bg-green-600 text-white">Accept</button>
                     <button onClick={() => reject(app.id)} className="px-3 py-1 text-sm rounded bg-red-600 text-white">Reject</button>
+                    {app.pitch && (
+                      <button
+                        onClick={() => analyze(app)}
+                        className="px-3 py-1 text-sm rounded bg-blue-600 text-white"
+                      >
+                        AI Feedback
+                      </button>
+                    )}
                   </div>
+                  {feedback[app.id] && (
+                    <div className="mt-3 p-3 rounded bg-Siora-dark text-sm space-y-1">
+                      <p>{feedback[app.id]?.fitSummary}</p>
+                      <ul className="list-disc pl-5">
+                        {feedback[app.id]?.adjustments.map((a, i) => (
+                          <li key={i}>{a}</li>
+                        ))}
+                      </ul>
+                      <p>
+                        Strength: {feedback[app.id]?.ratings.strength}/5 | Clarity:{' '}
+                        {feedback[app.id]?.ratings.clarity}/5 | Uniqueness:{' '}
+                        {feedback[app.id]?.ratings.uniqueness}/5
+                      </p>
+                      {feedback[app.id]?.tags.length > 0 && (
+                        <p>Issues: {feedback[app.id]?.tags.join(', ')}</p>
+                      )}
+                    </div>
+                  )}
                 </div>
               );
             })}

--- a/apps/web/types/pitch.ts
+++ b/apps/web/types/pitch.ts
@@ -2,3 +2,14 @@ export type PitchResult = {
   reasoning: string;
   pitch: string;
 };
+
+export type PitchFeedback = {
+  fitSummary: string;
+  adjustments: string[];
+  ratings: {
+    strength: number;
+    clarity: number;
+    uniqueness: number;
+  };
+  tags: string[];
+};


### PR DESCRIPTION
## Summary
- add API to analyze creator pitch using OpenAI
- show AI feedback for pitches on campaign applications page
- store pitch feedback type definitions

## Testing
- `pnpm install`
- `npm run lint` *(fails: 175 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687fe9395384832cb70e34f16adbf00b