### PR TITLE
Fix client page metadata

### DIFF
--- a/apps/web/app/head.tsx
+++ b/apps/web/app/head.tsx
@@ -1,0 +1,19 @@
+export default function Head() {
+  return (
+    <>
+      <title>Siora – AI-Powered Brand Partnerships for Creators</title>
+      <meta
+        name="description"
+        content="Discover fair collaborations between creators and brands powered by AI."
+      />
+      <meta
+        property="og:title"
+        content="Siora – AI-Powered Brand Partnerships for Creators"
+      />
+      <meta
+        property="og:description"
+        content="Discover fair collaborations between creators and brands powered by AI."
+      />
+    </>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -2,20 +2,9 @@
 import React, { useEffect } from 'react'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
-import type { Metadata } from 'next'
 import { motion } from 'framer-motion'
 import { Disclosure } from '@headlessui/react'
 import { ChevronUp } from 'lucide-react'
-
-export const metadata: Metadata = {
-  title: 'Siora – AI-Powered Brand Partnerships for Creators',
-  description: 'Discover fair collaborations between creators and brands powered by AI.',
-  openGraph: {
-    title: 'Siora – AI-Powered Brand Partnerships for Creators',
-    description:
-      'Discover fair collaborations between creators and brands powered by AI.'
-  }
-}
 
 export default function Page() {
   const { data: session, status } = useSession()


### PR DESCRIPTION
## Summary
- remove metadata export from `page.tsx`
- add a `head.tsx` file for metadata

## Testing
- `pnpm lint`
- `pnpm build:web` *(fails: Module not found ../../packages/shared-utils/src/advancedMatch)*

------
https://chatgpt.com/codex/tasks/task_e_687ff3a6d91c832cb7a8884b3d3d8ccc