### PR TITLE
Fix imports and update ESLint config

### DIFF
--- a/apps/web/lib/match.ts
+++ b/apps/web/lib/match.ts
@@ -1,5 +1,5 @@
-import type { CreatorPersona, BrandProfile } from '../../packages/shared-utils/src/fitScoreEngine';
-import { advancedMatch } from '../../packages/shared-utils/src/advancedMatch';
+import type { CreatorPersona, BrandProfile } from '../../../packages/shared-utils/src/fitScoreEngine';
+import { advancedMatch } from '../../../packages/shared-utils/src/advancedMatch';
 
 export async function matchCreator(
   creator: CreatorPersona,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,8 +1,12 @@
+import fs from 'fs';
 import { dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { FlatCompat } from '@eslint/eslintrc';
 import js from '@eslint/js';
-import eslintrc from './.eslintrc.json' assert { type: 'json' };
+
+const eslintrc = JSON.parse(
+  fs.readFileSync(new URL('./.eslintrc.json', import.meta.url), 'utf8')
+);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);


### PR DESCRIPTION
## Summary
- load `.eslintrc.json` with `fs.readFileSync` so eslint works with Node 22
- correct relative paths to shared-utils in `apps/web/lib/match.ts`

## Testing
- `pnpm lint` *(fails: 40 errors, 237 warnings)*
- `pnpm build:web`

------
https://chatgpt.com/codex/tasks/task_e_6880a3c308c8832c9603a404dba4ebce