### PR TITLE
Implement marketing landing page

### DIFF
--- a/apps/web/app/head.tsx
+++ b/apps/web/app/head.tsx
@@ -1,19 +1,20 @@
 export default function Head() {
   return (
     <>
-      <title>Siora – AI-Powered Brand Partnerships for Creators</title>
+      <title>Siora – Smarter Brand-Creator Matches</title>
       <meta
         name="description"
-        content="Discover fair collaborations between creators and brands powered by AI."
+        content="AI-powered brand-creator partnerships. Built for creators who value their worth."
       />
       <meta
         property="og:title"
-        content="Siora – AI-Powered Brand Partnerships for Creators"
+        content="Siora – Smarter Brand-Creator Matches"
       />
       <meta
         property="og:description"
-        content="Discover fair collaborations between creators and brands powered by AI."
+        content="AI-powered brand-creator partnerships. Built for creators who value their worth."
       />
+      <meta property="og:image" content="/siora-logo.svg" />
     </>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,7 +3,7 @@ import React, { useEffect } from 'react'
 import { useSession } from 'next-auth/react'
 import { useRouter } from 'next/navigation'
 import { motion } from 'framer-motion'
-import { Disclosure } from '@headlessui/react'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
 import { ChevronUp } from 'lucide-react'
 
 export default function Page() {
@@ -25,43 +25,40 @@ export default function Page() {
       <section className="px-6 py-24 text-center max-w-5xl mx-auto space-y-6">
         <motion.h1
           initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
           transition={{ duration: 0.6 }}
           className="text-5xl font-extrabold tracking-tight"
         >
-          Forge Fair Brand Partnerships
+          Smarter, fairer brand deals.
         </motion.h1>
         <motion.p
           initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
           transition={{ delay: 0.1, duration: 0.6 }}
           className="text-zinc-300 max-w-xl mx-auto"
         >
-          Siora matches authentic creators and brands using AI-driven personas.
+          AI-powered brand-creator partnerships. Built for creators who value their worth.
         </motion.p>
         <motion.div
           initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
           transition={{ delay: 0.2, duration: 0.6 }}
           className="flex flex-col sm:flex-row justify-center gap-4"
         >
           <a
-            href="/explorer"
+            href="/signup?role=creator"
             className="px-6 py-3 rounded-md bg-Siora-accent hover:bg-Siora-hover transition shadow-Siora-hover"
           >
-            Explore creators
+            Join as Creator
           </a>
           <a
             href="/signup?role=brand"
-            className="px-6 py-3 rounded-md bg-white text-Siora-dark hover:bg-zinc-200 transition"
-          >
-            Join as brand
-          </a>
-          <a
-            href="/signup?role=creator"
             className="px-6 py-3 rounded-md border border-white hover:bg-white hover:text-Siora-dark transition"
           >
-            Join as creator
+            Join as Brand
           </a>
         </motion.div>
       </section>
@@ -75,7 +72,7 @@ export default function Page() {
           transition={{ duration: 0.6 }}
           className="text-xl font-semibold"
         >
-          Fair partnerships. Smarter matches. Built for real creators.
+          Siora empowers creators to find aligned partnerships — and helps brands discover voices that truly fit.
         </motion.p>
       </section>
 
@@ -91,7 +88,7 @@ export default function Page() {
             className="space-y-2"
           >
             <span className="text-5xl font-bold text-Siora-accent">1</span>
-            <p>Build your profile</p>
+            <p>Build a persona or campaign brief</p>
           </motion.div>
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -101,7 +98,7 @@ export default function Page() {
             className="space-y-2"
           >
             <span className="text-5xl font-bold text-Siora-accent">2</span>
-            <p>Discover matches</p>
+            <p>Discover fair matches</p>
           </motion.div>
           <motion.div
             initial={{ opacity: 0, y: 20 }}
@@ -111,29 +108,29 @@ export default function Page() {
             className="space-y-2"
           >
             <span className="text-5xl font-bold text-Siora-accent">3</span>
-            <p>Collaborate with aligned brands</p>
+            <p>Collaborate and get paid</p>
           </motion.div>
         </div>
       </section>
 
       {/* Value props */}
       <section className="px-6 py-24 bg-Siora-mid">
-        <h2 className="text-3xl font-bold text-center mb-12">Why Siora?</h2>
+        <h2 className="text-3xl font-bold text-center mb-12">Features</h2>
         <div className="grid md:grid-cols-2 gap-12 max-w-5xl mx-auto">
           <div>
             <h3 className="text-2xl font-semibold mb-4">Creators</h3>
             <ul className="space-y-2 list-disc list-inside text-zinc-300">
-              <li>No affiliate-only offers</li>
-              <li>Get paid your worth</li>
-              <li>Automated persona &amp; pitch</li>
+              <li>Smart persona builder</li>
+              <li>Fairness layer</li>
+              <li>Protect against affiliate-only offers</li>
             </ul>
           </div>
           <div>
             <h3 className="text-2xl font-semibold mb-4">Brands</h3>
             <ul className="space-y-2 list-disc list-inside text-zinc-300">
-              <li>Smarter discovery</li>
-              <li>Fair matching</li>
-              <li>Campaign-ready brief tools</li>
+              <li>GPT-powered briefs</li>
+              <li>Intelligent match scoring</li>
+              <li>Shortlist management</li>
             </ul>
           </div>
         </div>
@@ -148,33 +145,35 @@ export default function Page() {
       {/* FAQ */}
       <section className="px-6 py-24 bg-Siora-mid">
         <h2 className="text-3xl font-bold text-center mb-8">FAQ</h2>
-        <div className="max-w-3xl mx-auto space-y-4">
-          {[
-            {
-              q: 'Is Siora free to use?',
-              a: 'Yes, creators can join for free. Brands pay per campaign.'
-            },
-            {
-              q: 'How do matches work?',
-              a: 'Our AI reviews each profile to suggest partners that share your values.'
-            },
-            { q: 'Can I change my role later?', a: 'Absolutely, contact support anytime.' }
-          ].map((item, i) => (
-            <Disclosure key={i} as="div" className="border-b border-Siora-border pb-2">
-              {({ open }) => (
-                <>
-                  <Disclosure.Button className="flex justify-between w-full text-left font-medium py-2">
-                    <span>{item.q}</span>
-                    <ChevronUp className={`w-4 h-4 transition-transform ${open ? 'rotate-180' : ''}`} />
-                  </Disclosure.Button>
-                  <Disclosure.Panel className="mt-2 text-zinc-300">{item.a}</Disclosure.Panel>
-                </>
-              )}
-            </Disclosure>
-          ))}
+        <div className="max-w-3xl mx-auto">
+          <Accordion type="single" collapsible className="space-y-2">
+            <AccordionItem value="item-1">
+              <AccordionTrigger>Is Siora free to use?</AccordionTrigger>
+              <AccordionContent>
+                Yes, creators can join for free. Brands pay per campaign.
+              </AccordionContent>
+            </AccordionItem>
+            <AccordionItem value="item-2">
+              <AccordionTrigger>How do matches work?</AccordionTrigger>
+              <AccordionContent>
+                Our AI reviews each profile to suggest partners that share your values.
+              </AccordionContent>
+            </AccordionItem>
+            <AccordionItem value="item-3">
+              <AccordionTrigger>Can I change my role later?</AccordionTrigger>
+              <AccordionContent>
+                Absolutely, contact support anytime.
+              </AccordionContent>
+            </AccordionItem>
+            <AccordionItem value="item-4">
+              <AccordionTrigger>How long does onboarding take?</AccordionTrigger>
+              <AccordionContent>
+                Most users create a profile and start matching in under two minutes.
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
         </div>
       </section>
-
       {/* CTA footer */}
       <section className="px-6 py-24 text-center">
         <motion.h2
@@ -184,7 +183,7 @@ export default function Page() {
           transition={{ duration: 0.6 }}
           className="text-3xl font-bold mb-6"
         >
-          Start creating fairer brand deals today
+          Get started in 2 minutes. No code. No spam.
         </motion.h2>
         <motion.div
           initial={{ opacity: 0, y: 20 }}
@@ -197,16 +196,21 @@ export default function Page() {
             href="/signup?role=creator"
             className="px-6 py-3 rounded-md bg-Siora-accent hover:bg-Siora-hover transition shadow-Siora-hover"
           >
-            Join as creator
+            Join as Creator
           </a>
           <a
             href="/signup?role=brand"
             className="px-6 py-3 rounded-md border border-white hover:bg-white hover:text-Siora-dark transition"
           >
-            Join as brand
+            Join as Brand
           </a>
         </motion.div>
       </section>
+      <footer className="bg-Siora-mid text-center text-sm py-6 space-x-4">
+        <a href="/privacy" className="underline hover:text-Siora-accent">Privacy Policy</a>
+        <a href="/terms" className="underline hover:text-Siora-accent">Terms of Service</a>
+        <p className="mt-2 text-zinc-400">© {new Date().getFullYear()} Siora</p>
+      </footer>
     </main>
   )
 }

--- a/apps/web/components/ui/accordion.tsx
+++ b/apps/web/components/ui/accordion.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+import * as AccordionPrimitive from '@radix-ui/react-accordion'
+import { ChevronDown } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export const Accordion = AccordionPrimitive.Root
+
+export const AccordionItem = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Item
+    ref={ref}
+    className={cn('border-b border-Siora-border', className)}
+    {...props}
+  />
+))
+AccordionItem.displayName = 'AccordionItem'
+
+export const AccordionTrigger = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <AccordionPrimitive.Header className="flex">
+    <AccordionPrimitive.Trigger
+      ref={ref}
+      className={cn(
+        'flex flex-1 items-center justify-between py-4 font-medium transition-all hover:underline',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200 data-[state=open]:rotate-180" />
+    </AccordionPrimitive.Trigger>
+  </AccordionPrimitive.Header>
+))
+AccordionTrigger.displayName = 'AccordionTrigger'
+
+export const AccordionContent = React.forwardRef<
+  React.ElementRef<typeof AccordionPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AccordionPrimitive.Content
+    ref={ref}
+    className={cn('pb-4 pt-0 text-zinc-300', className)}
+    {...props}
+  />
+))
+AccordionContent.displayName = 'AccordionContent'
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "@headlessui/react": "^1.7.17",
     "@next-auth/prisma-adapter": "^1.0.7",
     "@prisma/client": "^6.9.0",
+    "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-tabs": "^1.1.12",
     "@react-pdf/renderer": "^4.3.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.17",
     "@prisma/client": "^6.9.0",
+    "@radix-ui/react-accordion": "^1.2.11",
     "@types/nodemailer": "^6.4.17",
     "axios": "^1.10.0",
     "framer-motion": "^12.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@prisma/client':
         specifier: ^6.9.0
         version: 6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3)
+      '@radix-ui/react-accordion':
+        specifier: ^1.2.11
+        version: 1.2.11(@types/react-dom@18.3.7(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/nodemailer':
         specifier: ^6.4.17
         version: 6.4.17
@@ -395,6 +398,9 @@ importers:
       '@prisma/client':
         specifier: ^6.9.0
         version: 6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3)
+      '@radix-ui/react-accordion':
+        specifier: ^1.2.11
+        version: 1.2.11(@types/react-dom@18.3.7(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@18.3.7(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -1065,6 +1071,32 @@ packages:
 
   '@radix-ui/primitive@1.1.2':
     resolution: {integrity: sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==}
+
+  '@radix-ui/react-accordion@1.2.11':
+    resolution: {integrity: sha512-l3W5D54emV2ues7jjeG1xcyN7S3jnK3zE2zHqgn0CmMsy9lNJwmgcrmaxS+7ipw15FAivzKNzH3d5EcGoFKw0A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.11':
+    resolution: {integrity: sha512-2qrRsVGSCYasSz1RFOorXwl0H7g7J1frQtgpQgYrt+MOidtPAINHn9CPovQXb83r8ahapdx3Tu0fa/pdFFSdPg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
@@ -4919,6 +4951,39 @@ snapshots:
       - supports-color
 
   '@radix-ui/primitive@1.1.2': {}
+
+  '@radix-ui/react-accordion@1.2.11(@types/react-dom@18.3.7(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-collapsible': 1.1.11(@types/react-dom@18.3.7(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 18.3.7(@types/react@19.1.8)
+
+  '@radix-ui/react-collapsible@1.1.11(@types/react-dom@18.3.7(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.4(@types/react-dom@18.3.7(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.8)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.8)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.8
+      '@types/react-dom': 18.3.7(@types/react@19.1.8)
 
   '@radix-ui/react-collection@1.1.7(@types/react-dom@18.3.7(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:


### PR DESCRIPTION
## Summary
- create shadcn-style Accordion component
- build full marketing landing page at `/`
- set site metadata for SEO
- add Radix accordion dependency

## Testing
- `pnpm lint`
- `pnpm build:web` *(fails: Can't resolve shared-utils)*

------
https://chatgpt.com/codex/tasks/task_e_687ff5c6dd04832cba9fca5559966853