### PR TITLE
Implement sleek dark theme

### DIFF
--- a/apps/brand/package.json
+++ b/apps/brand/package.json
@@ -14,6 +14,7 @@
     "@prisma/client": "^6.9.0",
     "@react-pdf/renderer": "^4.3.0",
     "@tailwindcss/typography": "^0.5.16",
+    "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/vite": "^4.1.3",
     "@tanstack/react-query": "^4.36.1",
     "@trpc/client": "^10.45.0",

--- a/apps/creator/package.json
+++ b/apps/creator/package.json
@@ -14,6 +14,7 @@
     "@prisma/client": "^6.9.0",
     "@react-pdf/renderer": "^4.3.0",
     "@tailwindcss/typography": "^0.5.16",
+    "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/vite": "^4.1.3",
     "@tanstack/react-query": "^4.36.1",
     "@trpc/client": "^10.45.0",

--- a/apps/web/app/creator/error.tsx
+++ b/apps/web/app/creator/error.tsx
@@ -8,11 +8,11 @@ export default function Error({ error, reset }: { error: Error & { digest?: stri
   }, [error]);
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-6">
-      <h2 className="text-2xl font-bold mb-4">Something went wrong</h2>
+    <div className="min-h-screen flex flex-col items-center justify-center bg-Siora-dark text-white space-y-4 p-6">
+      <h2 className="text-2xl font-bold">Something went wrong</h2>
       <button
         onClick={() => reset()}
-        className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded"
+        className="bg-Siora-accent hover:bg-Siora-hover px-4 py-2 rounded-xl transition-all hover:scale-[1.02]"
       >
         Try again
       </button>

--- a/apps/web/app/creator/not-found.tsx
+++ b/apps/web/app/creator/not-found.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 export default function NotFound() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-6">
-      <h2 className="text-2xl font-bold mb-4">404 - Page Not Found</h2>
-      <p>The page you are looking for does not exist.</p>
+    <div className="min-h-screen flex flex-col items-center justify-center bg-Siora-dark text-white space-y-4 p-6">
+      <h2 className="text-2xl font-bold">Oops. Page not found.</h2>
+      <a
+        href="/dashboard"
+        className="px-4 py-2 bg-Siora-accent hover:bg-Siora-hover rounded-xl transition-all hover:scale-[1.02]"
+      >
+        ← Back to dashboard
+      </a>
     </div>
   );
 }

--- a/apps/web/app/error.tsx
+++ b/apps/web/app/error.tsx
@@ -8,11 +8,11 @@ export default function Error({ error, reset }: { error: Error & { digest?: stri
   }, [error]);
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-6">
-      <h2 className="text-2xl font-bold mb-4">Something went wrong</h2>
+    <div className="min-h-screen flex flex-col items-center justify-center bg-Siora-dark text-white space-y-4 p-6">
+      <h2 className="text-2xl font-bold">Something went wrong</h2>
       <button
         onClick={() => reset()}
-        className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded"
+        className="bg-Siora-accent hover:bg-Siora-hover px-4 py-2 rounded-xl transition-all hover:scale-[1.02]"
       >
         Try again
       </button>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -7,8 +7,8 @@
     scroll-behavior: smooth;
   }
   body {
-    background-color: #0f172a;
-    color: white;
+    background-color: #111827;
+    color: #F9FAFB;
     font-family: theme("fontFamily.sans");
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/apps/web/app/home/error.tsx
+++ b/apps/web/app/home/error.tsx
@@ -8,11 +8,11 @@ export default function Error({ error, reset }: { error: Error & { digest?: stri
   }, [error]);
 
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-6">
-      <h2 className="text-2xl font-bold mb-4">Something went wrong</h2>
+    <div className="min-h-screen flex flex-col items-center justify-center bg-Siora-dark text-white space-y-4 p-6">
+      <h2 className="text-2xl font-bold">Something went wrong</h2>
       <button
         onClick={() => reset()}
-        className="bg-blue-600 hover:bg-blue-500 text-white px-4 py-2 rounded"
+        className="bg-Siora-accent hover:bg-Siora-hover px-4 py-2 rounded-xl transition-all hover:scale-[1.02]"
       >
         Try again
       </button>

--- a/apps/web/app/home/not-found.tsx
+++ b/apps/web/app/home/not-found.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 export default function NotFound() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-6">
-      <h2 className="text-2xl font-bold mb-4">404 - Page Not Found</h2>
-      <p>The page you are looking for does not exist.</p>
+    <div className="min-h-screen flex flex-col items-center justify-center bg-Siora-dark text-white space-y-4 p-6">
+      <h2 className="text-2xl font-bold">Oops. Page not found.</h2>
+      <a
+        href="/dashboard"
+        className="px-4 py-2 bg-Siora-accent hover:bg-Siora-hover rounded-xl transition-all hover:scale-[1.02]"
+      >
+        ← Back to dashboard
+      </a>
     </div>
   );
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 "use client";
 import "./globals.css";
+import { Inter } from 'next/font/google';
 import type { ReactNode } from "react";
 import { SessionProvider } from "next-auth/react";
 import { BrandUserProvider } from "../lib/brandUser";
@@ -10,6 +11,7 @@ import { ThemeProvider } from "./providers";
 import PostHogProvider from "../components/PostHogProvider";
 import { Analytics } from "@vercel/analytics/react";
 import * as React from "react";
+const inter = Inter({ subsets: ['latin'] });
 import {
   LayoutDashboard,
   Heart,
@@ -40,20 +42,20 @@ const navLinks: NavLink[] = [
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en" className="scroll-smooth">
+    <html lang="en" className={`${inter.className} scroll-smooth`}>
       <head>
         <title>Siora Dashboard</title>
         <meta name="description" content="Siora brand dashboard" />
         <link rel="icon" href="/favicon-32x32.png" sizes="32x32" />
       </head>
-      <body className="min-h-screen bg-[#0D0F12] text-white font-sans antialiased">
+      <body className="min-h-screen bg-Siora-dark text-white antialiased">
         <ThemeProvider>
           <PostHogProvider />
           <Analytics />
           <SessionProvider>
             <BrandUserProvider>
               <TrpcProvider>
-                <header className="sticky top-0 z-50 bg-[#0D0F12]/80 backdrop-blur border-b border-Siora-border">
+                <header className="sticky top-0 z-50 bg-Siora-dark/80 backdrop-blur border-b border-Siora-border">
                   <div className="max-w-7xl mx-auto px-6 sm:px-8 py-4 flex justify-between items-center">
                     <AuthStatus />
                     <div className="flex items-center gap-4">

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 export default function NotFound() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-6">
-      <h2 className="text-2xl font-bold mb-4">404 - Page Not Found</h2>
-      <p>The page you are looking for does not exist.</p>
+    <div className="min-h-screen flex flex-col items-center justify-center bg-Siora-dark text-white space-y-4 p-6">
+      <h2 className="text-2xl font-bold">Oops. Page not found.</h2>
+      <a
+        href="/dashboard"
+        className="px-4 py-2 bg-Siora-accent hover:bg-Siora-hover rounded-xl transition-all hover:scale-[1.02]"
+      >
+        ← Back to dashboard
+      </a>
     </div>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import { motion } from 'framer-motion'
 import { Hero } from 'shared-ui'
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
-import { ChevronUp } from 'lucide-react'
+import { ChevronUp, Search, Gauge, Handshake } from 'lucide-react'
 
 export default function Page() {
   const { data: session, status } = useSession()
@@ -22,21 +22,33 @@ export default function Page() {
 
   return (
     <main className="min-h-screen bg-Siora-dark text-white font-sans">
+      <header className="sticky top-0 z-50 bg-Siora-dark/80 backdrop-blur px-6 sm:px-12 py-4 flex justify-between items-center">
+        <span className="font-bold text-lg">Siora</span>
+        <nav className="flex items-center gap-6 text-sm">
+          <a href="/signin" className="hover:text-Siora-accent transition-all">Login</a>
+          <a href="#how" className="hover:text-Siora-accent transition-all">How it works</a>
+          <a href="/creator" className="bg-Siora-accent hover:bg-Siora-hover text-white px-4 py-2 rounded-xl transition-all hover:scale-[1.02]">Start</a>
+        </nav>
+      </header>
       {/* Hero */}
       <Hero
-        title="AI-powered brand‑creator partnerships."
-        subtitle="AI-powered brand-creator partnerships. Built for creators who value their worth."
-        ctaLabel="Join as Creator"
-        ctaHref="/creator"
+        title="Siora connects brands with creators that match their values — not just follower counts."
+        subtitle=""
         className="max-w-5xl"
         fullHeight
       />
       <div className="flex justify-center gap-4 -mt-8">
         <a
           href="/brand"
-          className="px-6 py-3 rounded-md border border-white hover:bg-white hover:text-Siora-dark transition"
+          className="px-6 py-3 rounded-xl bg-Siora-accent hover:bg-Siora-hover transition-all hover:scale-[1.02]"
         >
-          Join as Brand
+          Start as Brand
+        </a>
+        <a
+          href="/creator"
+          className="px-6 py-3 rounded-xl bg-Siora-accent hover:bg-Siora-hover transition-all hover:scale-[1.02]"
+        >
+          Start as Creator
         </a>
       </div>
 
@@ -54,7 +66,7 @@ export default function Page() {
       </section>
 
       {/* How it works */}
-      <section className="px-6 py-24 max-w-4xl mx-auto space-y-12">
+      <section id="how" className="px-6 py-24 max-w-4xl mx-auto space-y-12">
         <h2 className="text-3xl font-bold text-center mb-6">How it works</h2>
         <div className="grid md:grid-cols-3 gap-8 text-center">
           <motion.div
@@ -92,23 +104,22 @@ export default function Page() {
 
       {/* Value props */}
       <section className="px-6 py-24 bg-Siora-mid">
-        <h2 className="text-3xl font-bold text-center mb-12">Features</h2>
-        <div className="grid md:grid-cols-2 gap-12 max-w-5xl mx-auto">
-          <div>
-            <h3 className="text-2xl font-semibold mb-4">Creators</h3>
-            <ul className="space-y-2 list-disc list-inside text-zinc-300">
-              <li>Smart persona builder</li>
-              <li>Fairness layer</li>
-              <li>Protect against affiliate-only offers</li>
-            </ul>
+        <h2 className="text-3xl font-bold text-center mb-12">Why Siora?</h2>
+        <div className="grid md:grid-cols-3 gap-12 max-w-5xl mx-auto">
+          <div className="space-y-3 text-center">
+            <Search className="w-10 h-10 mx-auto text-Siora-accent" />
+            <h3 className="text-xl font-semibold">Find creators who match your tone.</h3>
+            <p className="text-zinc-400 text-sm">Our AI analyses style and values so you connect with personalities that truly resonate.</p>
           </div>
-          <div>
-            <h3 className="text-2xl font-semibold mb-4">Brands</h3>
-            <ul className="space-y-2 list-disc list-inside text-zinc-300">
-              <li>GPT-powered briefs</li>
-              <li>Intelligent match scoring</li>
-              <li>Shortlist management</li>
-            </ul>
+          <div className="space-y-3 text-center">
+            <Gauge className="w-10 h-10 mx-auto text-Siora-accent" />
+            <h3 className="text-xl font-semibold">AI-powered campaign scoring.</h3>
+            <p className="text-zinc-400 text-sm">See at a glance how each creator aligns with your brief for efficient outreach.</p>
+          </div>
+          <div className="space-y-3 text-center">
+            <Handshake className="w-10 h-10 mx-auto text-Siora-accent" />
+            <h3 className="text-xl font-semibold">Respect creators’ value.</h3>
+            <p className="text-zinc-400 text-sm">Transparent offers ensure fair deals that build lasting relationships.</p>
           </div>
         </div>
       </section>
@@ -171,15 +182,15 @@ export default function Page() {
         >
           <a
             href="/creator"
-            className="px-6 py-3 rounded-md bg-Siora-accent hover:bg-Siora-hover transition shadow-Siora-hover"
+            className="px-6 py-3 rounded-xl bg-Siora-accent hover:bg-Siora-hover transition-all hover:scale-[1.02]"
           >
-            Join as Creator
+            Start as Creator
           </a>
           <a
             href="/brand"
-            className="px-6 py-3 rounded-md border border-white hover:bg-white hover:text-Siora-dark transition"
+            className="px-6 py-3 rounded-xl bg-Siora-accent hover:bg-Siora-hover transition-all hover:scale-[1.02]"
           >
-            Join as Brand
+            Start as Brand
           </a>
         </motion.div>
       </section>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-tabs": "^1.1.12",
     "@react-pdf/renderer": "^4.3.0",
     "@tailwindcss/typography": "^0.5.16",
+    "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/vite": "^4.1.3",
     "@tanstack/react-query": "^4.36.1",
     "@trpc/client": "^10.45.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@eslint/eslintrc": "3.3.1",
     "@eslint/js": "^9.31.0",
     "@tailwindcss/postcss": "^4.1.11",
+    "@tailwindcss/forms": "^0.5.10",
     "@types/axios": "^0.14.4",
     "@types/node": "^24.0.15",
     "@types/react": "^19.1.8",

--- a/packages/shared-ui/src/Hero.tsx
+++ b/packages/shared-ui/src/Hero.tsx
@@ -29,7 +29,7 @@ export function Hero({
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.5 }}
-        className="text-5xl font-extrabold tracking-tight"
+        className="text-4xl sm:text-6xl font-bold tracking-tight"
       >
         {title}
       </motion.h1>
@@ -49,7 +49,7 @@ export function Hero({
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.2, duration: 0.5 }}
           href={ctaHref}
-          className="inline-block px-6 py-3 rounded-md bg-Siora-accent text-white hover:bg-Siora-hover transition-all duration-300 ease-in-out"
+          className="inline-block px-6 py-3 rounded-xl bg-Siora-accent text-white hover:bg-Siora-hover transition-all duration-300 hover:scale-[1.02]"
         >
           {ctaLabel}
         </motion.a>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@eslint/js':
         specifier: ^9.31.0
         version: 9.31.0
+      '@tailwindcss/forms':
+        specifier: ^0.5.10
+        version: 0.5.10(tailwindcss@4.1.11)
       '@tailwindcss/postcss':
         specifier: ^4.1.11
         version: 4.1.11
@@ -129,6 +132,9 @@ importers:
       '@react-pdf/renderer':
         specifier: ^4.3.0
         version: 4.3.0(react@19.1.0)
+      '@tailwindcss/forms':
+        specifier: ^0.5.10
+        version: 0.5.10(tailwindcss@4.1.11)
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@4.1.11)
@@ -265,6 +271,9 @@ importers:
       '@react-pdf/renderer':
         specifier: ^4.3.0
         version: 4.3.0(react@19.1.0)
+      '@tailwindcss/forms':
+        specifier: ^0.5.10
+        version: 0.5.10(tailwindcss@4.1.11)
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@4.1.11)
@@ -410,6 +419,9 @@ importers:
       '@react-pdf/renderer':
         specifier: ^4.3.0
         version: 4.3.0(react@19.1.0)
+      '@tailwindcss/forms':
+        specifier: ^0.5.10
+        version: 0.5.10(tailwindcss@4.1.11)
       '@tailwindcss/typography':
         specifier: ^0.5.16
         version: 0.5.16(tailwindcss@4.1.11)
@@ -1471,6 +1483,11 @@ packages:
 
   '@swc/helpers@0.5.17':
     resolution: {integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==}
+
+  '@tailwindcss/forms@0.5.10':
+    resolution: {integrity: sha512-utI1ONF6uf/pPNO68kmN1b8rEwNXv3czukalo8VtJH8ksIkZXr3Q3VYudZLkCsDd4Wku120uF02hYK25XGPorw==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1'
 
   '@tailwindcss/node@4.1.11':
     resolution: {integrity: sha512-yzhzuGRmv5QyU9qLNg4GTlYI6STedBWRE7NjxP45CsFYYq9taI0zJXZBMqIC/c8fViNLhmrbpSFS57EoxUmD6Q==}
@@ -3373,6 +3390,10 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mini-svg-data-uri@1.4.4:
+    resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
+    hasBin: true
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -5353,6 +5374,11 @@ snapshots:
   '@swc/helpers@0.5.17':
     dependencies:
       tslib: 2.8.1
+
+  '@tailwindcss/forms@0.5.10(tailwindcss@4.1.11)':
+    dependencies:
+      mini-svg-data-uri: 1.4.4
+      tailwindcss: 4.1.11
 
   '@tailwindcss/node@4.1.11':
     dependencies:
@@ -7564,6 +7590,8 @@ snapshots:
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mini-svg-data-uri@1.4.4: {}
 
   minimatch@3.1.2:
     dependencies:

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,12 +6,12 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        'Siora-dark': '#0f172a',
-        'Siora-mid': '#1e293b',
-        'Siora-light': '#334155',
-        'Siora-accent': '#7c3aed',
-        'Siora-accent-soft': '#a78bfa',
-        'Siora-border': '#475569',
+        'Siora-dark': '#111827',
+        'Siora-mid': '#1f2937',
+        'Siora-light': '#374151',
+        'Siora-accent': '#6366F1',
+        'Siora-accent-soft': '#818cf8',
+        'Siora-border': '#4b5563',
         'Siora-hover': '#818cf8',
       },
       backgroundImage: {
@@ -25,5 +25,8 @@ module.exports = {
       },
     },
   },
-  plugins: [require('@tailwindcss/typography')],
+  plugins: [
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/forms'),
+  ],
 };


### PR DESCRIPTION
## Summary
- refresh global dark palette and add Tailwind forms plugin
- import Inter font and update layout
- enhance Hero component with smoother CTAs
- redesign marketing page with sticky nav and value props
- style error and not-found pages to match theme

## Testing
- `pnpm lint`
- `pnpm build:web`


------
https://chatgpt.com/codex/tasks/task_e_68863e6588f4832cb3a0910183c09f53