### PR TITLE
Add campaign fairness check

### DIFF
--- a/apps/web/app/api/fairness/evaluateCampaign/route.ts
+++ b/apps/web/app/api/fairness/evaluateCampaign/route.ts
@@ -1,0 +1,19 @@
+import { evaluateCampaign } from '@/lib/fairness/evaluateCampaign';
+
+export async function POST(req: Request) {
+  try {
+    const body = await req.json();
+    const result = await evaluateCampaign(body);
+    return new Response(JSON.stringify(result), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    console.error('fairness evaluate error:', error);
+    return new Response(
+      JSON.stringify({ error: 'Unexpected error', details: message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/apps/web/app/api/fairness/feedback/route.ts
+++ b/apps/web/app/api/fairness/feedback/route.ts
@@ -1,0 +1,17 @@
+export async function POST(req: Request) {
+  try {
+    const { campaignId, feedback } = await req.json();
+    console.log('campaign feedback', campaignId, feedback);
+    return new Response(JSON.stringify({ success: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error';
+    console.error('feedback error:', error);
+    return new Response(
+      JSON.stringify({ error: 'Unexpected error', details: message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/apps/web/components/FeedbackButton.tsx
+++ b/apps/web/components/FeedbackButton.tsx
@@ -1,0 +1,51 @@
+'use client';
+import React, { useState } from 'react';
+
+export default function FeedbackButton({ id }: { id: string }) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState('');
+  const [sent, setSent] = useState(false);
+
+  async function send() {
+    try {
+      await fetch('/api/fairness/feedback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ campaignId: id, feedback: text }),
+      });
+      setSent(true);
+      setText('');
+    } catch (err) {
+      console.error('feedback error', err);
+    }
+  }
+
+  if (sent) {
+    return (
+      <button className="text-sm underline" onClick={() => setSent(false)}>
+        Feedback sent
+      </button>
+    );
+  }
+
+  return open ? (
+    <div className="flex gap-2">
+      <input
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        className="p-1 rounded bg-Siora-light text-white border border-Siora-border"
+        placeholder="Your feedback"
+      />
+      <button onClick={send} className="px-2 py-1 text-sm rounded bg-Siora-accent text-white">
+        Send
+      </button>
+      <button onClick={() => setOpen(false)} className="text-sm underline">
+        Cancel
+      </button>
+    </div>
+  ) : (
+    <button onClick={() => setOpen(true)} className="text-sm underline text-Siora-accent">
+      Leave Feedback
+    </button>
+  );
+}

--- a/apps/web/lib/fairness/evaluateCampaign.ts
+++ b/apps/web/lib/fairness/evaluateCampaign.ts
@@ -1,0 +1,42 @@
+import { callOpenAI, safeJson } from 'shared-utils';
+
+export interface CampaignDetails {
+  name?: string;
+  description?: string;
+  deliverables?: string;
+  compensation?: string;
+}
+
+export interface FairnessResult {
+  fair: boolean;
+  concerns: string[];
+}
+
+export async function evaluateCampaign(
+  campaign: CampaignDetails
+): Promise<FairnessResult> {
+  const summary = [
+    campaign.description ? `Description: ${campaign.description}` : undefined,
+    campaign.deliverables ? `Deliverables: ${campaign.deliverables}` : undefined,
+    campaign.compensation ? `Compensation: ${campaign.compensation}` : undefined,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const messages = [
+    {
+      role: 'system',
+      content: [
+        'You assess if influencer campaign offers are fair to creators.',
+        'Consider if payment is adequate and deliverables reasonable.',
+        'Return ONLY JSON matching this TypeScript interface:',
+        '{ fair: boolean; concerns: string[] }',
+        'Mark fair=false if compensation is too low or expectations unrealistic.',
+      ].join('\n'),
+    },
+    { role: 'user', content: summary },
+  ];
+
+  const content = await callOpenAI({ messages, temperature: 0.2, fallback: '{"fair":true,"concerns":[]}' });
+  return safeJson<FairnessResult>(content, { fair: true, concerns: [] });
+}


### PR DESCRIPTION
## Summary
- add AI-based fairness evaluator
- expose fairness API endpoints
- display fairness warnings and feedback option on campaigns page

## Testing
- `npm run lint`
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_687ff0b37848832cbae0dcad8112a3c3