### PR TITLE
Refine brand/creator flows

### DIFF
--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -33,7 +33,7 @@ This app does not require any environment variables by default.
 
 ## Dashboard
 
-Visit `/signin` to log in. After signing in, head to `/brands` to search creator personas. Results can be filtered by tone, platform and vibe. Each profile can be saved to your personal shortlist which is stored in your browser using `localStorage`. View your selections any time at `/shortlist`.
+Visit `/auth/login` to log in. After signing in, head to `/brands` to search creator personas. Results can be filtered by tone, platform and vibe. Each profile can be saved to your personal shortlist which is stored in your browser using `localStorage`. View your selections any time at `/shortlist`.
 
 `/dashboard` and `/personas` remain available for exploring personas without authentication.
 

--- a/apps/web/app/analytics/page.tsx
+++ b/apps/web/app/analytics/page.tsx
@@ -6,7 +6,7 @@ import { matchScore } from 'shared-utils';
 export default async function AnalyticsPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
-    redirect('/signin');
+    redirect('/auth/login');
   }
 
   const campaigns = await prisma.campaign.findMany({

--- a/apps/web/app/auth/login/page.tsx
+++ b/apps/web/app/auth/login/page.tsx
@@ -1,0 +1,44 @@
+'use client'
+import { useState } from 'react'
+import { signIn } from 'next-auth/react'
+import { generateInstagramAuthUrl } from '@/lib/instagram'
+
+export default function LoginPage() {
+  const [mode, setMode] = useState<'brand' | 'creator'>('brand')
+
+  const handleGoogle = () => {
+    signIn('google', { callbackUrl: '/select-role' })
+  }
+
+  const handleInstagram = () => {
+    window.location.href = generateInstagramAuthUrl()
+  }
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center gap-6 bg-Siora-dark text-white p-6">
+      <div className="flex gap-4 mb-4">
+        <button
+          onClick={() => setMode('brand')}
+          className={`px-4 py-2 rounded-md border ${mode === 'brand' ? 'bg-Siora-accent text-white' : 'bg-transparent text-white'}`}
+        >
+          Login as Brand
+        </button>
+        <button
+          onClick={() => setMode('creator')}
+          className={`px-4 py-2 rounded-md border ${mode === 'creator' ? 'bg-Siora-accent text-white' : 'bg-transparent text-white'}`}
+        >
+          Login with Instagram
+        </button>
+      </div>
+      {mode === 'brand' ? (
+        <button onClick={handleGoogle} className="px-6 py-3 bg-indigo-600 hover:bg-indigo-700 rounded-md">
+          Continue with Google
+        </button>
+      ) : (
+        <button onClick={handleInstagram} className="px-6 py-3 bg-pink-600 hover:bg-pink-700 rounded-md">
+          Connect Instagram
+        </button>
+      )}
+    </main>
+  )
+}

--- a/apps/web/app/brands/page.tsx
+++ b/apps/web/app/brands/page.tsx
@@ -23,7 +23,7 @@ export default function BrandsDashboard() {
 
 
   useEffect(() => {
-    if (!user) router.replace("/signin");
+    if (!user) router.replace("/auth/login");
   }, [user, router]);
 
   if (!user) {

--- a/apps/web/app/creator/AuthGuard.tsx
+++ b/apps/web/app/creator/AuthGuard.tsx
@@ -9,10 +9,10 @@ export default function AuthGuard({ children }: PropsWithChildren) {
   const router = useRouter();
 
   useEffect(() => {
-    if (status === 'unauthenticated') router.replace('/signin');
+    if (status === 'unauthenticated') router.replace('/auth/login');
     if (status === 'authenticated') {
       if (!session || (session.user as { role?: string }).role !== 'creator') {
-        router.replace('/signin');
+        router.replace('/auth/login');
       }
     }
   }, [status, session, router]);

--- a/apps/web/app/creator/[id]/notes/page.tsx
+++ b/apps/web/app/creator/[id]/notes/page.tsx
@@ -12,7 +12,7 @@ export default function CreatorNotesPage({ params }: { params: { id: string } })
   const { notes, updateNote, status: collab, updateStatus } = useCreatorMeta(user?.email ?? null);
 
   useEffect(() => {
-    if (!user) router.replace("/signin");
+    if (!user) router.replace("/auth/login");
   }, [user, router]);
 
   if (!user) return null;

--- a/apps/web/app/creator/select-role/page.tsx
+++ b/apps/web/app/creator/select-role/page.tsx
@@ -9,7 +9,7 @@ export default function SelectRole() {
 
   if (status === "loading") return null;
   if (!session) {
-    router.replace("/signin");
+    router.replace("/auth/login");
     return null;
   }
 

--- a/apps/web/app/dashboard/shortlist/page.tsx
+++ b/apps/web/app/dashboard/shortlist/page.tsx
@@ -17,7 +17,7 @@ export default function ShortlistPage() {
   const [compare, setCompare] = useState(false);
 
   useEffect(() => {
-    if (!user) router.replace("/signin");
+    if (!user) router.replace("/auth/login");
   }, [user, router]);
 
   if (!user) return null;

--- a/apps/web/app/home/dashboard/page.tsx
+++ b/apps/web/app/home/dashboard/page.tsx
@@ -17,7 +17,7 @@ interface Persona {
 export default async function DashboardPage() {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
-    redirect('/signin');
+    redirect('/auth/login');
   }
 
   const file = await fs.readFile(

--- a/apps/web/app/marketing/page.tsx
+++ b/apps/web/app/marketing/page.tsx
@@ -11,7 +11,7 @@ export default function MarketingPage() {
         </p>
         <div className="flex gap-4">
           <a href="/signup" className="px-6 py-3 rounded-full bg-Siora-accent text-white font-semibold hover:bg-Siora-hover">Sign Up</a>
-          <a href="/signin" className="px-6 py-3 rounded-full border border-Siora-accent text-Siora-accent hover:bg-Siora-accent hover:text-white">Log In</a>
+          <a href="/auth/login" className="px-6 py-3 rounded-full border border-Siora-accent text-Siora-accent hover:bg-Siora-accent hover:text-white">Log In</a>
         </div>
       </section>
 

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -25,7 +25,7 @@ export default function Page() {
       <header className="sticky top-0 z-50 bg-black/70 backdrop-blur px-6 sm:px-12 py-4 flex justify-between items-center">
         <span className="font-bold text-lg">Siora</span>
         <nav className="flex items-center gap-6 text-sm">
-          <a href="/signin" className="px-3 py-1 rounded-md bg-indigo-600 hover:bg-indigo-700 text-white transition-colors">Login</a>
+          <a href="/auth/login" className="px-3 py-1 rounded-md bg-indigo-600 hover:bg-indigo-700 text-white transition-colors">Login</a>
           <a href="#how" className="hover:text-indigo-400 transition-colors">How it works</a>
           <a href="/creator" className="px-4 py-2 rounded-xl bg-emerald-500 hover:bg-emerald-600 text-white transition-colors">Start</a>
         </nav>
@@ -39,16 +39,16 @@ export default function Page() {
       />
       <div className="flex justify-center gap-4 -mt-8">
         <a
-          href="/brand"
+          href="/dashboard"
           className="px-6 py-3 rounded-xl bg-emerald-500 hover:bg-emerald-600 transition-all hover:scale-[1.02]"
         >
-          Start as Brand
+          I'm a Brand
         </a>
         <a
           href="/creator"
           className="px-6 py-3 rounded-xl bg-emerald-500 hover:bg-emerald-600 transition-all hover:scale-[1.02]"
         >
-          Start as Creator
+          I'm a Creator
         </a>
       </div>
 
@@ -184,20 +184,21 @@ export default function Page() {
             href="/creator"
             className="px-6 py-3 rounded-xl bg-emerald-500 hover:bg-emerald-600 transition-all hover:scale-[1.02]"
           >
-            Start as Creator
+            I'm a Creator
           </a>
           <a
-            href="/brand"
+            href="/dashboard"
             className="px-6 py-3 rounded-xl bg-emerald-500 hover:bg-emerald-600 transition-all hover:scale-[1.02]"
           >
-            Start as Brand
+            I'm a Brand
           </a>
         </motion.div>
       </section>
       <footer className="bg-Siora-mid text-center text-sm py-6 space-x-4">
+        <a href="/about" className="underline hover:text-Siora-accent">About Us</a>
+        <a href="/mission" className="underline hover:text-Siora-accent">Our Mission</a>
+        <a href="/contact" className="underline hover:text-Siora-accent">Contact</a>
         <a href="/privacy" className="underline hover:text-Siora-accent">Privacy</a>
-        <a href="/terms" className="underline hover:text-Siora-accent">Terms</a>
-        <a href="/signin" className="underline hover:text-Siora-accent">Login</a>
         <p className="mt-2 text-zinc-400">© {new Date().getFullYear()} Siora</p>
       </footer>
     </main>

--- a/apps/web/app/profile/page.tsx
+++ b/apps/web/app/profile/page.tsx
@@ -12,7 +12,7 @@ export default function ProfilePage() {
 
   useEffect(() => {
     if (status === "loading") return;
-    if (!session) router.replace("/signin");
+    if (!session) router.replace("/auth/login");
   }, [status, session, router]);
 
   const save = async () => {

--- a/apps/web/app/select-role/page.tsx
+++ b/apps/web/app/select-role/page.tsx
@@ -9,7 +9,7 @@ export default function SelectRole() {
 
   if (status === "loading") return null;
   if (!session) {
-    router.replace("/signin");
+    router.replace("/auth/login");
     return null;
   }
 

--- a/apps/web/creator/lib/auth.ts
+++ b/apps/web/creator/lib/auth.ts
@@ -14,7 +14,7 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   pages: {
-    signIn: "/signin",
+    signIn: "/auth/login",
   },
   session: {
     strategy: "database",

--- a/apps/web/home/lib/auth.ts
+++ b/apps/web/home/lib/auth.ts
@@ -43,5 +43,5 @@ export const authOptions: NextAuthOptions = {
       },
     }),
   ],
-  pages: { signIn: '/signin' },
+  pages: { signIn: '/auth/login' },
 };

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -19,7 +19,7 @@ export const authOptions: NextAuthOptions = {
     }),
   ],
   pages: {
-    signIn: "/signin",
+    signIn: "/auth/login",
   },
   session: {
     strategy: "database",


### PR DESCRIPTION
## Summary
- update landing page CTAs and footer links
- add `/auth/login` with brand/creator sign in options
- change NextAuth signIn page and redirects
- update pages to use the new login route

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688693dacaa4832cafbb5c30bb5687b5