### PR TITLE
refine waitlist + landing polish + analytics

### DIFF
--- a/apps/web/app/admin/waitlist/page.tsx
+++ b/apps/web/app/admin/waitlist/page.tsx
@@ -1,0 +1,59 @@
+import { headers } from "next/headers";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminWaitlistPage({ searchParams }: { searchParams: { role?: string; confirmed?: string } }) {
+  const auth = headers().get("authorization");
+  const token = process.env.ADMIN_TOKEN;
+  if (token && auth !== `Bearer ${token}`) {
+    return (
+      <div className="py-20 text-center">
+        <p>Unauthorized</p>
+      </div>
+    );
+  }
+
+  const where: any = {};
+  if (searchParams.role) where.role = searchParams.role.toUpperCase();
+  if (searchParams.confirmed === "true") where.confirmedAt = { not: null };
+  if (searchParams.confirmed === "false") where.confirmedAt = null;
+
+  const signups = await prisma.waitlistSignup.findMany({
+    where,
+    orderBy: { createdAt: "desc" },
+  });
+  const referralCounts = await Promise.all(
+    signups.map((s) => prisma.waitlistSignup.count({ where: { referredBy: s.referralCode } }))
+  );
+
+  return (
+    <div className="py-10">
+      <h1 className="mb-6 text-2xl font-semibold">Waitlist</h1>
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="text-left">
+            <th className="p-2">Email</th>
+            <th className="p-2">Role</th>
+            <th className="p-2">IG</th>
+            <th className="p-2">Created</th>
+            <th className="p-2">Referrals</th>
+            <th className="p-2">Confirmed</th>
+          </tr>
+        </thead>
+        <tbody>
+          {signups.map((s, i) => (
+            <tr key={s.id} className="border-t border-zinc-800">
+              <td className="p-2">{s.email}</td>
+              <td className="p-2">{s.role}</td>
+              <td className="p-2">{s.igHandle || ""}</td>
+              <td className="p-2">{s.createdAt.toISOString()}</td>
+              <td className="p-2">{referralCounts[i]}</td>
+              <td className="p-2">{s.confirmedAt ? "yes" : "no"}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/app/api/waitlist/export/route.ts
+++ b/apps/web/app/api/waitlist/export/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req: Request) {
+  const auth = req.headers.get("authorization");
+  if (process.env.ADMIN_TOKEN && auth !== `Bearer ${process.env.ADMIN_TOKEN}`) {
+    return new NextResponse("Unauthorized", { status: 401 });
+  }
+
+  const signups = await prisma.waitlistSignup.findMany({ orderBy: { createdAt: "desc" } });
+  const counts = await Promise.all(
+    signups.map((s) => prisma.waitlistSignup.count({ where: { referredBy: s.referralCode } }))
+  );
+  const header = [
+    "email",
+    "role",
+    "igHandle",
+    "createdAt",
+    "referrals",
+    "confirmedAt",
+    "utmSource",
+    "utmMedium",
+    "utmCampaign",
+  ];
+  const rows = signups.map((s, i) => [
+    s.email,
+    s.role,
+    s.igHandle || "",
+    s.createdAt.toISOString(),
+    String(counts[i]),
+    s.confirmedAt ? s.confirmedAt.toISOString() : "",
+    s.utmSource || "",
+    s.utmMedium || "",
+    s.utmCampaign || "",
+  ]);
+  const csv = [header.join(","), ...rows.map((r) => r.map((x) => `"${x}"`).join(","))].join("\n");
+  return new NextResponse(csv, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/csv",
+      "Content-Disposition": "attachment; filename=waitlist.csv",
+    },
+  });
+}

--- a/apps/web/app/api/waitlist/route.ts
+++ b/apps/web/app/api/waitlist/route.ts
@@ -1,34 +1,97 @@
-import { NextResponse } from 'next/server';
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { Resend } from "resend";
+import { randomBytes, createHash } from "crypto";
+import { headers } from "next/headers";
+import dns from "dns/promises";
 
 export async function POST(req: Request) {
   try {
-    const { email } = await req.json();
-    if (!email || typeof email !== 'string') {
-      return NextResponse.json({ error: 'Email required' }, { status: 400 });
+    const {
+      email,
+      role,
+      igHandle,
+      website,
+      referredBy,
+      utmSource,
+      utmMedium,
+      utmCampaign,
+    } = await req.json();
+
+    if (!email || typeof email !== "string") {
+      return NextResponse.json({ error: "Email required" }, { status: 400 });
+    }
+    if (website) {
+      return NextResponse.json({ error: "Invalid" }, { status: 400 });
     }
 
-    const webhook = process.env.WAITLIST_WEBHOOK_URL;
-    if (webhook) {
-      await fetch(webhook, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
+    const ip = headers().get("x-forwarded-for") || "";
+    const ipHash = createHash("sha256").update(ip).digest("hex");
+    const recent = await prisma.waitlistSignup.findFirst({
+      where: {
+        OR: [{ email }, { ipHash }],
+        createdAt: { gt: new Date(Date.now() - 60 * 1000) },
+      },
+    });
+    if (recent) {
+      return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+    }
+
+    const domain = email.split("@")[1];
+    try {
+      await Promise.race([
+        dns.resolveMx(domain),
+        new Promise((_, reject) => setTimeout(() => reject(new Error("timeout")), 2000)),
+      ]);
+    } catch {
+      return NextResponse.json({ error: "Invalid email domain" }, { status: 400 });
+    }
+
+    const referralCode = randomBytes(4).toString("hex");
+    const token = randomBytes(16).toString("hex");
+    const confirmExpires = new Date(Date.now() + 72 * 60 * 60 * 1000);
+
+    let refCode: string | undefined;
+    if (referredBy) {
+      const ref = await prisma.waitlistSignup.findUnique({ where: { referralCode: referredBy } });
+      if (ref && ref.email !== email) {
+        refCode = referredBy;
+      }
+    }
+
+    const signup = await prisma.waitlistSignup.create({
+      data: {
+        email,
+        role: role === "brand" ? "BRAND" : "CREATOR",
+        igHandle,
+        referralCode,
+        referredBy: refCode,
+        confirmToken: token,
+        confirmExpires,
+        ipHash,
+        utmSource,
+        utmMedium,
+        utmCampaign,
+      },
+    });
+
+    if (process.env.RESEND_API_KEY) {
+      const resend = new Resend(process.env.RESEND_API_KEY);
+      const baseUrl = process.env.NEXT_PUBLIC_APP_URL || "https://usesiora.com";
+      await resend.emails.send({
+        from: "Siora <noreply@usesiora.com>",
+        to: email,
+        subject: "Confirm your spot on Siora’s waitlist",
+        html: `<p>Thanks for joining!</p><p><a href="${baseUrl}/api/waitlist/verify?token=${token}">Confirm email</a></p>`,
       });
     }
 
-    const approved = process.env.APPROVED_DOMAINS?.split(',').map(d => d.trim().toLowerCase()) || [];
-    const domain = email.split('@')[1]?.toLowerCase();
-    if (domain && approved.includes(domain) && process.env.INVITE_WEBHOOK_URL) {
-      await fetch(process.env.INVITE_WEBHOOK_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
-      });
+    return NextResponse.json({ code: signup.referralCode });
+  } catch (err: any) {
+    console.error("waitlist POST error", err);
+    if (err.code === "P2002") {
+      return NextResponse.json({ error: "Already signed up" }, { status: 200 });
     }
-
-    return NextResponse.json({ ok: true });
-  } catch (err) {
-    console.error('waitlist POST error', err);
-    return NextResponse.json({ error: 'Server error' }, { status: 500 });
+    return NextResponse.json({ error: "Server error" }, { status: 500 });
   }
 }

--- a/apps/web/app/api/waitlist/verify/route.ts
+++ b/apps/web/app/api/waitlist/verify/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const token = searchParams.get("token");
+  if (!token) {
+    return NextResponse.redirect("/");
+  }
+
+  const signup = await prisma.waitlistSignup.findFirst({
+    where: { confirmToken: token, confirmExpires: { gt: new Date() } },
+  });
+  if (!signup) {
+    return NextResponse.redirect("/");
+  }
+
+  await prisma.waitlistSignup.update({
+    where: { id: signup.id },
+    data: { confirmedAt: new Date(), confirmToken: null, confirmExpires: null },
+  });
+
+  return NextResponse.redirect(`/waitlist/thank-you?code=${signup.referralCode}&verified=1`);
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -32,8 +32,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </nav>
           </header>
           <main className="mx-auto max-w-7xl px-4">{children}</main>
-          <footer className="mx-auto max-w-7xl px-4 py-10 text-sm text-white/50">
-            © {new Date().getFullYear()} Siora — All rights reserved.
+          <footer className="mx-auto max-w-7xl px-4 py-10 text-sm text-white/50 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <p>© {new Date().getFullYear()} Siora</p>
+            <nav className="flex gap-4">
+              <Link href="/about">About</Link>
+              <Link href="/contact">Contact</Link>
+              <Link href="/privacy">Privacy</Link>
+              <Link href="/terms">Terms</Link>
+            </nav>
           </footer>
         </body>
       </html>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,18 +1,26 @@
 
 "use client";
 
+import { useEffect } from "react";
 import Hero from "@/components/marketing/Hero";
 import Features from "@/components/marketing/Features";
 import WaitlistForm from "@/components/marketing/WaitlistForm";
+import HowItWorks from "@/components/marketing/HowItWorks";
 import { Toaster } from "react-hot-toast";
+import { track } from "@/lib/analytics/track";
 
 export default function Home() {
+  useEffect(() => {
+    track("landing_view");
+  }, []);
+
   return (
     <>
       <Toaster position="top-right" />
       <Hero />
-      <Features />
       <WaitlistForm />
+      <Features />
+      <HowItWorks />
     </>
   );
 }

--- a/apps/web/app/waitlist/thank-you/ThankYouClient.tsx
+++ b/apps/web/app/waitlist/thank-you/ThankYouClient.tsx
@@ -1,0 +1,78 @@
+"use client";
+import { useEffect } from "react";
+import { track } from "@/lib/analytics/track";
+import { toast, Toaster } from "react-hot-toast";
+
+interface Props {
+  code: string;
+  referrals: number;
+  confirmed: boolean;
+  verified: boolean;
+}
+
+export default function ThankYouClient({ code, referrals, confirmed, verified }: Props) {
+  const shareUrl = `${process.env.NEXT_PUBLIC_APP_URL || "https://usesiora.com"}/?ref=${code}`;
+
+  useEffect(() => {
+    track("thank_you_view");
+    if (verified) {
+      toast.success("Email verified");
+      track("waitlist_verified");
+    }
+  }, [verified]);
+
+  const copy = async () => {
+    await navigator.clipboard.writeText(shareUrl);
+    track("referral_share_click", { channel: "copy" });
+    toast.success("Link copied");
+  };
+
+  return (
+    <div className="py-20 text-center">
+      <Toaster position="top-right" />
+      <h1 className="text-4xl font-semibold">You're in.</h1>
+      <p className="mt-2 text-white/70">Invite friends for earlier access.</p>
+      {!confirmed && (
+        <div className="mt-4 rounded-md bg-yellow-500/10 px-4 py-2 text-sm text-yellow-500">
+          Please confirm your email—check your inbox.
+        </div>
+      )}
+      <span className="mt-6 inline-block rounded-full bg-zinc-900 px-3 py-1 text-sm">
+        {referrals}/5
+      </span>
+      <div className="mx-auto mt-6 max-w-md">
+        <input
+          readOnly
+          value={shareUrl}
+          className="w-full rounded-lg border border-zinc-800 bg-zinc-900/70 p-3 text-center"
+        />
+        <button
+          onClick={copy}
+          className="mt-3 w-full rounded-lg bg-indigo-600 px-5 py-3 text-white hover:bg-indigo-700"
+        >
+          Copy link
+        </button>
+        <div className="mt-4 flex justify-center gap-4 text-sm">
+          <a
+            href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => track("referral_share_click", { channel: "twitter" })}
+            className="underline"
+          >
+            Twitter
+          </a>
+          <a
+            href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(shareUrl)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={() => track("referral_share_click", { channel: "linkedin" })}
+            className="underline"
+          >
+            LinkedIn
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/waitlist/thank-you/page.tsx
+++ b/apps/web/app/waitlist/thank-you/page.tsx
@@ -1,0 +1,36 @@
+import { prisma } from "@/lib/prisma";
+import ThankYouClient from "./ThankYouClient";
+import Link from "next/link";
+
+export default async function Page({ searchParams }: { searchParams: { code?: string; verified?: string } }) {
+  const code = searchParams.code;
+  if (!code) {
+    return (
+      <div className="py-20 text-center">
+        <p>Missing referral code.</p>
+        <Link href="/" className="underline">Go back</Link>
+      </div>
+    );
+  }
+
+  const signup = await prisma.waitlistSignup.findUnique({ where: { referralCode: code } });
+  if (!signup) {
+    return (
+      <div className="py-20 text-center">
+        <p>We couldn't find your signup.</p>
+        <Link href="/" className="underline">Go back</Link>
+      </div>
+    );
+  }
+
+  const referrals = await prisma.waitlistSignup.count({ where: { referredBy: code } });
+
+  return (
+    <ThankYouClient
+      code={code}
+      referrals={referrals}
+      confirmed={!!signup.confirmedAt}
+      verified={searchParams.verified === "1"}
+    />
+  );
+}

--- a/apps/web/components/marketing/Features.tsx
+++ b/apps/web/components/marketing/Features.tsx
@@ -1,20 +1,20 @@
-import { Briefcase, Search, BarChart3 } from "lucide-react";
+import { Mic2, ShieldCheck, WandSparkles } from "lucide-react";
 
 const features = [
   {
-    icon: Briefcase,
-    title: "Smart briefs",
-    desc: "Kick off collaborations with structured briefs that clarify goals, deliverables, timelines, and usage rights.",
+    icon: Mic2,
+    title: "Match by voice & values",
+    desc: "Reach partners who sound like you. Siora looks beyond audience stats to find true fit.",
   },
   {
-    icon: Search,
-    title: "Creator discovery",
-    desc: "Find the right fit with filters for audience, values, and performance — not just follower counts.",
+    icon: ShieldCheck,
+    title: "Creator-first fairness checks",
+    desc: "Our safeguards keep deals transparent and respectful for every creator.",
   },
   {
-    icon: BarChart3,
-    title: "Shared analytics",
-    desc: "Track content performance across channels with transparent, privacy-safe metrics both sides can trust.",
+    icon: WandSparkles,
+    title: "Briefs & personas generated for you",
+    desc: "AI drafts what you need so you can skip the busywork and start collaborating.",
   },
 ];
 
@@ -23,10 +23,10 @@ const Features = () => {
     <section id="features" className="py-16">
       <div className="text-center">
         <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">
-          Designed for people and brands to meet in the middle
+          Why Siora
         </h2>
         <p className="mt-3 text-white/70">
-          Reduce friction, increase signal, and collaborate with clarity.
+          Premium tools for campaigns that actually resonate.
         </p>
       </div>
       <div className="mt-10 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">

--- a/apps/web/components/marketing/Hero.tsx
+++ b/apps/web/components/marketing/Hero.tsx
@@ -1,35 +1,21 @@
 import { Button } from "@/components/ui/button";
-import { Sparkles } from "lucide-react";
 
 const Hero = () => {
   return (
     <header className="py-20 text-center">
-      <span className="inline-flex items-center gap-2 rounded-full border border-Siora-accent/50 bg-Siora-accent/10 px-3 py-1 text-xs text-Siora-accent">
-        <Sparkles className="size-3" /> Early access
-      </span>
-      <h1 className="mt-6 text-4xl font-semibold tracking-tight sm:text-5xl md:text-6xl">
-        Siora — where creators and brands connect, collaborate, and grow
+      <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl md:text-6xl">
+        Smarter, fairer brand deals.
       </h1>
       <p className="mt-4 mx-auto max-w-2xl text-base text-white/70 sm:text-lg">
-        Build authentic partnerships without the inbox chaos. Streamlined briefs, discovery, and performance insights in one shared workspace.
+        Siora pairs brands with creators who share values—not just audience stats.
       </p>
-      <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
-        <Button asChild variant="brand" size="lg">
-          <a href="#waitlist">Join the waitlist</a>
+      <div className="mt-8 flex justify-center gap-3">
+        <Button asChild variant="outline" size="lg">
+          <a href="#waitlist">Brand</a>
         </Button>
         <Button asChild variant="outline" size="lg">
-          <a href="#features">See how it works</a>
+          <a href="#waitlist">Creator</a>
         </Button>
-      </div>
-      <div className="mt-12">
-        <figure className="mx-auto max-w-5xl overflow-hidden rounded-xl border border-Siora-border bg-gray-900/50">
-          <img
-            src="https://placehold.co/1200x600/png"
-            alt="Siora collaborative workspace connecting creators and brands"
-            loading="lazy"
-            className="h-auto w-full object-cover"
-          />
-        </figure>
       </div>
     </header>
   );

--- a/apps/web/components/marketing/HowItWorks.tsx
+++ b/apps/web/components/marketing/HowItWorks.tsx
@@ -1,0 +1,26 @@
+const steps = [
+  { title: "Create", desc: "Set up your profile and goals." },
+  { title: "Match", desc: "We pair brands and creators by values." },
+  { title: "Collaborate", desc: "Run fair deals with shared tools." },
+];
+
+const HowItWorks = () => {
+  return (
+    <section className="py-16">
+      <div className="text-center">
+        <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">How it works</h2>
+      </div>
+      <ol className="mt-10 grid grid-cols-1 gap-6 md:grid-cols-3">
+        {steps.map((s, i) => (
+          <li key={s.title} className="text-center">
+            <div className="mb-4 text-3xl text-indigo-500">{i + 1}</div>
+            <h3 className="text-lg font-semibold">{s.title}</h3>
+            <p className="mt-2 text-sm text-white/70">{s.desc}</p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+};
+
+export default HowItWorks;

--- a/apps/web/components/marketing/WaitlistForm.tsx
+++ b/apps/web/components/marketing/WaitlistForm.tsx
@@ -1,152 +1,162 @@
-import { useState } from "react";
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { toast } from "react-hot-toast";
+import { track } from "@/lib/analytics/track";
+import Link from "next/link";
+import { SignedIn, SignedOut } from "@clerk/nextjs";
 
 const schema = z.object({
   role: z.enum(["creator", "brand"]),
-  name: z.string().min(2, "Please enter your name"),
-  email: z.string().email("Enter a valid email"),
-  company: z.string().optional(),
-  website: z.string().url().optional().or(z.literal("")),
-  message: z.string().max(500).optional(),
-  source: z.string().optional(),
-  consent: z.boolean().refine((v) => v === true, { message: "Please accept to join the list" }),
+  email: z.string().email(),
+  igHandle: z.string().optional(),
+  website: z.string().optional(),
 });
 
 type FormValues = z.infer<typeof schema>;
 
-const sources = [
-  { value: "twitter", label: "Twitter/X" },
-  { value: "linkedin", label: "LinkedIn" },
-  { value: "friend", label: "Friend/colleague" },
-  { value: "search", label: "Search" },
-  { value: "other", label: "Other" },
-];
-
 const WaitlistForm = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const referredBy = searchParams.get("ref") || undefined;
+  const utmSource = searchParams.get("utm_source") || undefined;
+  const utmMedium = searchParams.get("utm_medium") || undefined;
+  const utmCampaign = searchParams.get("utm_campaign") || undefined;
+
   const [loading, setLoading] = useState(false);
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),
-    defaultValues: {
-      role: "creator",
-      name: "",
-      email: "",
-      company: "",
-      website: "",
-      message: "",
-      source: "",
-      consent: true,
-    },
+    defaultValues: { role: "creator", email: "" },
   });
 
-  const isBrand = form.watch("role") === "brand";
+  useEffect(() => {
+    track("waitlist_form_view");
+  }, []);
 
   const onSubmit = async (values: FormValues) => {
     setLoading(true);
     try {
-      try {
-        const local = JSON.parse(localStorage.getItem("siora_waitlist") || "[]");
-        local.push({ ...values, at: new Date().toISOString() });
-        localStorage.setItem("siora_waitlist", JSON.stringify(local));
-      } catch {}
-      toast.success("You're on the list — we'll be in touch soon!");
-      form.reset({ role: values.role, consent: true });
+      const res = await fetch("/api/waitlist", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...values,
+          referredBy,
+          utmSource,
+          utmMedium,
+          utmCampaign,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || "Error");
+      track("waitlist_form_submit", {
+        role: values.role,
+        source: utmSource,
+        utm: { source: utmSource, medium: utmMedium, campaign: utmCampaign },
+      });
+      if (referredBy) {
+        track("referral_signup", { referredBy });
+      }
+      router.push(`/waitlist/thank-you?code=${json.code}`);
     } catch (err) {
-      console.error("Waitlist submission failed:", err);
-      try {
-        const local = JSON.parse(localStorage.getItem("siora_waitlist") || "[]");
-        local.push({ ...values, at: new Date().toISOString() });
-        localStorage.setItem("siora_waitlist", JSON.stringify(local));
-      } catch {}
-      toast.success("You're on the list!");
+      console.error(err);
+      toast.error("Something went wrong");
     } finally {
       setLoading(false);
     }
   };
 
+  const isCreator = form.watch("role") === "creator";
+
   return (
     <section id="waitlist" className="py-16">
-      <div className="grid max-w-5xl grid-cols-1 gap-8 md:grid-cols-2 mx-auto">
-        <div>
-          <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">Join the early access waitlist</h2>
-          <p className="mt-3 text-white/70">
-            Be first to try Siora. Whether you’re a creator or a brand, you’ll get updates and an invite when we open the doors.
-          </p>
-          <ul className="mt-6 space-y-3 text-sm text-white/70">
-            <li>• Zero spam — just meaningful updates.</li>
-            <li>• Priority invites for early sign-ups.</li>
-            <li>• Help shape the roadmap.</li>
-          </ul>
-        </div>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="rounded-xl border border-Siora-border bg-gray-900/50 p-6 shadow-sm">
-          <div className="grid grid-cols-2 gap-3">
-            <div className="col-span-2">
-              <Label htmlFor="role">I am a</Label>
-              <div className="mt-2 inline-flex gap-2">
-                <Button type="button" variant={form.watch("role") === "creator" ? "brand" : "outline"} onClick={() => form.setValue("role", "creator")}>Creator</Button>
-                <Button type="button" variant={form.watch("role") === "brand" ? "brand" : "outline"} onClick={() => form.setValue("role", "brand")}>Brand</Button>
-              </div>
-            </div>
-            <div className="col-span-2">
-              <Label htmlFor="name">Full name</Label>
-              <Input id="name" placeholder="Alex Morgan" {...form.register("name")} />
-              {form.formState.errors.name && (
-                <p className="mt-1 text-xs text-red-500">{form.formState.errors.name.message}</p>
-              )}
-            </div>
-            <div className="col-span-2">
-              <Label htmlFor="email">Email</Label>
-              <Input id="email" type="email" placeholder="you@domain.com" {...form.register("email")} />
-              {form.formState.errors.email && (
-                <p className="mt-1 text-xs text-red-500">{form.formState.errors.email.message}</p>
-              )}
-            </div>
-            {isBrand && (
-              <div className="col-span-2">
-                <Label htmlFor="company">Company</Label>
-                <Input id="company" placeholder="Brand or org" {...form.register("company")} />
-              </div>
-            )}
-            <div className="col-span-2">
-              <Label htmlFor="website">Website or profile</Label>
-              <Input id="website" placeholder="https://..." {...form.register("website")} />
-              {form.formState.errors.website && (
-                <p className="mt-1 text-xs text-red-500">Valid URL please</p>
-              )}
-            </div>
-            <div className="col-span-2">
-              <Label htmlFor="message">What would you use Siora for?</Label>
-              <Textarea id="message" rows={3} placeholder="Tell us a bit about your needs" {...form.register("message")} />
-            </div>
-            <div className="col-span-2">
-              <Label htmlFor="source">How did you hear about us?</Label>
-              <Select onValueChange={(v) => form.setValue("source", v)}>
-                <SelectTrigger id="source" className="w-full">
-                  <SelectValue placeholder="Select a source" />
-                </SelectTrigger>
-                <SelectContent>
-                  {sources.map((s) => (
-                    <SelectItem key={s.value} value={s.value}>{s.label}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="col-span-2 mt-1 flex items-center gap-2">
-              <input id="consent" type="checkbox" className="size-4" {...form.register("consent")} />
-              <Label htmlFor="consent" className="text-sm text-white/70">I agree to receive early access updates</Label>
-            </div>
-            <div className="col-span-2 mt-2">
-              <Button type="submit" variant="brand" size="lg" disabled={loading} className="w-full">
-                {loading ? "Joining..." : "Join the waitlist"}
+      <div className="mx-auto max-w-md">
+        <h2 className="text-3xl font-semibold tracking-tight md:text-4xl text-center">
+          Join the early access list
+        </h2>
+        <form
+          onSubmit={form.handleSubmit(onSubmit)}
+          className="mt-8 rounded-xl border border-zinc-800 bg-zinc-900/70 p-6"
+        >
+          <input type="text" className="hidden" {...form.register("website")} />
+          <div className="mb-4">
+            <Label>I am a</Label>
+            <div className="mt-2 flex gap-2">
+              <Button
+                type="button"
+                onClick={() => form.setValue("role", "creator")}
+                className={
+                  form.watch("role") === "creator"
+                    ? "bg-indigo-600 text-white"
+                    : "bg-zinc-800"
+                }
+              >
+                Creator
+              </Button>
+              <Button
+                type="button"
+                onClick={() => form.setValue("role", "brand")}
+                className={
+                  form.watch("role") === "brand"
+                    ? "bg-indigo-600 text-white"
+                    : "bg-zinc-800"
+                }
+              >
+                Brand
               </Button>
             </div>
+          </div>
+          <div className="mb-4">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              className="focus:ring-2 focus:ring-indigo-500"
+              placeholder="you@example.com"
+              {...form.register("email")}
+            />
+          </div>
+          {isCreator && (
+            <div className="mb-4">
+              <Label htmlFor="igHandle">Instagram handle</Label>
+              <Input
+                id="igHandle"
+                placeholder="@handle"
+                className="focus:ring-2 focus:ring-indigo-500"
+                {...form.register("igHandle")}
+              />
+            </div>
+          )}
+          <Button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg px-5 py-3"
+          >
+            {loading ? "Joining..." : "Join waitlist"}
+          </Button>
+          <div className="mt-4 text-center text-sm text-white/70">
+            <SignedIn>
+              <Link href="/dashboard" className="underline">
+                Go to Dashboard
+              </Link>
+            </SignedIn>
+            <SignedOut>
+              <div className="flex justify-center gap-4">
+                <Link href="/auth/login?role=brand" className="underline">
+                  Sign in as Brand
+                </Link>
+                <Link href="/instagram/login" className="underline">
+                  Sign in with Instagram
+                </Link>
+              </div>
+            </SignedOut>
           </div>
         </form>
       </div>

--- a/apps/web/lib/analytics/track.ts
+++ b/apps/web/lib/analytics/track.ts
@@ -1,0 +1,8 @@
+'use client';
+import posthog from 'posthog-js';
+
+export function track(event: string, properties?: Record<string, any>) {
+  if (typeof window === 'undefined') return;
+  if (!posthog.__loaded) return;
+  posthog.capture(event, properties);
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,7 +1,14 @@
 import { authMiddleware } from "@clerk/nextjs";
 
 export default authMiddleware({
-  publicRoutes: ["/", "/pricing", "/api/health"],
+  publicRoutes: [
+    "/",
+    "/pricing",
+    "/api/health",
+    "/waitlist(.*)",
+    "/api/waitlist(.*)",
+    "/admin/waitlist(.*)",
+  ],
 });
 
 export const config = {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -45,6 +45,7 @@
     "next": "^15.3.4",
     "next-auth": "^4.24.11",
     "posthog-js": "^1.257.1",
+    "resend": "^3.2.0",
     "prisma": "^6.9.0",
     "puppeteer": "^21.9.0",
     "react": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -542,6 +542,9 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.1.8)(react@19.1.0)
+      resend:
+        specifier: ^3.2.0
+        version: 3.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       shared-ui:
         specifier: workspace:*
         version: link:../../packages/shared-ui
@@ -1088,6 +1091,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -1192,6 +1199,9 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@one-ini/wasm@0.1.1':
+    resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
   '@opentelemetry/api-logs@0.53.0':
     resolution: {integrity: sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==}
@@ -1419,6 +1429,10 @@ packages:
 
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@prisma/client@6.12.0':
     resolution: {integrity: sha512-wn98bJ3Cj6edlF4jjpgXwbnQIo/fQLqqQHPk2POrZPxTlhY3+n90SSIF3LMRVa8VzRFC/Gec3YKJRxRu+AIGVA==}
@@ -1738,6 +1752,13 @@ packages:
       '@types/react':
         optional: true
 
+  '@react-email/render@0.0.16':
+    resolution: {integrity: sha512-wDaMy27xAq1cJHtSFptp0DTKPuV2GYhloqia95ub/DH9Dea1aWYsbdM918MOc/b/HvVS3w1z8DWzfAk13bGStQ==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^18.2.0
+      react-dom: ^18.2.0
+
   '@react-pdf/fns@3.1.2':
     resolution: {integrity: sha512-qTKGUf0iAMGg2+OsUcp9ffKnKi41RukM/zYIWMDJ4hRVYSr89Q7e3wSDW/Koqx3ea3Uy/z3h2y3wPX6Bdfxk6g==}
 
@@ -1904,6 +1925,9 @@ packages:
 
   '@rushstack/eslint-patch@1.12.0':
     resolution: {integrity: sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==}
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
 
   '@sentry-internal/browser-utils@8.55.0':
     resolution: {integrity: sha512-ROgqtQfpH/82AQIpESPqPQe0UyWywKJsmVIqi3c5Fh+zkds5LUxnssTj3yNd1x+kxaPDVB023jAP+3ibNgeNDw==}
@@ -2515,6 +2539,10 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  abbrev@2.0.0:
+    resolution: {integrity: sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -2582,9 +2610,17 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.0:
+    resolution: {integrity: sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.1:
+    resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
+    engines: {node: '>=12'}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -2883,6 +2919,10 @@ packages:
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
+  commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -2898,6 +2938,9 @@ packages:
   concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
     engines: {'0': node >= 0.8}
+
+  config-chain@1.1.13:
+    resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -3023,6 +3066,10 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
+
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
@@ -3067,8 +3114,21 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
   dompurify@3.2.6:
     resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3081,8 +3141,16 @@ packages:
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   ecc-jsbn@0.1.2:
     resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
+
+  editorconfig@1.0.4:
+    resolution: {integrity: sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   electron-to-chromium@1.5.187:
     resolution: {integrity: sha512-cl5Jc9I0KGUoOoSbxvTywTa40uspGJt/BDBoDLoxJRSBpWh4FFXBsjNRHfQrONsV/OoEjDfHUmZQa2d6Ze4YgA==}
@@ -3102,6 +3170,10 @@ packages:
   enhanced-resolve@5.18.2:
     resolution: {integrity: sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==}
     engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -3334,6 +3406,9 @@ packages:
     resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
     engines: {'0': node >=0.6.0}
 
+  fast-deep-equal@2.0.1:
+    resolution: {integrity: sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3417,6 +3492,10 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
 
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
@@ -3530,6 +3609,10 @@ packages:
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -3619,6 +3702,10 @@ packages:
   hsl-to-rgb-for-reals@1.1.1:
     resolution: {integrity: sha512-LgOWAkrN0rFaQpfdWBQlv/VhkOxb5AsBjk6NQVx4yEzWS923T07X0M1Y0VNko2H52HeSpZrZNNMJ0aFqsdVzQg==}
 
+  html-to-text@9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
@@ -3628,6 +3715,9 @@ packages:
 
   html2pdf.js@0.10.3:
     resolution: {integrity: sha512-RcB1sh8rs5NT3jgbN5zvvTmkmZrsUrxpZ/RI8TMbvuReNZAdJZG5TMfA2TBP6ZXxpXlWf9NB/ciLXVb6W2LbRQ==}
+
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -3683,6 +3773,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@1.3.8:
+    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
@@ -3865,6 +3958,9 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jay-peg@1.1.1:
     resolution: {integrity: sha512-D62KEuBxz/ip2gQKOEhk/mx14o7eiFRaU+VNNSP4MOiIkwb/D6B3G1Mfas7C/Fit8EsSV2/IWjZElx/Gs6A4ww==}
 
@@ -3881,6 +3977,11 @@ packages:
 
   jpeg-exif@1.1.4:
     resolution: {integrity: sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==}
+
+  js-beautify@1.15.4:
+    resolution: {integrity: sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   js-cookie@3.0.5:
     resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
@@ -3963,6 +4064,9 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  leac@0.6.0:
+    resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -4225,6 +4329,10 @@ packages:
     resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minimatch@9.0.1:
+    resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -4353,6 +4461,11 @@ packages:
     resolution: {integrity: sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==}
     engines: {node: '>=6.0.0'}
 
+  nopt@7.2.1:
+    resolution: {integrity: sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+    hasBin: true
+
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -4456,6 +4569,9 @@ packages:
     resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
     engines: {node: '>= 14'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
 
@@ -4475,6 +4591,9 @@ packages:
 
   parse-svg-path@0.1.2:
     resolution: {integrity: sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==}
+
+  parseley@0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -4497,6 +4616,9 @@ packages:
 
   pdfkit@0.15.2:
     resolution: {integrity: sha512-s3GjpdBFSCaeDSX/v73MI5UsPqH1kjKut2AXCgxQ5OH10lPVOu5q5vLAG0OCpz/EYqKsTSw1WHpENqMvp43RKg==}
+
+  peberminta@0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -4645,6 +4767,9 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proto-list@1.2.4:
+    resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
+
   proxy-agent@6.3.1:
     resolution: {integrity: sha512-Rb5RVBy1iyqOtNl15Cw/llpeLH8bsb37gM1FUfKQ+Wck6xHlbAhWGUFiTRHtkjqGTA5pSHz6+0hrPW/oECihPQ==}
     engines: {node: '>= 14'}
@@ -4729,6 +4854,9 @@ packages:
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
+
+  react-promise-suspense@0.3.4:
+    resolution: {integrity: sha512-I42jl7L3Ze6kZaq+7zXWSunBa3b1on5yfvUW6Eo/3fFOj6dZ5Bqmcd264nJbTK/gn1HjjILAjSwnZbV4RpSaNQ==}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -4820,6 +4948,10 @@ packages:
     resolution: {integrity: sha512-gAZ+kLqBdHarXB64XpAe2VCjB7rIRv+mU8tfRWziHRJ5umKsIHN2tLLv6EtMw7WCdP19S0ERVMldNvxYCHnhSQ==}
     engines: {node: '>=8.6.0'}
 
+  resend@3.5.0:
+    resolution: {integrity: sha512-bKu4LhXSecP6krvhfDzyDESApYdNfjirD5kykkT1xO0Cj9TKSiGh5Void4pGTs3Am+inSnp4dg0B5XzdwHBJOQ==}
+    engines: {node: '>=18'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -4903,6 +5035,9 @@ packages:
     resolution: {integrity: sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==}
     engines: {node: '>= 10.13.0'}
 
+  selderee@0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -4963,6 +5098,10 @@ packages:
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -5035,6 +5174,10 @@ packages:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
 
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
     engines: {node: '>= 0.4'}
@@ -5070,6 +5213,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -5548,6 +5695,10 @@ packages:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
 
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -6019,6 +6170,15 @@ snapshots:
   '@img/sharp-win32-x64@0.34.3':
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.2
@@ -6104,6 +6264,8 @@ snapshots:
       fastq: 1.19.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@one-ini/wasm@0.1.1': {}
 
   '@opentelemetry/api-logs@0.53.0':
     dependencies:
@@ -6399,6 +6561,9 @@ snapshots:
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
 
   '@panva/hkdf@1.2.1': {}
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@prisma/client@6.12.0(prisma@6.12.0(typescript@5.8.3))(typescript@5.8.3)':
     optionalDependencies:
@@ -6706,6 +6871,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.8
 
+  '@react-email/render@0.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      html-to-text: 9.0.5
+      js-beautify: 1.15.4
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-promise-suspense: 0.3.4
+
   '@react-pdf/fns@3.1.2': {}
 
   '@react-pdf/font@4.0.2':
@@ -6890,6 +7063,11 @@ snapshots:
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.12.0': {}
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
 
   '@sentry-internal/browser-utils@8.55.0':
     dependencies:
@@ -7569,6 +7747,8 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  abbrev@2.0.0: {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -7630,9 +7810,13 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.0: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.1: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -7962,6 +8146,8 @@ snapshots:
 
   comma-separated-tokens@2.0.3: {}
 
+  commander@10.0.1: {}
+
   commander@2.20.3: {}
 
   commander@3.0.2: {}
@@ -7976,6 +8162,11 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 2.3.8
       typedarray: 0.0.6
+
+  config-chain@1.1.13:
+    dependencies:
+      ini: 1.3.8
+      proto-list: 1.2.4
 
   convert-source-map@2.0.0: {}
 
@@ -8095,6 +8286,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  deepmerge@4.3.1: {}
+
   define-data-property@1.1.4:
     dependencies:
       es-define-property: 1.0.1
@@ -8135,10 +8328,28 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
   dompurify@3.2.6:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
     optional: true
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
 
   dotenv@16.6.1: {}
 
@@ -8150,10 +8361,19 @@ snapshots:
 
   duplexer@0.1.2: {}
 
+  eastasianwidth@0.2.0: {}
+
   ecc-jsbn@0.1.2:
     dependencies:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
+
+  editorconfig@1.0.4:
+    dependencies:
+      '@one-ini/wasm': 0.1.1
+      commander: 10.0.1
+      minimatch: 9.0.1
+      semver: 7.7.2
 
   electron-to-chromium@1.5.187: {}
 
@@ -8171,6 +8391,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.2
+
+  entities@4.5.0: {}
 
   env-paths@2.2.1: {}
 
@@ -8577,6 +8799,8 @@ snapshots:
 
   extsprintf@1.3.0: {}
 
+  fast-deep-equal@2.0.1: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -8670,6 +8894,11 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
 
   forever-agent@0.6.1: {}
 
@@ -8793,6 +9022,15 @@ snapshots:
 
   glob-to-regexp@0.4.1: {}
 
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -8896,6 +9134,14 @@ snapshots:
 
   hsl-to-rgb-for-reals@1.1.1: {}
 
+  html-to-text@9.0.5:
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
+
   html-url-attributes@3.0.1: {}
 
   html2canvas@1.4.1:
@@ -8908,6 +9154,13 @@ snapshots:
       es6-promise: 4.2.8
       html2canvas: 1.4.1
       jspdf: 3.0.1
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -8972,6 +9225,8 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  ini@1.3.8: {}
 
   inline-style-parser@0.2.4: {}
 
@@ -9154,6 +9409,12 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jay-peg@1.1.1:
     dependencies:
       restructure: 3.0.2
@@ -9169,6 +9430,14 @@ snapshots:
   jose@4.15.9: {}
 
   jpeg-exif@1.1.4: {}
+
+  js-beautify@1.15.4:
+    dependencies:
+      config-chain: 1.1.13
+      editorconfig: 1.0.4
+      glob: 10.4.5
+      js-cookie: 3.0.5
+      nopt: 7.2.1
 
   js-cookie@3.0.5: {}
 
@@ -9249,6 +9518,8 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  leac@0.6.0: {}
 
   levn@0.4.1:
     dependencies:
@@ -9618,6 +9889,10 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
+  minimatch@9.0.1:
+    dependencies:
+      brace-expansion: 2.0.2
+
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.2
@@ -9716,6 +9991,10 @@ snapshots:
   node-releases@2.0.19: {}
 
   nodemailer@7.0.5: {}
+
+  nopt@7.2.1:
+    dependencies:
+      abbrev: 2.0.0
 
   normalize-path@3.0.0: {}
 
@@ -9846,6 +10125,8 @@ snapshots:
       degenerator: 5.0.1
       netmask: 2.0.2
 
+  package-json-from-dist@1.0.1: {}
+
   pako@0.2.9: {}
 
   pako@1.0.11: {}
@@ -9873,6 +10154,11 @@ snapshots:
 
   parse-svg-path@0.1.2: {}
 
+  parseley@0.12.1:
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -9893,6 +10179,8 @@ snapshots:
       jpeg-exif: 1.1.4
       linebreak: 1.1.0
       png-js: 1.0.0
+
+  peberminta@0.9.0: {}
 
   pend@1.2.0: {}
 
@@ -10019,6 +10307,8 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proto-list@1.2.4: {}
+
   proxy-agent@6.3.1:
     dependencies:
       agent-base: 7.1.4
@@ -10136,6 +10426,10 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  react-promise-suspense@0.3.4:
+    dependencies:
+      fast-deep-equal: 2.0.1
 
   react-remove-scroll-bar@2.3.8(@types/react@19.1.8)(react@19.1.0):
     dependencies:
@@ -10274,6 +10568,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  resend@3.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@react-email/render': 0.0.16(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -10379,6 +10680,10 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.17.1)
       ajv-keywords: 5.1.0(ajv@8.17.1)
 
+  selderee@0.11.0:
+    dependencies:
+      parseley: 0.12.1
+
   semver@6.3.1: {}
 
   semver@7.7.2: {}
@@ -10479,6 +10784,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  signal-exit@4.1.0: {}
+
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
@@ -10566,6 +10873,12 @@ snapshots:
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
 
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.1.0
+
   string.prototype.includes@2.0.1:
     dependencies:
       call-bind: 1.0.8
@@ -10632,6 +10945,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.1.0:
+    dependencies:
+      ansi-regex: 6.2.0
 
   strip-bom@3.0.0: {}
 
@@ -11166,6 +11483,12 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.1
+      string-width: 5.1.2
+      strip-ansi: 7.1.0
 
   wrappy@1.0.2: {}
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -173,3 +173,29 @@ model ShortlistItem {
   @@unique([shortlistId, creatorId])
 }
 
+enum WaitlistRole {
+  CREATOR
+  BRAND
+}
+
+model WaitlistSignup {
+  id             String       @id @default(cuid())
+  email          String       @unique
+  role           WaitlistRole
+  igHandle       String?
+  referralCode   String       @unique
+  referredBy     String?
+  confirmToken   String?
+  confirmExpires DateTime?
+  confirmedAt    DateTime?
+  ipHash         String?
+  utmSource      String?
+  utmMedium      String?
+  utmCampaign    String?
+  createdAt      DateTime     @default(now())
+  updatedAt      DateTime     @updatedAt
+
+  @@index([referralCode])
+  @@index([referredBy])
+}
+


### PR DESCRIPTION
## Summary
- streamline landing hero and waitlist form with premium copy
- add waitlist signup API with referrals, email verification, and analytics tracking
- provide admin view and CSV export for waitlist management

## Testing
- `pnpm install --ignore-scripts`
- `npx prisma@6.9.0 migrate dev --name waitlist_upgrades --schema=./prisma/schema.prisma` *(fails: Environment variable not found: DATABASE_URL)*
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68ab8e2f7330832c9f2127f0ccf309b8