### PR TITLE
Add shortlist pipeline and deal workflow

### DIFF
--- a/apps/web/app/api/deal/evaluate/route.ts
+++ b/apps/web/app/api/deal/evaluate/route.ts
@@ -1,0 +1,49 @@
+import { prisma } from "@/lib/prisma";
+import { auth } from "@clerk/nextjs/server";
+import { getBrandForUser } from "@/lib/guards";
+import { consumeCredits } from "@/lib/credits";
+import OpenAI from "openai";
+
+export const runtime = "nodejs";
+const ai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+
+export async function POST(req: Request) {
+  const { userId } = auth(); if (!userId) return new Response("Unauthorized", { status: 401 });
+  const brand = await getBrandForUser(); if (!brand) return new Response("Brand not found", { status: 404 });
+
+  const { creatorId, campaignId, deliverables, rights, priceEUR, notes } = await req.json();
+
+  const debit = await consumeCredits(brand.id, 1, "AI_ANALYZE", "Deal evaluation");
+  if (!debit.ok) return new Response(JSON.stringify({ error: "Not enough credits" }), { status: 402 });
+
+  const creator = await prisma.creator.findUnique({ where: { id: creatorId } });
+  const brief = campaignId ? (await prisma.campaign.findUnique({ where: { id: campaignId } }))?.brief : null;
+
+  const prompt = `Assess a proposed influencer deal for fairness, risks, and suggestions.
+Creator followers: ${creator?.followers}, ER: ${creator?.engagement ?? "n/a"}%
+Deliverables: ${deliverables}
+Usage rights: ${rights || "unspecified"}
+Price (EUR): ${priceEUR}
+Campaign brief: ${brief ?? "—"}
+Return JSON: { "fairnessScore": 0-100, "risks": "…", "suggestion": "…" }`;
+
+  const res = await ai.chat.completions.create({
+    model: "gpt-4o-mini",
+    response_format: { type: "json_object" },
+    messages: [{ role: "user", content: prompt }],
+    temperature: 0.2,
+  });
+
+  const j = JSON.parse(res.choices[0]?.message?.content || "{}");
+  const saved = await prisma.dealEval.create({
+    data: {
+      brandId: brand.id, creatorId, campaignId,
+      deliverables, rights, priceEUR, notes,
+      fairnessScore: j.fairnessScore ?? null,
+      risks: j.risks ?? null,
+      suggestion: j.suggestion ?? null,
+    },
+  });
+
+  return Response.json(saved);
+}

--- a/apps/web/app/api/outreach/draft/route.ts
+++ b/apps/web/app/api/outreach/draft/route.ts
@@ -1,0 +1,41 @@
+import { currentUser, auth } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+import { consumeCredits } from "@/lib/credits";
+import OpenAI from "openai";
+
+export const runtime = "nodejs";
+const ai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+
+export async function POST(req: Request) {
+  const { userId } = auth(); if (!userId) return new Response("Unauthorized", { status: 401 });
+  const { creatorId, campaignId, tone = "friendly" } = await req.json();
+
+  const email = (await currentUser())?.emailAddresses?.[0]?.emailAddress!;
+  const brand = await prisma.brand.findFirst({ where: { owner: { email } } });
+  if (!brand) return new Response("Brand not found", { status: 404 });
+
+  const debit = await consumeCredits(brand.id, 1, "AI_ANALYZE", "Outreach draft");
+  if (!debit.ok) return new Response(JSON.stringify({ error: "Not enough credits" }), { status: 402 });
+
+  const creator = await prisma.creator.findUnique({ where: { id: creatorId } });
+  const camp = campaignId ? await prisma.campaign.findUnique({ where: { id: campaignId } }) : null;
+
+  const prompt = `Write a concise ${tone} first-contact email to creator ${creator?.name} (${creator?.handle}) for a brand campaign.
+Brand: ${brand.name}
+Campaign: ${camp?.title ?? "—"}
+Brief: ${camp?.brief ?? "—"}
+Keep under 120 words. End with one clear call-to-action.`;
+
+  const res = await ai.chat.completions.create({
+    model: "gpt-4o-mini",
+    messages: [{ role: "user", content: prompt }],
+    temperature: 0.5,
+  });
+
+  const body = res.choices[0]?.message?.content?.trim() ?? "";
+  const draft = await prisma.outreach.create({
+    data: { brandId: brand.id, creatorId, campaignId, channel: "email", subject: camp?.title ?? "Collaboration", body, status: "draft" },
+  });
+
+  return Response.json({ id: draft.id, subject: draft.subject, body });
+}

--- a/apps/web/app/api/outreach/update/route.ts
+++ b/apps/web/app/api/outreach/update/route.ts
@@ -1,0 +1,9 @@
+import { prisma } from "@/lib/prisma";
+export async function POST(req: Request) {
+  const { outreachId, status } = await req.json(); // "sent" | "replied"
+  const data: any = { status };
+  if (status === "sent") data.sentAt = new Date();
+  if (status === "replied") data.replyAt = new Date();
+  await prisma.outreach.update({ where: { id: outreachId }, data });
+  return Response.json({ ok: true });
+}

--- a/apps/web/app/api/shortlist/list/route.ts
+++ b/apps/web/app/api/shortlist/list/route.ts
@@ -1,0 +1,13 @@
+import { currentUser } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+
+export async function GET() {
+  const email = (await currentUser())?.emailAddresses?.[0]?.emailAddress!;
+  const brand = await prisma.brand.findFirst({ where: { owner: { email } } });
+  if (!brand) return new Response("Brand not found", { status: 404 });
+
+  let sl = await prisma.shortlist.findFirst({ where: { brandId: brand.id }, include: { items: { include: { creator: true } } } });
+  if (!sl) sl = await prisma.shortlist.create({ data: { brandId: brand.id, name: "My Shortlist" } });
+
+  return Response.json(sl);
+}

--- a/apps/web/app/api/shortlist/remove/route.ts
+++ b/apps/web/app/api/shortlist/remove/route.ts
@@ -1,0 +1,6 @@
+import { prisma } from "@/lib/prisma";
+export async function POST(req: Request) {
+  const { itemId } = await req.json();
+  await prisma.shortlistItem.delete({ where: { id: itemId } });
+  return Response.json({ ok: true });
+}

--- a/apps/web/app/api/shortlist/share/route.ts
+++ b/apps/web/app/api/shortlist/share/route.ts
@@ -1,0 +1,8 @@
+import { prisma } from "@/lib/prisma";
+import { randomBytes } from "crypto";
+export async function POST(req: Request) {
+  const { shortlistId } = await req.json();
+  const shareId = randomBytes(6).toString("hex");
+  await prisma.shortlist.update({ where: { id: shortlistId }, data: { shareId } });
+  return Response.json({ url: `/s/${shareId}` });
+}

--- a/apps/web/app/api/shortlist/update/route.ts
+++ b/apps/web/app/api/shortlist/update/route.ts
@@ -1,0 +1,6 @@
+import { prisma } from "@/lib/prisma";
+export async function POST(req: Request) {
+  const { itemId, status, note } = await req.json();
+  await prisma.shortlistItem.update({ where: { id: itemId }, data: { status, note } });
+  return Response.json({ ok: true });
+}

--- a/apps/web/app/deal/[creatorId]/page.tsx
+++ b/apps/web/app/deal/[creatorId]/page.tsx
@@ -1,0 +1,20 @@
+import { prisma } from "@/lib/prisma";
+
+export default async function DealPage({ params }: { params: { creatorId: string } }) {
+  const c = await prisma.creator.findUnique({ where: { id: params.creatorId } });
+  if (!c) return <div className="p-8">Creator not found</div>;
+
+  return (
+    <section className="mx-auto max-w-3xl py-8">
+      <h1 className="text-2xl font-semibold">Deal evaluation — {c.name}</h1>
+      <form className="mt-4 space-y-3" action="/api/deal/evaluate" method="POST">
+        <input type="hidden" name="creatorId" value={c.id} />
+        <textarea name="deliverables" required placeholder="1 IG reel + 3 stories…" className="w-full rounded border border-white/10 bg-white/5 p-2" rows={4}/>
+        <input name="rights" placeholder="3 months paid usage + whitelisting" className="w-full rounded border border-white/10 bg-white/5 p-2"/>
+        <input name="priceEUR" type="number" min={0} required placeholder="Budget (EUR)" className="w-full rounded border border-white/10 bg-white/5 p-2"/>
+        <textarea name="notes" placeholder="Extra context…" className="w-full rounded border border-white/10 bg-white/5 p-2" rows={3}/>
+        <button className="rounded-xl bg-white/90 px-4 py-2 text-gray-900">Evaluate (1 credit)</button>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -23,6 +23,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <div className="hidden gap-6 md:flex">
                 <NavLink href="/">Home</NavLink>
                 <NavLink href="/dashboard">Dashboard</NavLink>
+                <NavLink href="/shortlist">Shortlist</NavLink>
+                <NavLink href="/billing">Billing & Credits</NavLink>
                 <NavLink href="/pricing">Pricing</NavLink>
               </div>
               <div className="flex items-center gap-2">
@@ -68,6 +70,12 @@ function MobileMenu() {
         </Link>
         <Link className="rounded-lg px-2 py-2 hover:bg-white/5" href="/dashboard">
           Dashboard
+        </Link>
+        <Link className="rounded-lg px-2 py-2 hover:bg-white/5" href="/shortlist">
+          Shortlist
+        </Link>
+        <Link className="rounded-lg px-2 py-2 hover:bg-white/5" href="/billing">
+          Billing & Credits
         </Link>
         <Link className="rounded-lg px-2 py-2 hover:bg-white/5" href="/pricing">
           Pricing

--- a/apps/web/app/s/[shareId]/page.tsx
+++ b/apps/web/app/s/[shareId]/page.tsx
@@ -1,0 +1,21 @@
+import { prisma } from "@/lib/prisma";
+export default async function SharedShortlist({ params }: { params: { shareId: string } }) {
+  const sl = await prisma.shortlist.findFirst({
+    where: { shareId: params.shareId },
+    include: { items: { include: { creator: true } } },
+  });
+  if (!sl) return <div className="p-8">Share not found.</div>;
+  return (
+    <section className="mx-auto max-w-4xl py-8">
+      <h1 className="text-2xl font-semibold">{sl.name}</h1>
+      <div className="mt-4 grid gap-4 sm:grid-cols-2">
+        {sl.items.map(i => (
+          <div key={i.id} className="rounded-xl border border-white/10 bg-white/5 p-4">
+            <div className="font-semibold">{i.creator.name}</div>
+            <div className="text-xs text-white/60">{i.creator.handle}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/shortlist/page.tsx
+++ b/apps/web/app/shortlist/page.tsx
@@ -1,0 +1,56 @@
+import { prisma } from "@/lib/prisma";
+
+export default async function ShortlistBoard() {
+  const sl = await prisma.shortlist.findFirst({
+    include: { items: { include: { creator: true } } },
+  });
+  if (!sl) return <div className="p-8">No shortlist yet.</div>;
+
+  const cols = ["PROSPECT","CONTACTED","NEGOTIATING","WON","LOST"] as const;
+  return (
+    <section className="mx-auto max-w-6xl py-8">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">{sl.name}</h1>
+        <form action="/api/shortlist/share" method="POST">
+          <input type="hidden" name="shortlistId" value={sl.id} />
+          <button className="rounded-xl border border-white/15 bg-white/5 px-3 py-2 text-sm hover:bg-white/10">
+            Share shortlist
+          </button>
+        </form>
+      </div>
+
+      <div className="mt-6 grid gap-4 md:grid-cols-5">
+        {cols.map(col => {
+          const items = sl.items.filter(i => i.status === col);
+          return (
+            <div key={col} className="rounded-2xl border border-white/10 bg-white/5 p-3">
+              <div className="mb-2 text-sm font-semibold">{col}</div>
+              <div className="space-y-2">
+                {items.map(i => (
+                  <div key={i.id} className="rounded-xl border border-white/10 bg-gray-900 p-3">
+                    <div className="text-sm font-medium">{i.creator.name}</div>
+                    <div className="text-xs text-white/60">{i.creator.handle}</div>
+                    <form className="mt-2 flex gap-2 text-xs" action="/api/shortlist/update" method="POST">
+                      <input type="hidden" name="itemId" value={i.id} />
+                      <select name="status" className="rounded border border-white/10 bg-white/5 px-2 py-1">
+                        <option>PROSPECT</option><option>CONTACTED</option><option>NEGOTIATING</option><option>WON</option><option>LOST</option>
+                      </select>
+                      <input name="note" placeholder="Add note…" className="flex-1 rounded border border-white/10 bg-white/5 px-2 py-1"/>
+                      <button className="rounded border border-white/10 bg-white/10 px-2">Save</button>
+                    </form>
+                    <div className="mt-2 text-xs text-white/60">{i.note}</div>
+                    <div className="mt-2 flex gap-2">
+                      <a className="rounded border border-white/10 bg-white/5 px-2 py-1 text-xs" href={`/campaigns/${i.campaignId ?? ""}/matches`}>Matches</a>
+                      <a className="rounded border border-white/10 bg-white/5 px-2 py-1 text-xs" href={`/deal/${i.creatorId}`}>Deal eval</a>
+                    </div>
+                  </div>
+                ))}
+                {!items.length && <div className="rounded border border-white/10 bg-white/5 p-2 text-xs text-white/60">Empty</div>}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/app/shortlist/print/page.tsx
+++ b/apps/web/app/shortlist/print/page.tsx
@@ -1,0 +1,23 @@
+import { prisma } from "@/lib/prisma";
+export default async function PrintShortlist() {
+  const sl = await prisma.shortlist.findFirst({
+    include: { items: { include: { creator: true } } },
+  });
+  if (!sl) return null;
+  return (
+    <section className="mx-auto max-w-4xl p-6 print:p-0">
+      <h1 className="text-2xl font-semibold">Shortlist Summary</h1>
+      <div className="mt-4 grid gap-2">
+        {sl.items.map(i => (
+          <div key={i.id} className="rounded border border-black/10 bg-white p-3 text-black print:border-0">
+            <div className="font-semibold">{i.creator.name} <span className="text-black/60">{i.creator.handle}</span></div>
+            <div className="text-sm">Followers: {i.creator.followers.toLocaleString()} · ER: {i.creator.engagement ?? "—"}%</div>
+            <div className="text-sm">Tone: {i.creator.tone ?? "—"} · Niche: {i.creator.niche ?? "—"}</div>
+            <div className="text-sm">Values: {(i.creator.values || []).join(", ")}</div>
+            {i.note && <div className="mt-1 text-sm">Note: {i.note}</div>}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -75,6 +75,14 @@ enum Plan {
   PRO
 }
 
+enum PipelineStatus {
+  PROSPECT
+  CONTACTED
+  NEGOTIATING
+  WON
+  LOST
+}
+
 model Creator {
   id          String   @id @default(cuid())
   name        String
@@ -153,24 +161,72 @@ model Match {
 }
 
 model Shortlist {
-  id        String         @id @default(cuid())
+  id        String   @id @default(cuid())
   brandId   String
-  brand     Brand          @relation(fields: [brandId], references: [id])
-  name      String         @default("Shortlist")
+  brand     Brand    @relation(fields: [brandId], references: [id])
+  name      String   @default("Shortlist")
+  shareId   String?  @unique
   items     ShortlistItem[]
-  createdAt DateTime       @default(now())
+  createdAt DateTime @default(now())
 }
 
 model ShortlistItem {
   id          String   @id @default(cuid())
   shortlistId String
   creatorId   String
+  campaignId  String?
   shortlist   Shortlist @relation(fields: [shortlistId], references: [id])
   creator     Creator   @relation(fields: [creatorId], references: [id])
+
+  status      PipelineStatus @default(PROSPECT)
   note        String?
-  createdAt   DateTime  @default(now())
+  lastContact DateTime?
+  createdAt   DateTime @default(now())
 
   @@unique([shortlistId, creatorId])
+}
+
+model ContactInfo {
+  id        String   @id @default(cuid())
+  creatorId String   @unique
+  email     String?
+  igDm      String?
+  ytEmail   String?
+  website   String?
+  createdAt DateTime @default(now())
+}
+
+model Outreach {
+  id          String   @id @default(cuid())
+  brandId     String
+  creatorId   String
+  campaignId  String?
+  channel     String
+  subject     String?
+  body        String
+  sentAt      DateTime?
+  replyAt     DateTime?
+  status      String   @default("draft")
+  createdAt   DateTime @default(now())
+
+  @@index([brandId, creatorId, campaignId])
+}
+
+model DealEval {
+  id          String   @id @default(cuid())
+  brandId     String
+  creatorId   String
+  campaignId  String?
+  // inputs
+  deliverables String
+  rights       String?
+  priceEUR     Int
+  notes        String?
+  // AI assessment
+  fairnessScore Int?
+  risks         String?
+  suggestion    String?
+  createdAt     DateTime @default(now())
 }
 
 model WaitlistSignup {


### PR DESCRIPTION
## Summary
- extend Prisma schema with pipeline statuses, sharing, outreach, and deal evaluation models
- add API routes for shortlist management, outreach drafting, and deal evaluation
- build shortlist board, deal evaluation form, public share, printable shortlist, and header links

## Testing
- `npx prisma migrate dev -n "workflow_pipeline_outreach_dealeval"` *(fails: Environment variable not found: DATABASE_URL)*
- `pnpm install` *(fails: Prisma schema validation error)*
- `pnpm lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_68ab8f734acc832cb272f8940cd2b08e