### PR TITLE
Add home button in toolbars

### DIFF
--- a/apps/brand/app/layout.tsx
+++ b/apps/brand/app/layout.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import { Nav, NavLink, PageTransition, ThemeToggle } from "shared-ui";
 
 const navLinks: NavLink[] = [
+  { href: "/", label: "Home" },
   { href: "/dashboard", label: "Dashboard" },
   { href: "/create-brief", label: "Create Brief" },
   { href: "/inbox", label: "Inbox" },

--- a/apps/web/app/creator/layout.tsx
+++ b/apps/web/app/creator/layout.tsx
@@ -18,6 +18,7 @@ export const metadata: Metadata = {
 };
 
 const navLinks: NavLink[] = [
+  { href: '/', label: 'Home' },
   { href: '/creator/dashboard', label: 'Dashboard' },
   { href: '/creator/campaigns', label: 'Campaigns' },
   { href: '/creator/applications', label: 'Applications' },

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -20,9 +20,11 @@ import {
   ShieldCheck,
   ScrollText,
   User,
+  Home as HomeIcon,
 } from "lucide-react";
 
 const navLinks: NavLink[] = [
+  { href: "/", label: "Home", icon: HomeIcon },
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { href: "/shortlist", label: "Shortlist", icon: Heart },
   { href: "/matches", label: "Matches", icon: Users2 },


### PR DESCRIPTION
## Summary
- add a `Home` nav link for the main dashboard layout
- include home in brand and creator toolbars

## Testing
- `pnpm install`
- `pnpm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6882abbdddd8832cacf09cdaa0f29b2e