### PR TITLE
feat: add campaign editor

### DIFF
--- a/apps/web/app/campaigns/[id]/edit/page.tsx
+++ b/apps/web/app/campaigns/[id]/edit/page.tsx
@@ -1,0 +1,49 @@
+import { prisma } from "@/lib/prisma";
+import CampaignForm from "../../shared/CampaignForm";
+import { updateCampaign, deleteCampaign } from "../../actions";
+
+export default async function EditCampaignPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const c = await prisma.campaign.findUnique({
+    where: { id: params.id },
+    select: {
+      id: true,
+      title: true,
+      brief: true,
+      niche: true,
+      targetTone: true,
+      budgetEUR: true,
+    },
+  });
+  if (!c) return <div className="p-8">Not found</div>;
+
+  return (
+    <section className="mx-auto max-w-3xl py-10">
+      <h1 className="text-2xl font-semibold">Edit Campaign</h1>
+      <div className="mt-6">
+        {/* @ts-expect-error Server Action passed to client form */}
+        <CampaignForm
+          initial={c}
+          action={(prev: any, fd: FormData) => updateCampaign(c.id, prev, fd)}
+          dangerZone={<DeleteButton id={c.id} />}
+        />
+      </div>
+    </section>
+  );
+}
+
+function DeleteButton({ id }: { id: string }) {
+  return (
+    <form action={async () => deleteCampaign(id)} className="mt-6">
+      <button
+        className="rounded-xl border border-red-500/30 bg-red-500/10 px-3 py-2 text-sm text-red-200 hover:bg-red-500/20"
+        type="submit"
+      >
+        Delete campaign
+      </button>
+    </form>
+  );
+}

--- a/apps/web/app/campaigns/actions.ts
+++ b/apps/web/app/campaigns/actions.ts
@@ -1,0 +1,78 @@
+"use server";
+
+import { revalidatePath, redirect } from "next/navigation";
+import { CampaignSchema } from "@/lib/campaigns";
+import { prisma } from "@/lib/prisma";
+import { auth, currentUser } from "@clerk/nextjs/server";
+
+async function getOwnerBrandId() {
+  const { userId } = auth();
+  if (!userId) throw new Error("Unauthorized");
+  const email = (await currentUser())?.emailAddresses?.[0]?.emailAddress ?? "";
+  const brand = await prisma.brand.findFirst({
+    where: { owner: { email } },
+    select: { id: true },
+  });
+  if (!brand) throw new Error("Brand not found");
+  return brand.id;
+}
+
+export async function createCampaign(prevState: any, formData: FormData) {
+  const brandId = await getOwnerBrandId();
+  const raw = Object.fromEntries(formData.entries());
+  const parsed = CampaignSchema.safeParse({
+    title: raw.title,
+    brief: raw.brief,
+    niche: raw.niche,
+    targetTone: raw.targetTone,
+    budgetEUR: raw.budgetEUR,
+  });
+
+  if (!parsed.success) {
+    return { ok: false, errors: parsed.error.flatten().fieldErrors };
+  }
+
+  const { title, brief, niche, targetTone, budgetEUR } = parsed.data;
+  const c = await prisma.campaign.create({
+    data: { brandId, title, brief, niche, targetTone, budgetEUR },
+  });
+
+  revalidatePath("/campaigns");
+  redirect(`/campaigns/${c.id}/matches`);
+}
+
+export async function updateCampaign(
+  campaignId: string,
+  prevState: any,
+  formData: FormData,
+) {
+  await getOwnerBrandId(); // auth check
+  const raw = Object.fromEntries(formData.entries());
+  const parsed = CampaignSchema.safeParse({
+    title: raw.title,
+    brief: raw.brief,
+    niche: raw.niche,
+    targetTone: raw.targetTone,
+    budgetEUR: raw.budgetEUR,
+  });
+  if (!parsed.success) {
+    return { ok: false, errors: parsed.error.flatten().fieldErrors };
+  }
+
+  const { title, brief, niche, targetTone, budgetEUR } = parsed.data;
+  await prisma.campaign.update({
+    where: { id: campaignId },
+    data: { title, brief, niche, targetTone, budgetEUR },
+  });
+
+  revalidatePath(`/campaigns/${campaignId}`);
+  redirect(`/campaigns/${campaignId}/matches`);
+}
+
+export async function deleteCampaign(campaignId: string) {
+  await getOwnerBrandId(); // auth check
+  await prisma.match.deleteMany({ where: { campaignId } });
+  await prisma.campaign.delete({ where: { id: campaignId } });
+  revalidatePath("/campaigns");
+  redirect("/campaigns");
+}

--- a/apps/web/app/campaigns/new/page.tsx
+++ b/apps/web/app/campaigns/new/page.tsx
@@ -1,0 +1,18 @@
+import CampaignForm from "../shared/CampaignForm";
+import { createCampaign } from "../actions";
+
+export default function NewCampaignPage() {
+  return (
+    <section className="mx-auto max-w-3xl py-10">
+      <h1 className="text-2xl font-semibold">New Campaign</h1>
+      <p className="mt-1 text-white/60">
+        Describe your product and what kind of creators you want.
+      </p>
+
+      <div className="mt-6">
+        {/* @ts-expect-error Server Action passed to client form */}
+        <CampaignForm action={createCampaign} />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/campaigns/page.tsx
+++ b/apps/web/app/campaigns/page.tsx
@@ -1,132 +1,68 @@
-'use client';
-import React from 'react';
+import { prisma } from "@/lib/prisma";
+import Link from "next/link";
 
-import { useState, useEffect } from "react";
-import { campaigns } from "@/app/data/campaigns";
-import { Badge } from "shared-ui";
-import FeedbackButton from "@/components/FeedbackButton";
-
-interface Fairness {
-  fair: boolean;
-  concerns: string[];
-}
-
-export default function CampaignsPage() {
-  const [platform, setPlatform] = useState("");
-  const [niche, setNiche] = useState("");
-  const [minBudget, setMinBudget] = useState("");
-  const [maxBudget, setMaxBudget] = useState("");
-  const [fairness, setFairness] = useState<Record<string, Fairness>>({});
-
-  useEffect(() => {
-    campaigns.forEach(async (c) => {
-      try {
-        const res = await fetch('/api/fairness/evaluateCampaign', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            name: c.name,
-            description: c.requirements,
-            deliverables: c.requirements,
-            compensation: `${c.budgetMin}-${c.budgetMax}`,
-          }),
-        });
-        if (res.ok) {
-          const data: Fairness = await res.json();
-          setFairness((prev) => ({ ...prev, [c.id]: data }));
-        }
-      } catch (err) {
-        console.error('fairness check failed', err);
-      }
-    });
-  }, []);
-
-  const filtered = campaigns.filter((c) => {
-    const matchPlatform =
-      !platform || c.platform.toLowerCase().includes(platform.toLowerCase());
-    const matchNiche = !niche || c.niche.toLowerCase().includes(niche.toLowerCase());
-    const min = parseInt(minBudget || "0", 10);
-    const max = parseInt(maxBudget || "0", 10);
-    const matchMin = !minBudget || c.budgetMax >= min;
-    const matchMax = !maxBudget || c.budgetMin <= max;
-    return matchPlatform && matchNiche && matchMin && matchMax;
+export default async function CampaignsPage() {
+  const campaigns = await prisma.campaign.findMany({
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      title: true,
+      niche: true,
+      targetTone: true,
+      analyzedAt: true,
+      createdAt: true,
+    },
   });
 
   return (
-    <main className="min-h-screen bg-gradient-radial from-Siora-dark via-Siora-mid to-Siora-light text-white px-6 py-10">
-      <div className="max-w-7xl mx-auto space-y-8">
-        <h1 className="text-4xl font-extrabold tracking-tight">Live Campaigns</h1>
+    <section className="mx-auto max-w-4xl py-10">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Campaigns</h1>
+        <Link
+          href="/campaigns/new"
+          className="rounded-xl bg-white/90 px-4 py-2 text-gray-900 hover:bg-white"
+        >
+          New campaign
+        </Link>
+      </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-4 gap-4">
-          <input
-            value={platform}
-            onChange={(e) => setPlatform(e.target.value)}
-            placeholder="Platform"
-            className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
-          />
-          <input
-            value={niche}
-            onChange={(e) => setNiche(e.target.value)}
-            placeholder="Niche"
-            className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
-          />
-          <input
-            type="number"
-            value={minBudget}
-            onChange={(e) => setMinBudget(e.target.value)}
-            placeholder="Min Budget"
-            className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
-          />
-          <input
-            type="number"
-            value={maxBudget}
-            onChange={(e) => setMaxBudget(e.target.value)}
-            placeholder="Max Budget"
-            className="w-full p-2 rounded-lg bg-Siora-light text-white placeholder-zinc-400 border border-Siora-border focus:outline-none focus:ring-2 focus:ring-Siora-accent"
-          />
-        </div>
-
-        {filtered.length === 0 ? (
-          <p className="text-center text-zinc-400 mt-10">No campaigns found.</p>
-        ) : (
-          <div className="space-y-6">
-            {filtered.map((c) => (
-              <div
-                key={c.id}
-                className="bg-white dark:bg-Siora-mid border border-gray-300 dark:border-Siora-border rounded-2xl p-6 shadow-Siora-hover space-y-2"
-              >
-                <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-1 flex items-center gap-2">
-                  {c.brand} – {c.name}
-                  {fairness[c.id] && !fairness[c.id].fair && (
-                    <Badge label="Unfair offer" className="bg-red-600 text-white" />
-                  )}
-                </h2>
-                {fairness[c.id] && fairness[c.id].concerns.length > 0 && (
-                  <p className="text-xs text-red-400">
-                    {fairness[c.id].concerns[0]}
-                  </p>
-                )}
-                <p className="text-sm text-gray-700 dark:text-zinc-300">
-                  {c.requirements}
-                </p>
-                <p className="text-sm text-gray-500 dark:text-zinc-400">
-                  Budget: ${'{'}c.budgetMin{'}'} - ${'{'}c.budgetMax{'}'}
-                </p>
-                <div className="flex gap-2 mt-2">
-                  <button
-                    onClick={() => alert('Apply flow coming soon!')}
-                    className="bg-Siora-accent hover:bg-Siora-accent-soft text-white px-3 py-1 rounded"
-                  >
-                    Apply as Creator
-                  </button>
-                  <FeedbackButton id={c.id} />
+      <div className="mt-6 grid gap-3">
+        {campaigns.map((c) => (
+          <div
+            key={c.id}
+            className="rounded-xl border border-white/10 bg-white/5 p-4"
+          >
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <div className="text-base font-semibold">{c.title}</div>
+                <div className="text-xs text-white/60">
+                  {c.niche || "—"} · {c.targetTone || "—"} · {""}
+                  {c.analyzedAt ? "Analyzed" : "Not analyzed"}
                 </div>
               </div>
-            ))}
+              <div className="flex gap-2">
+                <Link
+                  className="rounded-lg border border-white/10 px-3 py-1.5 hover:bg-white/10"
+                  href={`/campaigns/${c.id}/matches`}
+                >
+                  Matches
+                </Link>
+                <Link
+                  className="rounded-lg border border-white/10 px-3 py-1.5 hover:bg-white/10"
+                  href={`/campaigns/${c.id}/edit`}
+                >
+                  Edit
+                </Link>
+              </div>
+            </div>
+          </div>
+        ))}
+        {campaigns.length === 0 && (
+          <div className="rounded-xl border border-white/10 bg-white/5 p-8 text-center text-white/70">
+            No campaigns yet. Create one to get started.
           </div>
         )}
       </div>
-    </main>
+    </section>
   );
 }
-

--- a/apps/web/app/campaigns/shared/CampaignForm.tsx
+++ b/apps/web/app/campaigns/shared/CampaignForm.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import * as React from "react";
+import { useFormStatus } from "react-dom";
+
+const TONES = [
+  "",
+  "Playful",
+  "Serious",
+  "Bold",
+  "Aspirational",
+  "Educational",
+];
+
+export default function CampaignForm({
+  initial,
+  action,
+  dangerZone,
+}: {
+  initial?: {
+    title: string;
+    brief: string;
+    niche: string | null;
+    targetTone: string | null;
+    budgetEUR: number | null;
+  };
+  action: (state: any, formData: FormData) => Promise<any>;
+  dangerZone?: React.ReactNode;
+}) {
+  const [errors, setErrors] = React.useState<Record<string, string[]>>({});
+  async function onAction(_: any, fd: FormData) {
+    const res = await action(_, fd);
+    if (res?.ok === false && res.errors) {
+      setErrors(res.errors as Record<string, string[]>);
+      return;
+    }
+  }
+
+  return (
+    <form action={onAction} className="rounded-2xl border border-white/10 bg-white/5 p-5">
+      <Field label="Title" name="title" error={errors.title}>
+        <input
+          name="title"
+          defaultValue={initial?.title || ""}
+          required
+          className="w-full rounded-lg border border-white/10 bg-gray-900 px-3 py-2 outline-none"
+          placeholder="Eco-friendly Summer Launch"
+        />
+      </Field>
+
+      <Field label="Brief" name="brief" error={errors.brief}>
+        <textarea
+          name="brief"
+          defaultValue={initial?.brief || ""}
+          required
+          rows={8}
+          className="w-full rounded-lg border border-white/10 bg-gray-900 px-3 py-2 outline-none"
+          placeholder="What is the product, who is the audience, what tone/values, deliverables, regions, budget..."
+        />
+      </Field>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Field label="Niche" name="niche" error={errors.niche}>
+          <input
+            name="niche"
+            defaultValue={initial?.niche || ""}
+            className="w-full rounded-lg border border-white/10 bg-gray-900 px-3 py-2 outline-none"
+            placeholder="Skincare / Fitness / Tech..."
+          />
+        </Field>
+
+        <Field label="Target tone" name="targetTone" error={errors.targetTone}>
+          <select
+            name="targetTone"
+            defaultValue={initial?.targetTone || ""}
+            className="w-full rounded-lg border border-white/10 bg-gray-900 px-3 py-2 outline-none"
+          >
+            {TONES.map((t) => (
+              <option key={t} value={t}>
+                {t || "—"}
+              </option>
+            ))}
+          </select>
+        </Field>
+      </div>
+
+      <Field label="Budget (EUR)" name="budgetEUR" error={errors.budgetEUR}>
+        <input
+          name="budgetEUR"
+          type="number"
+          min={0}
+          defaultValue={initial?.budgetEUR ?? ""}
+          className="w-full rounded-lg border border-white/10 bg-gray-900 px-3 py-2 outline-none"
+          placeholder="5000"
+        />
+      </Field>
+
+      <div className="mt-5 flex items-center gap-3">
+        <SubmitButton />
+        <a
+          href="/campaigns"
+          className="rounded-xl border border-white/15 bg-white/5 px-4 py-2 text-sm hover:bg-white/10"
+        >
+          Cancel
+        </a>
+      </div>
+
+      {dangerZone}
+    </form>
+  );
+}
+
+function Field({
+  label,
+  name,
+  error,
+  children,
+}: {
+  label: string;
+  name: string;
+  error?: string[];
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mt-4">
+      <label className="mb-1 block text-sm text-white/80" htmlFor={name}>
+        {label}
+      </label>
+      {children}
+      {!!error?.length && (
+        <div className="mt-1 text-xs text-red-300">{error.join(", ")}</div>
+      )}
+    </div>
+  );
+}
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="rounded-xl bg-white/90 px-4 py-2 text-gray-900 hover:bg-white disabled:opacity-60"
+    >
+      {pending ? "Saving…" : "Save & view matches"}
+    </button>
+  );
+}

--- a/apps/web/lib/campaigns.ts
+++ b/apps/web/lib/campaigns.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const CampaignSchema = z.object({
+  title: z.string().min(3, "Title is too short").max(120),
+  brief: z
+    .string()
+    .min(20, "Brief should explain the goal")
+    .max(5000),
+  niche: z.string().optional().default(""),
+  targetTone: z
+    .enum(["Playful", "Serious", "Bold", "Aspirational", "Educational"])
+    .optional()
+    .or(z.literal(""))
+    .default(""),
+  budgetEUR: z.coerce.number().int().nonnegative().optional(),
+});
+
+export type CampaignInput = z.infer<typeof CampaignSchema>;

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-hot-toast": "^2.5.2",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "zod": "^3.25.76"
   },
   "prisma": {
     "schema": "./prisma/schema.prisma",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@eslint/eslintrc':
         specifier: 3.3.1
@@ -134,7 +137,7 @@ importers:
         version: 1.7.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@prisma/client':
         specifier: ^6.9.0
         version: 6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3)
@@ -188,7 +191,7 @@ importers:
         version: 15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       prisma:
         specifier: ^6.9.0
         version: 6.12.0(typescript@5.8.3)
@@ -273,7 +276,7 @@ importers:
         version: 1.7.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@prisma/client':
         specifier: ^6.9.0
         version: 6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3)
@@ -327,7 +330,7 @@ importers:
         version: 15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       prisma:
         specifier: ^6.9.0
         version: 6.12.0(typescript@5.8.3)
@@ -415,7 +418,7 @@ importers:
         version: 1.7.19(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@next-auth/prisma-adapter':
         specifier: ^1.0.7
-        version: 1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       '@prisma/client':
         specifier: ^6.9.0
         version: 6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3)
@@ -502,7 +505,7 @@ importers:
         version: 15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-auth:
         specifier: ^4.24.11
-        version: 4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       openai:
         specifier: ^4.0.0
         version: 4.104.0(zod@3.25.76)
@@ -6029,10 +6032,10 @@ snapshots:
       '@tybys/wasm-util': 0.10.0
     optional: true
 
-  '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
+  '@next-auth/prisma-adapter@1.0.7(@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3))(next-auth@4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))':
     dependencies:
       '@prisma/client': 6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3)
-      next-auth: 4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next-auth: 4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   '@next/env@15.4.2': {}
 
@@ -9639,7 +9642,7 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next-auth@4.24.11(next@15.4.2(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next-auth@4.24.11(next@15.4.2(@babel/core@7.28.3)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(nodemailer@7.0.5)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/runtime': 7.27.6
       '@panva/hkdf': 1.2.1


### PR DESCRIPTION
## Summary
- add campaign validation schema with zod
- create server actions for campaign CRUD
- implement campaign list, create, and edit pages with reusable form

## Testing
- `pnpm exec eslint apps/web/lib/campaigns.ts apps/web/app/campaigns/actions.ts apps/web/app/campaigns/page.tsx apps/web/app/campaigns/new/page.tsx apps/web/app/campaigns/[id]/edit/page.tsx apps/web/app/campaigns/shared/CampaignForm.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68ab89b3f490832cb2f2819b20b6f87d