### PR TITLE
Add creator dashboard with auth guard

### DIFF
--- a/apps/web/app/creator/AuthGuard.tsx
+++ b/apps/web/app/creator/AuthGuard.tsx
@@ -1,0 +1,37 @@
+'use client';
+import { PropsWithChildren, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import { Spinner } from 'shared-ui';
+
+export default function AuthGuard({ children }: PropsWithChildren) {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === 'unauthenticated') router.replace('/signin');
+    if (status === 'authenticated') {
+      if (!session || (session.user as { role?: string }).role !== 'creator') {
+        router.replace('/signin');
+      }
+    }
+  }, [status, session, router]);
+
+  if (status === 'loading') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-950 text-white">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (!session || (session.user as { role?: string }).role !== 'creator') {
+    return (
+      <main className="min-h-screen flex items-center justify-center bg-gray-950 text-white">
+        Access denied
+      </main>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/apps/web/app/creator/page.tsx
+++ b/apps/web/app/creator/page.tsx
@@ -1,60 +1,125 @@
 'use client';
 import React, { useEffect, useState } from 'react';
+import { SessionProvider } from 'next-auth/react';
+import toast, { Toaster } from 'react-hot-toast';
+import AuthGuard from './AuthGuard';
+import { useGeneratePersona } from '@creator/lib/useGeneratePersona';
+import { loadPersonasFromLocal, savePersonaToLocal } from '@creator/lib/localPersonas';
+import { loadProfileSettings } from '@creator/lib/profileSettings';
+import type { PersonaProfile } from '@creator/types/persona';
 import Link from 'next/link';
-import { loadPersonasFromLocal, type StoredPersona } from '@creator/lib/localPersonas';
-import { brands } from '@creator/data/brands';
 
-export default function CreatorDashboard() {
-  const [personas, setPersonas] = useState<StoredPersona[]>([]);
+export default function CreatorPage() {
+  return (
+    <SessionProvider>
+      <Toaster />
+      <AuthGuard>
+        <Dashboard />
+      </AuthGuard>
+    </SessionProvider>
+  );
+}
+
+function Dashboard() {
+  const { generate, loading, persona, setPersona } = useGeneratePersona();
+  const [pitch, setPitch] = useState('');
+  const [pitchLoading, setPitchLoading] = useState(false);
+
   useEffect(() => {
-    setPersonas(loadPersonasFromLocal());
-  }, []);
+    const list = loadPersonasFromLocal();
+    if (list.length > 0) setPersona(list[0].persona as PersonaProfile);
+    if (typeof window !== 'undefined') {
+      const storedPitch = localStorage.getItem('creatorPitch');
+      if (storedPitch) setPitch(storedPitch);
+    }
+  }, [setPersona]);
+
+  const handleGeneratePersona = async () => {
+    const settings = loadProfileSettings();
+    const bio = settings?.bio || '';
+    if (!bio) {
+      toast.error('No intro found in profile settings');
+    }
+    const result = await generate({ captions: [bio || ''] });
+    if (result) {
+      savePersonaToLocal(result);
+      toast.success('Persona generated');
+    }
+  };
+
+  const handleGeneratePitch = async () => {
+    if (!persona) {
+      toast.error('Generate persona first');
+      return;
+    }
+    setPitchLoading(true);
+    try {
+      const res = await fetch('/api/pitch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ persona, brand: 'Generic Brand' }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to generate pitch');
+      setPitch(data.pitch as string);
+      if (typeof window !== 'undefined') {
+        localStorage.setItem('creatorPitch', data.pitch as string);
+      }
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Error generating pitch');
+    } finally {
+      setPitchLoading(false);
+    }
+  };
 
   return (
-    <main className="min-h-screen bg-background text-foreground p-6 space-y-6">
-      <h1 className="text-2xl font-bold">Creator Dashboard</h1>
-      {personas.length === 0 ? (
-        <p>
-          No personas found.{' '}
-          <Link href="/creator/generate" className="underline">
-            Generate one
-          </Link>
-          .
-        </p>
-      ) : (
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold">Your Personas</h2>
-          <ul className="space-y-2">
-            {personas.map((p, idx) => (
-              <li key={idx} className="border border-white/10 p-4 rounded">
-                <p className="font-semibold">{(p.persona as any).name || `Persona ${idx + 1}`}</p>
-                {(p.persona as any).summary && (
-                  <p className="text-sm text-foreground/80">{(p.persona as any).summary}</p>
-                )}
-              </li>
-            ))}
-          </ul>
+    <main className="min-h-screen bg-gray-950 text-white p-6 space-y-8">
+      <h1 className="text-2xl font-bold text-indigo-400">Creator Dashboard</h1>
+
+      <section className="rounded-xl border border-gray-800 p-6 bg-gray-900/80 shadow-md space-y-4">
+        <h2 className="text-xl font-semibold">🎯 Your Persona</h2>
+        {persona ? (
+          <div className="space-y-2">
+            <p><span className="font-semibold">Age:</span> {(persona as any).age || 'N/A'}</p>
+            <p><span className="font-semibold">Tone:</span> {(persona as any).tone || 'N/A'}</p>
+            <p><span className="font-semibold">Personality:</span> {persona.personality || 'N/A'}</p>
+            <p><span className="font-semibold">Strengths:</span> {(persona.interests || []).join(', ') || 'N/A'}</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            <p>Generate a persona to get tailored brand opportunities.</p>
+            <button onClick={handleGeneratePersona} className="bg-indigo-500 hover:bg-indigo-600 text-white rounded px-4 py-2" disabled={loading}>
+              {loading ? 'Generating...' : 'Generate My Persona'}
+            </button>
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-xl border border-gray-800 p-6 bg-gray-900/80 shadow-md space-y-4">
+        <h2 className="text-xl font-semibold">🧠 Your Brand Pitch</h2>
+        {pitch ? (
+          <textarea
+            className="w-full p-2 bg-gray-800 rounded text-white"
+            rows={6}
+            value={pitch}
+            onChange={(e) => setPitch(e.target.value)}
+          />
+        ) : (
+          <p className="text-sm">Generate a short pitch to introduce yourself to brands.</p>
+        )}
+        <button onClick={handleGeneratePitch} className="bg-indigo-500 hover:bg-indigo-600 text-white rounded px-4 py-2" disabled={pitchLoading}>
+          {pitchLoading ? 'Generating...' : pitch ? 'Refine Pitch' : 'Generate Pitch'}
+        </button>
+      </section>
+
+      <section className="rounded-xl border border-gray-800 p-6 bg-gray-900/80 shadow-md space-y-2">
+        <h2 className="text-xl font-semibold">🛠 Tools &amp; Settings</h2>
+        <div className="flex flex-col gap-2 text-indigo-400">
+          <Link href="/creator/settings" className="underline">Update Profile</Link>
+          <Link href="/creator/signin" className="underline">Connect Instagram Again</Link>
+          <Link href="/creator/contact" className="underline">Contact Support</Link>
         </div>
-      )}
-      <div className="space-y-2">
-        <h2 className="text-xl font-semibold">Brand Opportunities</h2>
-        <ul className="grid gap-4 md:grid-cols-2">
-          {brands.slice(0, 4).map((brand) => (
-            <li key={brand.id} className="border border-white/10 p-4 rounded">
-              <p className="font-semibold">{brand.name}</p>
-              <p className="text-sm text-foreground/80">{brand.summary}</p>
-            </li>
-          ))}
-        </ul>
-        <Link href="/creator/brands" className="underline">
-          View all brands
-        </Link>
-      </div>
-      <div>
-        <Link href="/creator/generate" className="px-4 py-2 mt-4 inline-block rounded bg-indigo-600 text-white">
-          Generate New Persona
-        </Link>
-      </div>
+      </section>
     </main>
   );
 }

--- a/apps/web/creator/lib/generatePersonaData.ts
+++ b/apps/web/creator/lib/generatePersonaData.ts
@@ -1,0 +1,26 @@
+import type { PersonaProfile } from '@creator/types/persona';
+
+export interface PersonaInput {
+  captions: string[];
+  tone?: string;
+  audience?: string;
+  platform?: string;
+}
+
+export async function generatePersonaData(input: PersonaInput): Promise<PersonaProfile | null> {
+  try {
+    const res = await fetch('/creator/api/generatePersona', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      throw new Error(data.error || 'Failed to generate');
+    }
+    return data as PersonaProfile;
+  } catch (err) {
+    console.error('generatePersonaData error:', err);
+    return null;
+  }
+}

--- a/apps/web/creator/lib/useGeneratePersona.ts
+++ b/apps/web/creator/lib/useGeneratePersona.ts
@@ -1,0 +1,30 @@
+'use client';
+import { useState } from 'react';
+import toast from 'react-hot-toast';
+import type { PersonaProfile } from '@creator/types/persona';
+import { generatePersonaData, PersonaInput } from './generatePersonaData';
+
+export function useGeneratePersona() {
+  const [loading, setLoading] = useState(false);
+  const [persona, setPersona] = useState<PersonaProfile | null>(null);
+
+  const generate = async (input: PersonaInput) => {
+    setLoading(true);
+    try {
+      const result = await generatePersonaData(input);
+      if (!result) {
+        toast.error('Failed to generate persona');
+        return null;
+      }
+      setPersona(result);
+      return result;
+    } catch (err) {
+      toast.error('Error generating persona');
+      return null;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { generate, loading, persona, setPersona };
+}

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "devDependencies": {
     "@eslint/eslintrc": "3.3.1",
     "@eslint/js": "^9.31.0",
-    "@tailwindcss/postcss": "^4.1.11",
     "@tailwindcss/forms": "^0.5.10",
+    "@tailwindcss/postcss": "^4.1.11",
     "@types/axios": "^0.14.4",
     "@types/node": "^24.0.15",
     "@types/react": "^19.1.8",
@@ -62,7 +62,8 @@
     "nodemailer": "^7.0.5",
     "pdfkit": "^0.15.2",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-hot-toast": "^2.5.2"
   },
   "prisma": {
     "schema": "./prisma/schema.prisma",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-hot-toast:
+        specifier: ^2.5.2
+        version: 2.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@eslint/eslintrc':
         specifier: 3.3.1
@@ -2786,6 +2789,11 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  goober@2.1.16:
+    resolution: {integrity: sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==}
+    peerDependencies:
+      csstype: ^3.0.10
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -3810,6 +3818,13 @@ packages:
     resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
       react: ^19.1.0
+
+  react-hot-toast@2.5.2:
+    resolution: {integrity: sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
 
   react-icons@4.12.0:
     resolution: {integrity: sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==}
@@ -6861,6 +6876,10 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  goober@2.1.16(csstype@3.1.3):
+    dependencies:
+      csstype: 3.1.3
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -8024,6 +8043,13 @@ snapshots:
     dependencies:
       react: 19.1.0
       scheduler: 0.26.0
+
+  react-hot-toast@2.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      csstype: 3.1.3
+      goober: 2.1.16(csstype@3.1.3)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   react-icons@4.12.0(react@19.1.0):
     dependencies:


### PR DESCRIPTION
## Summary
- add AuthGuard component to protect creator routes
- install and use `react-hot-toast`
- implement hooks to generate persona data via GPT
- update `/creator` page with persona and brand pitch sections

## Testing
- `pnpm lint`
- `pnpm test` *(fails: no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_68866b1e205c832cb483b3837641cfe4