### PR TITLE
Expose creator tools on main site

### DIFF
--- a/apps/brand/app/layout.tsx
+++ b/apps/brand/app/layout.tsx
@@ -9,6 +9,7 @@ const navLinks: NavLink[] = [
   { href: "/dashboard", label: "Dashboard" },
   { href: "/create-brief", label: "Create Brief" },
   { href: "/inbox", label: "Inbox" },
+  { href: "/creator", label: "Creator View" },
 ];
 
 export default function RootLayout({ children }: { children: ReactNode }) {

--- a/apps/creator/app/page.tsx
+++ b/apps/creator/app/page.tsx
@@ -1,15 +1,12 @@
-import React from 'react';
-export default function HomePage() {
-  return (
-    <main className="p-6 space-y-3">
-      <h1 className="text-3xl font-bold">Creator Dashboard</h1>
-      <p className="text-lg font-semibold">
-        You're not here for handouts. You're here to partner on your terms.
-      </p>
-      <p className="text-sm">
-        Siora helps you find brands who value your influence, not just your
-        affiliate sales.
-      </p>
-    </main>
-  );
+import CreatorOnboarding from './onboarding/page';
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from './lib/auth';
+
+export default async function HomePage() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect('/signin');
+  }
+  return <CreatorOnboarding />;
 }


### PR DESCRIPTION
## Summary
- show Creator onboarding flow on `/creator` home page
- link to Creator View from brand layout navigation

## Testing
- `pnpm lint`
- `pnpm --filter web build`
- `pnpm --filter creator build` *(fails: export metadata with `use client`)*
- `pnpm --filter brand build`


------
https://chatgpt.com/codex/tasks/task_e_6885fb50cb68832ca663cd1f5f4d14fa