### PR TITLE
feat: add creator comparison dialog

### DIFF
--- a/apps/web/app/campaigns/[id]/matches/MatchesClient.tsx
+++ b/apps/web/app/campaigns/[id]/matches/MatchesClient.tsx
@@ -51,6 +51,13 @@ export default function MatchesClient({
   const [loading, setLoading] = React.useState<null | string>(null);
   const [error, setError] = React.useState<string>("");
   const [autoMsg, setAutoMsg] = React.useState<string>("");
+  const [selected, setSelected] = React.useState<string[]>([]);
+
+  function toggleSelect(id: string) {
+    setSelected((sel) =>
+      sel.includes(id) ? sel.filter((x) => x !== id) : [...sel, id].slice(-3)
+    );
+  }
 
   const estimatedCost = (!campaign.analyzedAt ? 1 : 0) + 20;
 
@@ -238,6 +245,13 @@ export default function MatchesClient({
         </a>
       </div>
 
+      {selected.length >= 2 && (
+        <CompareDialog
+          creators={matches.filter((m) => selected.includes(m.id))}
+          onClose={() => setSelected([])}
+        />
+      )}
+
       {autoMsg && (
         <div className="mt-3 rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-2 text-sm text-emerald-200">
           {autoMsg}
@@ -289,7 +303,18 @@ export default function MatchesClient({
             </div>
 
             <div className="mt-4 flex items-center justify-between">
-              <DetailsDialog m={m} campaign={{ niche: campaign.niche, targetTone: campaign.targetTone }} />
+              <div className="flex items-center gap-3">
+                <DetailsDialog m={m} campaign={{ niche: campaign.niche, targetTone: campaign.targetTone }} />
+                <label className="flex items-center gap-2 text-xs text-white/70">
+                  <input
+                    type="checkbox"
+                    checked={selected.includes(m.id)}
+                    onChange={() => toggleSelect(m.id)}
+                    className="h-3 w-3 accent-indigo-500"
+                  />
+                  Compare
+                </label>
+              </div>
               <button
                 onClick={() => shortlist(m.id)}
                 disabled={loading === `shortlist:${m.id}`}
@@ -417,4 +442,91 @@ function fmtK(n: number) {
   if (n < 1000) return String(n);
   if (n < 1_000_000) return (n / 1000).toFixed(n % 1000 ? 1 : 0) + "k";
   return (n / 1_000_000).toFixed(1) + "M";
+}
+
+function CompareDialog({
+  creators,
+  onClose,
+}: {
+  creators: CreatorRow[];
+  onClose: () => void;
+}) {
+  return (
+    <Dialog open={true} onOpenChange={onClose}>
+      <DialogContent className="max-w-5xl border-white/10 bg-gray-950 text-white">
+        <DialogHeader>
+          <DialogTitle className="text-lg">Compare creators</DialogTitle>
+        </DialogHeader>
+
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-collapse text-sm">
+            <thead>
+              <tr className="text-white/60">
+                <th className="p-2 text-left">Metric</th>
+                {creators.map((c) => (
+                  <th key={c.id} className="p-2 text-left font-medium">
+                    {c.name} <span className="text-xs text-white/50">({c.handle})</span>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="p-2">Match Score</td>
+                {creators.map((c) => (
+                  <td key={c.id} className="p-2 font-semibold">
+                    {c.score}%
+                  </td>
+                ))}
+              </tr>
+              <tr>
+                <td className="p-2">Followers</td>
+                {creators.map((c) => (
+                  <td key={c.id} className="p-2">{fmtK(c.followers)}</td>
+                ))}
+              </tr>
+              <tr>
+                <td className="p-2">Avg Views</td>
+                {creators.map((c) => (
+                  <td key={c.id} className="p-2">{fmtK(c.avgViews)}</td>
+                ))}
+              </tr>
+              <tr>
+                <td className="p-2">Engagement</td>
+                {creators.map((c) => (
+                  <td key={c.id} className="p-2">
+                    {c.engagement ? `${c.engagement.toFixed(1)}%` : "—"}
+                  </td>
+                ))}
+              </tr>
+              <tr>
+                <td className="p-2">Tone</td>
+                {creators.map((c) => (
+                  <td key={c.id} className="p-2">{c.tone || "—"}</td>
+                ))}
+              </tr>
+              <tr>
+                <td className="p-2">Niche</td>
+                {creators.map((c) => (
+                  <td key={c.id} className="p-2">{c.niche || "—"}</td>
+                ))}
+              </tr>
+              <tr>
+                <td className="p-2">Values</td>
+                {creators.map((c) => (
+                  <td key={c.id} className="p-2">{(c.values || []).join(", ")}</td>
+                ))}
+              </tr>
+              <tr>
+                <td className="p-2">Rationale</td>
+                {creators.map((c) => (
+                  <td key={c.id} className="p-2 text-white/70">{c.rationale}</td>
+                ))}
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
 }


### PR DESCRIPTION
## Summary
- allow selecting up to three creators for side-by-side comparison
- show compare dialog with key metrics and rationale

## Testing
- `pnpm --filter web lint` *(fails: next: not found)*
- `pnpm install` *(fails: prisma schema validation error)*

------
https://chatgpt.com/codex/tasks/task_e_68ab90f45348832ca917a9383c247ea1