### PR TITLE
feat: add AI analysis and matching

### DIFF
--- a/apps/web/app/api/campaigns/analyze/route.ts
+++ b/apps/web/app/api/campaigns/analyze/route.ts
@@ -1,0 +1,39 @@
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+import { analyzeTextProfile, embed } from "@/lib/ai";
+import { getBrandForUser } from "@/lib/guards";
+import { consumeCredits } from "@/lib/credits";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  const { userId } = auth();
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const { campaignId } = await req.json();
+  if (!campaignId) return new Response("campaignId required", { status: 400 });
+
+  const brand = await getBrandForUser();
+  if (!brand) return new Response("Brand not found", { status: 404 });
+
+  const camp = await prisma.campaign.findUnique({ where: { id: campaignId } });
+  if (!camp?.brief) return new Response("Campaign has no brief", { status: 400 });
+
+  const debit = await consumeCredits(brand.id, 1, "AI_ANALYZE", `Analyze campaign ${campaignId}`);
+  if (!debit.ok) return new Response(JSON.stringify({ error: "Not enough credits" }), { status: 402 });
+
+  const { tone, values, keywords } = await analyzeTextProfile(camp.brief);
+  const vec = await embed([camp.title, camp.brief, (values || []).join(" ")].join("\n"));
+
+  await prisma.$executeRawUnsafe(
+    `update "Campaign" set "targetTone" = $1, "desiredValues" = $2, "desiredKeywords" = $3, "analyzedAt" = now(), embedding = $4 where id = $5`,
+    tone,
+    values,
+    keywords,
+    JSON.stringify(vec),
+    campaignId,
+  );
+
+  return Response.json({ ok: true, tone, values, keywords });
+}

--- a/apps/web/app/api/creators/analyze/route.ts
+++ b/apps/web/app/api/creators/analyze/route.ts
@@ -1,0 +1,45 @@
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+import { analyzeTextProfile, embed } from "@/lib/ai";
+import { getBrandForUser } from "@/lib/guards";
+import { consumeCredits } from "@/lib/credits";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request) {
+  const { userId } = auth();
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const { creatorId } = await req.json();
+  if (!creatorId) return new Response("creatorId required", { status: 400 });
+
+  const brand = await getBrandForUser();
+  if (!brand) return new Response("Brand not found", { status: 404 });
+
+  const debit = await consumeCredits(brand.id, 1, "AI_ANALYZE", `Analyze creator ${creatorId}`);
+  if (!debit.ok) return new Response(JSON.stringify({ error: "Not enough credits" }), { status: 402 });
+
+  const creator = await prisma.creator.findUnique({ where: { id: creatorId } });
+  if (!creator?.bio) return new Response("Creator has no bio", { status: 400 });
+
+  const { tone, values, keywords } = await analyzeTextProfile(creator.bio);
+  const vec = await embed([
+    creator.name,
+    creator.handle,
+    creator.bio,
+    (creator.tags || []).join(" "),
+    (values || []).join(" "),
+  ].join("\n"));
+
+  await prisma.$executeRawUnsafe(
+    `update "Creator" set "tone" = $1, "values" = $2, "keywords" = $3, "analysisAt" = now(), embedding = $4 where id = $5`,
+    tone,
+    values,
+    keywords,
+    JSON.stringify(vec),
+    creatorId,
+  );
+
+  return Response.json({ ok: true, tone, values, keywords, remaining: debit.remaining });
+}

--- a/apps/web/app/api/match/generate/route.ts
+++ b/apps/web/app/api/match/generate/route.ts
@@ -1,0 +1,119 @@
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+import { getBrandForUser } from "@/lib/guards";
+import { consumeCredits } from "@/lib/credits";
+import { scoreMatch, oneIfEqual, softSetOverlap } from "@/lib/matchScore";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Row = {
+  id: string;
+  name: string;
+  handle: string;
+  niche: string | null;
+  tone: string | null;
+  values: string[] | null;
+  followers: number;
+  avgViews: number;
+  engagement: number | null;
+  location: string | null;
+  dist: number;
+};
+
+export async function POST(req: Request) {
+  const { userId } = auth();
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const { campaignId, topK = 20, minFollowers = 1000, maxFollowers = 2_000_000 } = await req.json();
+  if (!campaignId) return new Response("campaignId required", { status: 400 });
+
+  const brand = await getBrandForUser();
+  if (!brand) return new Response("Brand not found", { status: 404 });
+
+  const camp = await prisma.campaign.findUnique({
+    where: { id: campaignId },
+    select: { id: true, embedding: true, targetTone: true, desiredValues: true, niche: true },
+  });
+  if (!camp?.embedding) return new Response("Campaign not analyzed yet", { status: 400 });
+
+  const rows: Row[] = await prisma.$queryRawUnsafe(
+    `
+    select
+      c.id, c.name, c.handle, c.niche, c.tone, c.values, c."followers", c."avgViews", c."engagement", c."location",
+      (c.embedding <=> $1) as dist
+    from "Creator" c
+    where c.embedding is not null
+      and c."followers" between $2 and $3
+    order by c.embedding <=> $1 asc
+    limit $4
+  `,
+    camp.embedding,
+    minFollowers,
+    maxFollowers,
+    Math.min(topK * 3, 200),
+  );
+
+  const scored = rows.map((c) => {
+    const semantic01 = 1 - Math.max(0, Math.min(1, c.dist));
+    const toneMatch01 = oneIfEqual(c.tone, camp.targetTone);
+    const nicheMatch01 = oneIfEqual(c.niche, camp.niche);
+    const audienceFit01 = 1;
+    const engagement01 = Math.max(0, Math.min(1, (c.engagement ?? 0) / 10));
+
+    const valuesOverlap = softSetOverlap(c.values || [], camp.desiredValues || []);
+    const semanticBoosted = Math.min(1, semantic01 * (1 + 0.15 * valuesOverlap));
+
+    const score = scoreMatch({
+      semantic01: semanticBoosted,
+      toneMatch01,
+      nicheMatch01,
+      audienceFit01,
+      engagement01,
+    });
+
+    return { ...c, score };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+  const top = scored.slice(0, topK);
+
+  const needed = top.length;
+  if (needed > 0) {
+    const debit = await consumeCredits(brand.id, needed, "AI_MATCH", `Generate matches for ${campaignId} (${needed})`);
+    if (!debit.ok) {
+      return new Response(
+        JSON.stringify({ error: `Not enough credits for ${needed} matches`, required: needed, remaining: debit.remaining }),
+        { status: 402 },
+      );
+    }
+  }
+
+  await prisma.$transaction(
+    top.map((m) =>
+      prisma.match.upsert({
+        where: { campaignId_creatorId: { campaignId, creatorId: m.id } },
+        update: { matchScore: m.score, rationale: rationaleText(m, camp) },
+        create: { campaignId, creatorId: m.id, matchScore: m.score, rationale: rationaleText(m, camp) },
+      }),
+    ),
+  );
+
+  return Response.json({
+    ok: true,
+    count: top.length,
+    data: top.map(({ dist, ...rest }) => rest),
+  });
+}
+
+function rationaleText(c: Row, camp: any) {
+  const bits = [] as string[];
+  if (c.tone && camp.targetTone && c.tone === camp.targetTone) bits.push(`tone match: ${c.tone}`);
+  if (c.niche && camp.niche && c.niche === camp.niche) bits.push(`niche: ${c.niche}`);
+  if (Array.isArray(c.values) && Array.isArray(camp.desiredValues)) {
+    const overlap = c.values.filter((v) => camp.desiredValues!.includes(v));
+    if (overlap.length) bits.push(`values: ${overlap.join(", ")}`);
+  }
+  bits.push("semantic fit via brief");
+  return bits.join(" · ");
+}

--- a/apps/web/lib/ai.ts
+++ b/apps/web/lib/ai.ts
@@ -1,0 +1,48 @@
+import OpenAI from "openai";
+
+export const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+
+// Extract tone, values, and keywords from free text
+export async function analyzeTextProfile(text: string) {
+  const sys = `You extract a creator or campaign profile from text.
+Return JSON with:
+- tone: one of ["Playful","Serious","Bold","Aspirational","Educational"]
+- values: up to 5 short value words (e.g., Sustainability, Transparency)
+- keywords: up to 12 lowercase keywords (no spaces if possible; use hyphens)`;
+
+  const user = `TEXT:\n${text}\n\nReturn ONLY JSON.`;
+
+  const chat = await openai.chat.completions.create({
+    model: "gpt-4o-mini",
+    response_format: { type: "json_object" },
+    messages: [
+      { role: "system", content: sys },
+      { role: "user", content: user },
+    ],
+    temperature: 0.2,
+  });
+
+  const raw = chat.choices[0]?.message?.content || "{}";
+  const parsed = JSON.parse(raw);
+  return {
+    tone: parsed.tone ?? null,
+    values: Array.isArray(parsed.values) ? parsed.values.slice(0, 5) : [],
+    keywords: Array.isArray(parsed.keywords) ? parsed.keywords.slice(0, 12) : [],
+  };
+}
+
+// Create 1536-dim embedding
+export async function embed(text: string) {
+  const res = await openai.embeddings.create({
+    model: "text-embedding-3-large",
+    input: text,
+  });
+  return res.data[0].embedding; // number[]
+}
+
+// Cosine to 0..1 similarity (client-side, if needed)
+export function cosine(a: number[], b: number[]) {
+  let dot = 0, na = 0, nb = 0;
+  for (let i = 0; i < a.length; i++) { dot += a[i]*b[i]; na += a[i]*a[i]; nb += b[i]*b[i]; }
+  return dot / (Math.sqrt(na) * Math.sqrt(nb) + 1e-9);
+}

--- a/apps/web/lib/matchScore.ts
+++ b/apps/web/lib/matchScore.ts
@@ -1,0 +1,30 @@
+export function scoreMatch(params: {
+  semantic01: number;
+  toneMatch01: number;
+  nicheMatch01: number;
+  audienceFit01: number;
+  engagement01: number;
+}) {
+  const { semantic01, toneMatch01, nicheMatch01, audienceFit01, engagement01 } = params;
+  const s =
+    0.55 * semantic01 +
+    0.20 * toneMatch01 +
+    0.10 * nicheMatch01 +
+    0.10 * audienceFit01 +
+    0.05 * engagement01;
+  return Math.round(Math.max(0, Math.min(1, s)) * 100);
+}
+
+export function oneIfEqual(a?: string | null, b?: string | null) {
+  if (!a || !b) return 0;
+  return a.trim().toLowerCase() === b.trim().toLowerCase() ? 1 : 0;
+}
+
+export function softSetOverlap(a: string[] = [], b: string[] = []) {
+  if (!a.length || !b.length) return 0;
+  const A = new Set(a.map((x) => x.toLowerCase()));
+  const B = new Set(b.map((x) => x.toLowerCase()));
+  let inter = 0;
+  for (const k of A) if (B.has(k)) inter++;
+  return inter / Math.max(A.size, B.size);
+}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "next": "^15.3.4",
     "nodemailer": "^7.0.5",
     "pdfkit": "^0.15.2",
+    "openai": "^4.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hot-toast": "^2.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       nodemailer:
         specifier: ^7.0.5
         version: 7.0.5
+      openai:
+        specifier: ^4.0.0
+        version: 4.104.0(zod@3.25.76)
       pdfkit:
         specifier: ^0.15.2
         version: 0.15.2
@@ -134,7 +137,7 @@ importers:
         version: 1.7.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@prisma/client':
         specifier: ^6.9.0
         version: 6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3)
@@ -188,7 +191,7 @@ importers:
         version: 15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       prisma:
         specifier: ^6.9.0
         version: 6.12.0(typescript@5.8.3)
@@ -273,7 +276,7 @@ importers:
         version: 1.7.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@prisma/client':
         specifier: ^6.9.0
         version: 6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3)
@@ -327,7 +330,7 @@ importers:
         version: 15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       prisma:
         specifier: ^6.9.0
         version: 6.12.0(typescript@5.8.3)
@@ -415,7 +418,7 @@ importers:
         version: 1.7.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@prisma/client':
         specifier: ^6.9.0
         version: 6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3)
@@ -502,7 +505,7 @@ importers:
         version: 15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       openai:
         specifier: ^4.0.0
         version: 4.104.0(zod@3.25.76)
@@ -6029,10 +6032,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.0
     optional: true
 
-  '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
+  '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
       '@prisma/client': 6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3)
-      next-auth: 4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next-auth: 4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   '@next/env@15.4.2': {}
 
@@ -9639,7 +9642,7 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next-auth@4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next-auth@4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/runtime': 7.27.6
       '@panva/hkdf': 1.2.1

--- a/prisma/migrations/20250827000000_ai_analysis_fields/migration.sql
+++ b/prisma/migrations/20250827000000_ai_analysis_fields/migration.sql
@@ -1,0 +1,17 @@
+-- Enable pgvector
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Creator analysis fields
+ALTER TABLE "Creator" ADD COLUMN IF NOT EXISTS "analysisAt" TIMESTAMP(3);
+ALTER TABLE "Creator" ADD COLUMN IF NOT EXISTS "keywords" TEXT[];
+ALTER TABLE "Creator" ADD COLUMN IF NOT EXISTS "embedding" vector(1536);
+
+-- Campaign analysis fields
+ALTER TABLE "Campaign" ADD COLUMN IF NOT EXISTS "desiredValues" TEXT[];
+ALTER TABLE "Campaign" ADD COLUMN IF NOT EXISTS "desiredKeywords" TEXT[];
+ALTER TABLE "Campaign" ADD COLUMN IF NOT EXISTS "analyzedAt" TIMESTAMP(3);
+ALTER TABLE "Campaign" ADD COLUMN IF NOT EXISTS "embedding" vector(1536);
+
+-- Optional helper indexes
+CREATE INDEX IF NOT EXISTS creator_embedding_idx ON "Creator" USING ivfflat ("embedding" vector_cosine_ops) WITH (lists = 100);
+CREATE INDEX IF NOT EXISTS campaign_embedding_idx ON "Campaign" USING ivfflat ("embedding" vector_cosine_ops) WITH (lists = 100);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -90,11 +90,18 @@ model Creator {
   bio         String?
   tags        String[]
 
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  // NEW: AI analysis snapshots
+  analysisAt  DateTime?
+  keywords    String[]
+
+  // NEW: embeddings (unsupported type – handled via raw SQL)
+  embedding   Unsupported("vector")?
 
   matches     Match[]
   shortlists  ShortlistItem[]
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
   @@index([platform])
   @@index([followers])
   @@fulltext([name, handle, bio])
@@ -116,10 +123,18 @@ model Campaign {
   niche      String?
   targetTone String?
 
+  // NEW: AI desired attributes
+  desiredValues   String[]
+  desiredKeywords String[]
+  analyzedAt      DateTime?
+
+  // NEW: embedding for semantic retrieval
+  embedding Unsupported("vector")?
+
+  matches    Match[]
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 
-  matches    Match[]
   @@index([brandId])
 }
 


### PR DESCRIPTION
## Summary
- add pgvector-backed analysis fields to Creator and Campaign models
- implement AI text analysis and embedding helpers
- expose endpoints for analyzing creators/campaigns and generating matches

## Testing
- `npx prisma migrate dev -n "ai_analysis_fields"` *(fails: Environment variable not found: DATABASE_URL)*
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab88d93d5c832ca4bfd6de26ae29ed