### PR TITLE
Add creator deal preference logic

### DIFF
--- a/apps/web/app/data/mock_creators_200.json
+++ b/apps/web/app/data/mock_creators_200.json
@@ -16,7 +16,10 @@
     "formats":[
       "Blogs",
       "Livestreams"
-    ]
+    ],
+    "deal_preference": "value-based, no affiliate-only",
+    "min_expected_fee": 500,
+    "revenue_share_tolerance": 20
   },
   {
     "id":"2",
@@ -34,7 +37,10 @@
     ],
     "formats":[
       "Blogs"
-    ]
+    ],
+    "deal_preference": "open to revenue share, no affiliate-only",
+    "min_expected_fee": 300,
+    "revenue_share_tolerance": 15
   },
   {
     "id":"3",

--- a/apps/web/app/messages/[creatorId]/page.tsx
+++ b/apps/web/app/messages/[creatorId]/page.tsx
@@ -5,7 +5,11 @@ import Link from "next/link";
 import creators from "@/app/data/mock_creators_200.json";
 import { ChatPanel, ChatMessage } from "shared-ui";
 
-type Message = ChatMessage & { creatorId: string; campaign?: string };
+type Message = ChatMessage & {
+  creatorId: string;
+  campaign?: string;
+  commissionOnly?: boolean;
+};
 
 export default function ChatPage({
   params,
@@ -16,6 +20,7 @@ export default function ChatPage({
   const brandId = "brand1"; // demo brand id until auth
   const [messages, setMessages] = useState<Message[]>([]);
   const [campaign, setCampaign] = useState("");
+  const [commissionOnly, setCommissionOnly] = useState(false);
   const [sending, setSending] = useState(false);
 
   useEffect(() => {
@@ -58,6 +63,7 @@ export default function ChatPage({
         text,
         timestamp: new Date().toISOString(),
         campaign,
+        commissionOnly,
       };
       setMessages((prev) => [...prev, newMessage]);
     } finally {
@@ -75,6 +81,21 @@ export default function ChatPage({
           value={campaign}
           onChange={(e) => setCampaign(e.target.value)}
         />
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={commissionOnly}
+            onChange={(e) => setCommissionOnly(e.target.checked)}
+          />
+          Commission-only deal
+        </label>
+        {commissionOnly &&
+          creator?.deal_preference &&
+          /no affiliate-only|value-based/i.test(creator.deal_preference) && (
+            <span className="text-red-600 text-sm">
+              Creator prefers value-based deals
+            </span>
+          )}
         <ChatPanel
           messages={messages}
           currentUser="brand"

--- a/packages/shared-utils/src/campaignFitScore.ts
+++ b/packages/shared-utils/src/campaignFitScore.ts
@@ -7,6 +7,7 @@ export interface CampaignBrief {
   platforms?: string[];
   deliverables?: string[];
   goals?: string[];
+  commissionOnly?: boolean;
 }
 
 function fuzzyMatch(a: string, b: string): boolean {
@@ -72,6 +73,14 @@ export function getCampaignFitScore(
     reasons.push(`Niche match: ${personaMatch.join(', ')}`);
   } else if (campaign.idealPersona && campaign.idealPersona.length > 0) {
     reasons.push('Niche does not match');
+  }
+
+  if (campaign.commissionOnly && creator.dealPreference) {
+    const dp = creator.dealPreference.toLowerCase();
+    if (dp.includes('no affiliate-only') || dp.includes('value-based')) {
+      score -= 15;
+      reasons.push('Creator dislikes commission-only deals');
+    }
   }
 
   const finalScore = Math.round(Math.max(0, Math.min(100, score)));

--- a/packages/shared-utils/src/fitScoreEngine.ts
+++ b/packages/shared-utils/src/fitScoreEngine.ts
@@ -16,6 +16,12 @@ export interface CreatorPersona {
   partnershipPreference?: string;
   undervaluedExperience?: string;
   supportWish?: string;
+  /** Creator expectations around payment models */
+  dealPreference?: string;
+  /** Minimum flat fee the creator expects */
+  minExpectedFee?: number;
+  /** Acceptable percentage for revenue share deals */
+  revenueShareTolerance?: number;
 }
 
 export interface BrandProfile {
@@ -26,6 +32,8 @@ export interface BrandProfile {
   values?: string[];
   desiredFormats?: string[];
   categories?: string[];
+  /** If true, campaign pays only commission (affiliate) */
+  commissionOnly?: boolean;
 }
 
 function arrayOverlap(a?: string[], b?: string[]): string[] {

--- a/packages/shared-utils/src/matchScore.ts
+++ b/packages/shared-utils/src/matchScore.ts
@@ -91,6 +91,14 @@ export function matchScore(
     if (wishOverlap.length > 0) reasons.push('Meets support needs');
   }
 
+  if (brand.commissionOnly && creator.dealPreference) {
+    const dp = creator.dealPreference.toLowerCase();
+    if (dp.includes('no affiliate-only') || dp.includes('value-based')) {
+      score -= 15;
+      reasons.push('Prefers value-based compensation');
+    }
+  }
+
   const finalScore = Math.round(Math.max(0, Math.min(100, score)));
   return { score: finalScore, reasons };
 }


### PR DESCRIPTION
## Summary
- extend CreatorPersona and BrandProfile models with deal preference and commission-only fields
- adjust match scoring to penalize commission-only offers when a creator dislikes affiliate-only deals
- expose commissionOnly option in campaign fit score
- show warning badge in brand message UI when offering commission-only deals
- update mock creators with deal preference data

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687fedb30b50832cb65d98a2c864481f