### PR TITLE
Expose creator tools under main domain

### DIFF
--- a/apps/brand/app/layout.tsx
+++ b/apps/brand/app/layout.tsx
@@ -9,6 +9,7 @@ const navLinks: NavLink[] = [
   { href: "/dashboard", label: "Dashboard" },
   { href: "/create-brief", label: "Create Brief" },
   { href: "/inbox", label: "Inbox" },
+  { href: "/creator", label: "Creator View" },
 ];
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/creator/app/layout.tsx
+++ b/apps/creator/app/layout.tsx
@@ -3,13 +3,24 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import { PageTransition, ThemeToggle } from 'shared-ui';
 import Link from 'next/link';
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@lib/auth';
 
 export const metadata = {
   title: 'Siora Creator',
   description: 'Creator tools for persona generation',
 };
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default async function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect('/signin');
+  }
   return (
     <html lang="en">
       <body className="min-h-screen bg-background text-foreground font-sans">
@@ -26,3 +37,4 @@ export default function RootLayout({ children }: { children: ReactNode }) {
     </html>
   );
 }
+

--- a/apps/creator/app/page.tsx
+++ b/apps/creator/app/page.tsx
@@ -1,15 +1,2 @@
-import React from 'react';
-export default function HomePage() {
-  return (
-    <main className="p-6 space-y-3">
-      <h1 className="text-3xl font-bold">Creator Dashboard</h1>
-      <p className="text-lg font-semibold">
-        You're not here for handouts. You're here to partner on your terms.
-      </p>
-      <p className="text-sm">
-        Siora helps you find brands who value your influence, not just your
-        affiliate sales.
-      </p>
-    </main>
-  );
-}
+export { default } from './onboarding/page'
+

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -28,7 +28,7 @@ const navLinks: NavLink[] = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
   { href: "/shortlist", label: "Shortlist", icon: Heart },
   { href: "/matches", label: "Matches", icon: Users2 },
-  { href: "/creator-info", label: "Creator View", icon: User },
+  { href: "/creator", label: "Creator View", icon: User },
   { href: "/analytics", label: "Analytics", icon: BarChart },
   { href: "/inbox", label: "Inbox", icon: Mail },
   { href: "/billing", label: "Billing", icon: CreditCard },

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -14,16 +14,13 @@ const nextConfig: NextConfig = {
   // Allow Next.js to transpile internal packages written in TypeScript.
   transpilePackages: ["shared-ui", "shared-utils"],
   async rewrites() {
-    const creatorUrl = process.env.CREATOR_APP_URL;
-    if (creatorUrl) {
-      return [
-        {
-          source: "/creator/:path*",
-          destination: `${creatorUrl}/:path*`,
-        },
-      ];
-    }
-    return [];
+    const creatorUrl = process.env.CREATOR_APP_URL || "http://localhost:3001";
+    return [
+      {
+        source: "/creator/:path*",
+        destination: `${creatorUrl}/:path*`,
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
## Summary
- expose creator onboarding on creator app homepage
- show Creator View link in all main navigation bars
- protect creator app with auth
- proxy /creator route to creator app

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6885f983a600832cb7c717ae9eb3ea94