### PR TITLE
feat: add one-click analyze and match flow

### DIFF
--- a/apps/web/app/api/match/auto/route.ts
+++ b/apps/web/app/api/match/auto/route.ts
@@ -1,0 +1,167 @@
+import { auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+import { getBrandForUser } from "@/lib/guards";
+import { consumeCredits } from "@/lib/credits";
+import { analyzeTextProfile, embed } from "@/lib/ai";
+import { scoreMatch, oneIfEqual, softSetOverlap } from "@/lib/matchScore";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type Row = {
+  id: string;
+  name: string;
+  handle: string;
+  niche: string | null;
+  tone: string | null;
+  values: string[] | null;
+  followers: number;
+  avgViews: number;
+  engagement: number | null;
+  location: string | null;
+  dist: number; // pgvector distance
+};
+
+export async function POST(req: Request) {
+  const { userId } = auth();
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const { campaignId, topK = 20, minFollowers = 1000, maxFollowers = 2_000_000 } = await req.json();
+  if (!campaignId) return new Response("campaignId required", { status: 400 });
+
+  const brand = await getBrandForUser();
+  if (!brand) return new Response("Brand not found", { status: 404 });
+
+  // Load campaign
+  const camp = await prisma.campaign.findUnique({
+    where: { id: campaignId },
+    select: {
+      id: true,
+      title: true,
+      brief: true,
+      niche: true,
+      targetTone: true,
+      embedding: true,
+      analyzedAt: true,
+      desiredValues: true,
+    },
+  });
+  if (!camp) return new Response("Campaign not found", { status: 404 });
+
+  // If not analyzed → analyze (1 credit)
+  if (!camp.embedding) {
+    if (!camp.brief) return new Response("Campaign has no brief to analyze", { status: 400 });
+
+    const debit = await consumeCredits(brand.id, 1, "AI_ANALYZE", `Auto: analyze campaign ${campaignId}`);
+    if (!debit.ok) {
+      return new Response(
+        JSON.stringify({ error: "Not enough credits to analyze campaign" }),
+        { status: 402 },
+      );
+    }
+
+    const { tone, values, keywords } = await analyzeTextProfile(camp.brief);
+    const vec = await embed([camp.title, camp.brief, (values || []).join(" ")].join("\n"));
+
+    await prisma.$executeRawUnsafe(
+      `update "Campaign" set "targetTone" = $1, "desiredValues" = $2, "desiredKeywords" = $3, "analyzedAt" = now(), embedding = $4 where id = $5`,
+      tone,
+      values,
+      keywords,
+      JSON.stringify(vec),
+      campaignId,
+    );
+
+    // refresh
+    const updated = await prisma.campaign.findUnique({
+      where: { id: campaignId },
+      select: { id: true, niche: true, targetTone: true, embedding: true, desiredValues: true },
+    });
+    Object.assign(camp, updated);
+  }
+
+  if (!camp.embedding) return new Response("Failed to analyze campaign", { status: 500 });
+
+  // Pull semantically similar creators (oversample, we re-rank)
+  const rows: Row[] = await prisma.$queryRawUnsafe(
+    `
+    select
+      c.id, c.name, c.handle, c.niche, c.tone, c.values, c."followers", c."avgViews", c."engagement", c."location",
+      (c.embedding <=> $1) as dist
+    from "Creator" c
+    where c.embedding is not null
+      and c."followers" between $2 and $3
+    order by c.embedding <=> $1 asc
+    limit $4
+  `,
+    camp.embedding,
+    minFollowers,
+    maxFollowers,
+    Math.min(topK * 3, 200),
+  );
+
+  // Score
+  const scored = rows.map((c) => {
+    const semantic01 = 1 - Math.max(0, Math.min(1, c.dist)); // invert distance
+    const toneMatch01 = oneIfEqual(c.tone, camp.targetTone);
+    const nicheMatch01 = oneIfEqual(c.niche, camp.niche);
+    const audienceFit01 = 1; // already filtered; refine if you pass an "ideal" range
+    const engagement01 = Math.max(0, Math.min(1, (c.engagement ?? 0) / 10)); // cap at 10%
+    const valuesOverlap = softSetOverlap(c.values || [], camp.desiredValues || []);
+    const semanticBoosted = Math.min(1, semantic01 * (1 + 0.15 * valuesOverlap));
+
+    const score = scoreMatch({
+      semantic01: semanticBoosted,
+      toneMatch01,
+      nicheMatch01,
+      audienceFit01,
+      engagement01,
+    });
+    return { ...c, score };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+  const top = scored.slice(0, topK);
+
+  // Charge credits: 1 per returned match
+  const needed = top.length;
+  if (needed > 0) {
+    const debit = await consumeCredits(brand.id, needed, "AI_MATCH", `Auto: matches for ${campaignId} (${needed})`);
+    if (!debit.ok) {
+      return new Response(
+        JSON.stringify({ error: `Not enough credits for ${needed} matches`, required: needed, remaining: debit.remaining }),
+        { status: 402 },
+      );
+    }
+  }
+
+  // Upsert results
+  await prisma.$transaction(
+    top.map((m) =>
+      prisma.match.upsert({
+        where: { campaignId_creatorId: { campaignId, creatorId: m.id } },
+        update: { matchScore: m.score, rationale: rationaleText(m, camp) },
+        create: { campaignId, creatorId: m.id, matchScore: m.score, rationale: rationaleText(m, camp) },
+      }),
+    ),
+  );
+
+  return Response.json({
+    ok: true,
+    analyzed: !camp.analyzedAt ? true : false, // rough signal
+    count: top.length,
+    data: top.map(({ dist, ...rest }) => rest),
+  });
+}
+
+function rationaleText(c: Row, camp: any) {
+  const bits = [];
+  if (c.tone && camp.targetTone && c.tone === camp.targetTone) bits.push(`tone match: ${c.tone}`);
+  if (c.niche && camp.niche && c.niche === camp.niche) bits.push(`niche: ${c.niche}`);
+  if (Array.isArray(c.values) && Array.isArray(camp.desiredValues)) {
+    const overlap = c.values.filter((v) => camp.desiredValues!.includes(v));
+    if (overlap.length) bits.push(`values: ${overlap.join(", ")}`);
+  }
+  bits.push(`semantic fit via brief`);
+  return bits.join(" · ");
+}

--- a/apps/web/app/campaigns/[id]/matches/MatchesClient.tsx
+++ b/apps/web/app/campaigns/[id]/matches/MatchesClient.tsx
@@ -35,6 +35,9 @@ export default function MatchesClient({
   const [matches, setMatches] = React.useState<CreatorRow[]>(initialMatches);
   const [loading, setLoading] = React.useState<null | string>(null);
   const [error, setError] = React.useState<string>("");
+  const [autoMsg, setAutoMsg] = React.useState<string>("");
+
+  const estimatedCost = (!campaign.analyzedAt ? 1 : 0) + 20;
 
   async function analyzeCampaign() {
     setLoading("analyze");
@@ -67,6 +70,27 @@ export default function MatchesClient({
       }
       return setError(j?.error || "Failed to generate matches");
     }
+    setMatches(j.data);
+  }
+
+  async function autoAnalyzeAndGenerate() {
+    setLoading("auto");
+    setError("");
+    setAutoMsg("");
+    const r = await fetch("/api/match/auto", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ campaignId: campaign.id, topK: 20 }),
+    });
+    const j = await r.json().catch(() => ({}));
+    setLoading(null);
+
+    if (!r.ok) {
+      if (r.status === 402) return setError(j?.error || "Not enough credits.");
+      return setError(j?.error || "Failed to run auto match");
+    }
+
+    if (j.analyzed) setAutoMsg("Analyzed campaign (+1 credit) and generated matches.");
     setMatches(j.data);
   }
 
@@ -164,6 +188,18 @@ export default function MatchesClient({
         )}
 
         <button
+          onClick={autoAnalyzeAndGenerate}
+          disabled={loading === "auto"}
+          className="rounded-xl bg-white/90 px-4 py-2 text-gray-900 hover:bg-white disabled:opacity-60"
+        >
+          {loading === "auto" ? "Working…" : "Analyze + Generate (auto)"}
+        </button>
+
+        <span className="rounded-md border border-white/10 bg-white/5 px-2 py-1 text-xs text-white/70">
+          ~{estimatedCost} credits
+        </span>
+
+        <button
           onClick={exportCSV}
           disabled={!matches.length}
           className="rounded-xl border border-white/15 bg-white/5 px-4 py-2 text-sm hover:bg-white/10 disabled:opacity-60"
@@ -178,6 +214,12 @@ export default function MatchesClient({
           Billing & Credits
         </a>
       </div>
+
+      {autoMsg && (
+        <div className="mt-3 rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-2 text-sm text-emerald-200">
+          {autoMsg}
+        </div>
+      )}
 
       {error && (
         <div className="mt-4 rounded-xl border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-200">


### PR DESCRIPTION
## Summary
- add `/api/match/auto` endpoint that analyzes campaigns if needed, generates matches, charges credits, and upserts results
- extend MatchesClient with one-click "Analyze + Generate" button, cost estimate, and success message

## Testing
- `pnpm exec eslint apps/web/app/api/match/auto/route.ts apps/web/app/campaigns/[id]/matches/MatchesClient.tsx` *(warn: 'dist' unused)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8c36d54c832cb1b1bac55c5d8af1