### PR TITLE
Fix Creator View link and add landing page

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules/
+.next/
+apps/*/.next/
+**/dist/

--- a/apps/web/app/creator-info/page.tsx
+++ b/apps/web/app/creator-info/page.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Link from 'next/link';
+
+export default function CreatorInfoPage() {
+  return (
+    <main className="min-h-screen px-6 py-10 space-y-8 text-center">
+      <h1 className="text-4xl font-bold">Creator Tools</h1>
+      <p className="text-zinc-300 max-w-2xl mx-auto">
+        Explore persona generation, performance insights and campaign tools.
+      </p>
+      <ul className="space-y-2 max-w-md mx-auto text-left list-disc list-inside">
+        <li>Generate AI personas</li>
+        <li>Manage campaigns and applications</li>
+        <li>Track performance metrics</li>
+        <li>Connect with brands</li>
+      </ul>
+      <div className="flex justify-center gap-4">
+        <Link href="/signup?role=creator" className="px-6 py-3 rounded-md bg-Siora-accent hover:bg-Siora-hover">
+          Join as Creator
+        </Link>
+        <Link href="/creator/dashboard" className="px-6 py-3 rounded-md border border-white hover:bg-white hover:text-Siora-dark">
+          Go to Dashboard
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -26,7 +26,7 @@ const navLinks: NavLink[] = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { href: "/shortlist", label: "Shortlist", icon: Heart },
   { href: "/matches", label: "Matches", icon: Users2 },
-  { href: "/creator", label: "Creator View", icon: User },
+  { href: "/creator-info", label: "Creator View", icon: User },
   { href: "/analytics", label: "Analytics", icon: BarChart },
   { href: "/inbox", label: "Inbox", icon: Mail },
   { href: "/billing", label: "Billing", icon: CreditCard },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -17,4 +17,9 @@ const compat = new FlatCompat({
   allConfig: js.configs.all,
 });
 
-export default compat.config(eslintrc);
+export default [
+  ...compat.config(eslintrc),
+  {
+    ignores: ['**/.next/**', 'node_modules/**', '**/dist/**']
+  }
+];


### PR DESCRIPTION
## Summary
- add `/creator-info` landing page for creators
- update nav link to use new landing page
- ignore build directories in ESLint config

## Testing
- `pnpm lint`
- `pnpm build:web`

------
https://chatgpt.com/codex/tasks/task_e_6882a8b526ec832cb73af95efae0c95d