### PR TITLE
Add AI rationale drawer for match cards

### DIFF
--- a/apps/web/app/api/match/generate/route.ts
+++ b/apps/web/app/api/match/generate/route.ts
@@ -61,8 +61,8 @@ export async function POST(req: Request) {
     const audienceFit01 = 1;
     const engagement01 = Math.max(0, Math.min(1, (c.engagement ?? 0) / 10));
 
-    const valuesOverlap = softSetOverlap(c.values || [], camp.desiredValues || []);
-    const semanticBoosted = Math.min(1, semantic01 * (1 + 0.15 * valuesOverlap));
+    const valuesOverlap01 = softSetOverlap(c.values || [], camp.desiredValues || []);
+    const semanticBoosted = Math.min(1, semantic01 * (1 + 0.15 * valuesOverlap01));
 
     const score = scoreMatch({
       semantic01: semanticBoosted,
@@ -72,7 +72,17 @@ export async function POST(req: Request) {
       engagement01,
     });
 
-    return { ...c, score };
+    return {
+      ...c,
+      score,
+      breakdown: {
+        toneMatch01,
+        nicheMatch01,
+        valuesOverlap01,
+        engagement01,
+        semanticHint: "Derived from pgvector; higher means closer",
+      },
+    };
   });
 
   scored.sort((a, b) => b.score - a.score);

--- a/apps/web/app/api/shortlist/add/route.ts
+++ b/apps/web/app/api/shortlist/add/route.ts
@@ -13,7 +13,9 @@ export async function POST(req: Request) {
       status: 400,
     });
 
-  const email = (await currentUser())?.emailAddresses?.[0]?.emailAddress!;
+  const email = (await currentUser())?.emailAddresses?.[0]?.emailAddress;
+  if (!email)
+    return new Response(JSON.stringify({ error: "Email required" }), { status: 400 });
   const brand = await prisma.brand.findFirst({ where: { owner: { email } } });
   if (!brand)
     return new Response(JSON.stringify({ error: "Brand not found" }), {

--- a/apps/web/components/ui/dialog.tsx
+++ b/apps/web/components/ui/dialog.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+const DialogTrigger = DialogPrimitive.Trigger
+const DialogPortal = DialogPrimitive.Portal
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Overlay>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>>((props, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className="fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Content>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-white/10 bg-gray-950 p-6 shadow-lg duration-200 sm:rounded-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-gray-950 disabled:pointer-events-none">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-1.5 text-center sm:text-left", className)} {...props} />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)} {...props} />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Title>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title ref={ref} className={cn("text-lg font-semibold leading-none tracking-tight", className)} {...props} />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<React.ElementRef<typeof DialogPrimitive.Description>, React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-white/70", className)} {...props} />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogTrigger,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}


### PR DESCRIPTION
## Summary
- add breakdown data to match generation API
- introduce reusable dialog component and match details drawer
- guard shortlist route against missing user email

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab8c72f3f8832c939c199f491dc04e