### PR TITLE
Fix Vercel build path

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "version": 2,
   "builds": [
     {
-      "src": "apps/web/next.config.js",
+      "src": "apps/web",
       "use": "@vercel/next"
     }
   ],


### PR DESCRIPTION
## Summary
- update `vercel.json` so the Next.js builder runs on `apps/web`

## Testing
- `pnpm build --filter=web`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6882aca3b4a0832c93b75d9eee153c65