### PR TITLE
Implement separate brand/creator flows

### DIFF
--- a/apps/web/app/auth/login/page.tsx
+++ b/apps/web/app/auth/login/page.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { useState } from 'react';
+import { signIn } from 'next-auth/react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from 'shared-ui';
+
+export default function LoginPage() {
+  const [tab, setTab] = useState('brand');
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center gap-6 p-6">
+      <h1 className="text-2xl font-bold">Login</h1>
+      <Tabs value={tab} onValueChange={setTab} className="w-80">
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="brand">Login as Brand</TabsTrigger>
+          <TabsTrigger value="creator">Login with Instagram</TabsTrigger>
+        </TabsList>
+        <TabsContent value="brand" className="mt-4 flex justify-center">
+          <button
+            onClick={() => signIn('google', { callbackUrl: '/dashboard' })}
+            className="px-4 py-2 bg-Siora-accent text-white rounded"
+          >
+            Sign in with Google
+          </button>
+        </TabsContent>
+        <TabsContent value="creator" className="mt-4 flex justify-center">
+          <button
+            onClick={() => (window.location.href = '/instagram/login')}
+            className="px-4 py-2 bg-Siora-accent text-white rounded"
+          >
+            Connect Instagram
+          </button>
+        </TabsContent>
+      </Tabs>
+    </main>
+  );
+}

--- a/apps/web/app/creator/page.tsx
+++ b/apps/web/app/creator/page.tsx
@@ -1,60 +1,47 @@
 'use client';
+// Creator portal with streamlined Instagram connect and campaign matching
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { loadPersonasFromLocal, type StoredPersona } from '@creator/lib/localPersonas';
-import { brands } from '@creator/data/brands';
+import { campaigns } from '@/app/data/campaigns';
 
-export default function CreatorDashboard() {
+export default function CreatorPage() {
   const [personas, setPersonas] = useState<StoredPersona[]>([]);
   useEffect(() => {
     setPersonas(loadPersonasFromLocal());
   }, []);
 
+  const persona = personas[0];
+
   return (
     <main className="min-h-screen bg-background text-foreground p-6 space-y-6">
-      <h1 className="text-2xl font-bold">Creator Dashboard</h1>
-      {personas.length === 0 ? (
-        <p>
-          No personas found.{' '}
-          <Link href="/creator/generate" className="underline">
-            Generate one
-          </Link>
-          .
-        </p>
-      ) : (
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold">Your Personas</h2>
-          <ul className="space-y-2">
-            {personas.map((p, idx) => (
-              <li key={idx} className="border border-white/10 p-4 rounded">
-                <p className="font-semibold">{(p.persona as any).name || `Persona ${idx + 1}`}</p>
-                {(p.persona as any).summary && (
-                  <p className="text-sm text-foreground/80">{(p.persona as any).summary}</p>
-                )}
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
-      <div className="space-y-2">
-        <h2 className="text-xl font-semibold">Brand Opportunities</h2>
-        <ul className="grid gap-4 md:grid-cols-2">
-          {brands.slice(0, 4).map((brand) => (
-            <li key={brand.id} className="border border-white/10 p-4 rounded">
-              <p className="font-semibold">{brand.name}</p>
-              <p className="text-sm text-foreground/80">{brand.summary}</p>
+      <h1 className="text-2xl font-bold">Creator Portal</h1>
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold">Connect</h2>
+        <a href="/instagram/login" className="px-4 py-2 inline-block rounded bg-Siora-accent text-white">
+          Connect Instagram
+        </a>
+      </section>
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold">Persona Summary</h2>
+        {persona ? (
+          <p className="text-sm text-foreground/80">{(persona.persona as any).summary}</p>
+        ) : (
+          <p>No persona yet. <Link href="/creator/generate" className="underline">Build one</Link>.</p>
+        )}
+      </section>
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold">Matched Campaigns</h2>
+        <ul className="space-y-2">
+          {campaigns.slice(0,3).map(c => (
+            <li key={c.id} className="border border-white/10 p-4 rounded">
+              <p className="font-semibold">{c.name}</p>
+              <p className="text-sm text-foreground/80">{c.requirements}</p>
+              <button className="mt-2 px-3 py-1 text-sm rounded bg-Siora-accent text-white">Apply</button>
             </li>
           ))}
         </ul>
-        <Link href="/creator/brands" className="underline">
-          View all brands
-        </Link>
-      </div>
-      <div>
-        <Link href="/creator/generate" className="px-4 py-2 mt-4 inline-block rounded bg-indigo-600 text-white">
-          Generate New Persona
-        </Link>
-      </div>
+      </section>
     </main>
   );
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,6 +7,7 @@ import { BrandUserProvider } from "../lib/brandUser";
 import TrpcProvider from "./trpcProvider";
 import { PageTransition, Nav, NavLink, ThemeToggle } from "shared-ui";
 import AuthStatus from "../components/AuthStatus";
+import Footer from "../components/Footer";
 import { ThemeProvider } from "./providers";
 import PostHogProvider from "../components/PostHogProvider";
 import { Analytics } from "@vercel/analytics/react";
@@ -68,6 +69,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                 <main className="max-w-7xl mx-auto px-6 sm:px-8 py-10">
                   <PageTransition>{children}</PageTransition>
                 </main>
+                <Footer />
               </TrpcProvider>
             </BrandUserProvider>
           </SessionProvider>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -39,16 +39,16 @@ export default function Page() {
       />
       <div className="flex justify-center gap-4 -mt-8">
         <a
-          href="/brand"
+          href="/dashboard"
           className="px-6 py-3 rounded-xl bg-emerald-500 hover:bg-emerald-600 transition-all hover:scale-[1.02]"
         >
-          Start as Brand
+          I'm a Brand
         </a>
         <a
           href="/creator"
           className="px-6 py-3 rounded-xl bg-emerald-500 hover:bg-emerald-600 transition-all hover:scale-[1.02]"
         >
-          Start as Creator
+          I'm a Creator
         </a>
       </div>
 
@@ -184,13 +184,13 @@ export default function Page() {
             href="/creator"
             className="px-6 py-3 rounded-xl bg-emerald-500 hover:bg-emerald-600 transition-all hover:scale-[1.02]"
           >
-            Start as Creator
+            I'm a Creator
           </a>
           <a
-            href="/brand"
+            href="/dashboard"
             className="px-6 py-3 rounded-xl bg-emerald-500 hover:bg-emerald-600 transition-all hover:scale-[1.02]"
           >
-            Start as Brand
+            I'm a Brand
           </a>
         </motion.div>
       </section>

--- a/apps/web/components/AdvancedFilterBar.tsx
+++ b/apps/web/components/AdvancedFilterBar.tsx
@@ -15,6 +15,8 @@ export type Filters = {
   minEngagement: number;
   maxEngagement: number;
   minCollabs: number;
+  minFollowers: number;
+  maxFollowers: number;
 };
 
 interface Props {
@@ -40,6 +42,8 @@ export default function AdvancedFilterBar({ onFilter }: Props) {
   const [minER, setMinER] = useState(0);
   const [maxER, setMaxER] = useState(10);
   const [minCollabs, setMinCollabs] = useState(0);
+  const [minFollowers, setMinFollowers] = useState(0);
+  const [maxFollowers, setMaxFollowers] = useState(1000000);
 
   useEffect(() => {
     onFilter({
@@ -52,8 +56,10 @@ export default function AdvancedFilterBar({ onFilter }: Props) {
       minEngagement: minER,
       maxEngagement: maxER,
       minCollabs,
+      minFollowers,
+      maxFollowers,
     });
-  }, [platformsSel, tonesSel, vibesSel, nichesSel, formatsSel, values, minER, maxER, minCollabs, onFilter]);
+  }, [platformsSel, tonesSel, vibesSel, nichesSel, formatsSel, values, minER, maxER, minCollabs, minFollowers, maxFollowers, onFilter]);
 
   const toggle = (value: string, list: string[], set: (v: string[]) => void) => {
     set(list.includes(value) ? list.filter((v) => v !== value) : [...list, value]);
@@ -146,6 +152,25 @@ export default function AdvancedFilterBar({ onFilter }: Props) {
           step={0.1}
           value={maxER}
           onChange={(e) => setMaxER(parseFloat(e.target.value))}
+        />
+      </div>
+
+      <div className="flex items-center gap-2">
+        <label>Followers {minFollowers}+</label>
+        <input
+          type="number"
+          min={0}
+          value={minFollowers}
+          onChange={(e) => setMinFollowers(parseInt(e.target.value) || 0)}
+          className="w-24 p-1 rounded bg-Siora-dark text-white"
+        />
+        <label className="ml-4">Max {maxFollowers}</label>
+        <input
+          type="number"
+          min={0}
+          value={maxFollowers}
+          onChange={(e) => setMaxFollowers(parseInt(e.target.value) || 0)}
+          className="w-24 p-1 rounded bg-Siora-dark text-white"
         />
       </div>
 

--- a/apps/web/components/Footer.tsx
+++ b/apps/web/components/Footer.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export default function Footer() {
+  return (
+    <footer className="bg-Siora-mid text-center text-sm py-6 space-x-4 mt-12">
+      <a href="/about" className="underline hover:text-Siora-accent">About Us</a>
+      <a href="/mission" className="underline hover:text-Siora-accent">Our Mission</a>
+      <a href="/contact" className="underline hover:text-Siora-accent">Contact</a>
+      <a href="/privacy" className="underline hover:text-Siora-accent">Privacy</a>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- add global footer
- link brand and creator CTAs from landing page
- add `/auth/login` page with brand/creator toggle
- streamline creator page with Instagram connect and matched campaigns
- simplify brand dashboard with campaign overview and tabs
- clarify brand and creator pages with inline comments
- restore and enhance advanced filtering for dashboard with follower range and sorting options

## Testing
- `npm run lint` *(shows only warnings)*
- `npx tsc -p apps/web/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68868b109994832ca90eef83160af612