### PR TITLE
chore: dead code/hidden features audit (no deletions)

### DIFF
--- a/tools/reports/dead-code-audit.json
+++ b/tools/reports/dead-code-audit.json
@@ -1,0 +1,194 @@
+[
+  {
+    "path": "apps/web/app/(auth)/instagram/callback/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/(auth)/instagram/login/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/admin/invite/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/analytics/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/billing/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/brand/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/brands/[id]/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/brands/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/campaign/new/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/campaigns/[id]/applications/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/campaigns/[id]/messages/[creatorId]/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/campaigns/[id]/messages/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/checklist/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/contract/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/creator/[id]/notes/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/creator/[id]/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/creator/analyze/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/creator/applications/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/creator/brand-discovery/[id]/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/app/creator/brand-discovery/page.tsx",
+    "type": "route",
+    "reason": "No navigation links found",
+    "suggested_action": "SURFACE"
+  },
+  {
+    "path": "apps/web/components/ChatSidebar.tsx",
+    "type": "component",
+    "reason": "No imports found",
+    "suggested_action": "DELETE"
+  },
+  {
+    "path": "apps/web/components/CampaignBriefForm.tsx",
+    "type": "component",
+    "reason": "No imports found",
+    "suggested_action": "DELETE"
+  },
+  {
+    "path": "apps/web/components/SavedCreatorCard.tsx",
+    "type": "component",
+    "reason": "No imports found",
+    "suggested_action": "DELETE"
+  },
+  {
+    "path": "apps/web/components/CreatorPreview.tsx",
+    "type": "component",
+    "reason": "No imports found",
+    "suggested_action": "DELETE"
+  },
+  {
+    "path": "apps/web/components/CollabRequestModal.tsx",
+    "type": "component",
+    "reason": "No imports found",
+    "suggested_action": "DELETE"
+  },
+  {
+    "path": "apps/web/lib/trpcClient.ts",
+    "type": "util",
+    "reason": "No imports found",
+    "suggested_action": "DELETE"
+  },
+  {
+    "path": "apps/web/utils/instagram.ts",
+    "type": "util",
+    "reason": "No imports found",
+    "suggested_action": "DELETE"
+  },
+  {
+    "path": "packages/shared-ui/src/components/ThemeToggle 2.tsx",
+    "type": "package-file",
+    "reason": "No imports found",
+    "suggested_action": "DELETE"
+  },
+  {
+    "path": "packages/shared-ui/src/components/NavLink 2.tsx",
+    "type": "package-file",
+    "reason": "No imports found",
+    "suggested_action": "DELETE"
+  },
+  {
+    "path": "packages/shared-ui/src/components/Nav 2.tsx",
+    "type": "package-file",
+    "reason": "No imports found",
+    "suggested_action": "DELETE"
+  },
+  {
+    "path": "packages/shared-ui/src/components/PageTransition 2.tsx",
+    "type": "package-file",
+    "reason": "No imports found",
+    "suggested_action": "DELETE"
+  },
+  {
+    "path": "packages/shared-utils/src/generateSmartPitch.ts",
+    "type": "gpt-feature",
+    "reason": "Uses OpenAI but not referenced",
+    "suggested_action": "SURFACE"
+  }
+]

--- a/tools/reports/dead-code-audit.md
+++ b/tools/reports/dead-code-audit.md
@@ -1,0 +1,64 @@
+# Dead Code & Hidden Features Audit
+
+## Orphan Routes
+Routes present under `apps/web/app` but not referenced via `Link` or router navigation. Total detected: 89. Sample:
+
+- /(auth)/instagram/callback
+- /(auth)/instagram/login
+- /admin/invite
+- /analytics
+- /billing
+- /brand
+- /brands/[id]
+- /campaign/new
+- /campaigns/[id]/applications
+- /campaigns/[id]/messages/[creatorId]
+- /creator/analyze
+- /creator/applications
+- /creator/brand-discovery/[id]
+- /creator/brand-discovery
+- /contract
+
+## Unused Components
+Components with no imports in the codebase:
+
+- apps/web/components/ChatSidebar.tsx
+- apps/web/components/CampaignBriefForm.tsx
+- apps/web/components/SavedCreatorCard.tsx
+- apps/web/components/CreatorPreview.tsx
+- apps/web/components/CollabRequestModal.tsx
+
+## Unused Hooks/Utils
+Helpers and utilities that are never imported:
+
+- apps/web/lib/trpcClient.ts
+- apps/web/utils/instagram.ts
+- packages/shared-ui/src/components/ThemeToggle 2.tsx
+- packages/shared-ui/src/components/NavLink 2.tsx
+- packages/shared-ui/src/components/Nav 2.tsx
+- packages/shared-ui/src/components/PageTransition 2.tsx
+
+## Hidden GPT features
+Code invoking GPT/OpenAI not surfaced in UI:
+
+- packages/shared-utils/src/generateSmartPitch.ts
+
+## Buttons with no handlers
+Buttons rendered without click handlers or meaningful action:
+
+- apps/web/app/admin/invite/page.tsx line 33
+- apps/web/app/feedback/[id]/page.tsx line 110
+- apps/web/app/home/preview/page.tsx line 23
+- apps/web/app/creator/performance/page.tsx line 89
+- apps/web/app/creator/campaigns/[id]/apply/page.tsx line 94
+- apps/web/app/creator/contracts/new/page.tsx line 151
+- apps/web/app/creator/contracts/review/page.tsx line 43
+
+## Localhost references
+No hardcoded `localhost` endpoints were detected.
+
+## Suggestions
+- Review orphan routes to determine if they should be surfaced or removed.
+- Remove or refactor unused components and utilities.
+- Expose hidden GPT-powered utilities where appropriate.
+- Add handlers to inert buttons or replace them with semantic elements.


### PR DESCRIPTION
## Summary
- add static audit report detailing orphan routes, unused components, unused utils, and hidden GPT helpers
- generate machine-readable manifest of flagged paths

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_689bc925d1f8832caf876fce160fe58e