### PR TITLE
feat: streamline onboarding to first matches

### DIFF
--- a/apps/web/.env.local
+++ b/apps/web/.env.local
@@ -28,7 +28,7 @@ CLERK_SECRET_KEY=
 CLERK_SIGN_IN_URL=/sign-in
 CLERK_SIGN_UP_URL=/sign-up
 CLERK_AFTER_SIGN_IN_URL=/dashboard
-CLERK_AFTER_SIGN_UP_URL=/dashboard
+CLERK_AFTER_SIGN_UP_URL=/welcome
 
 # Credit packs
 STRIPE_PRICE_PACK_100=price_pack_100

--- a/apps/web/app/api/onboarding/route.ts
+++ b/apps/web/app/api/onboarding/route.ts
@@ -1,0 +1,44 @@
+import { auth, currentUser } from "@clerk/nextjs/server";
+import { prisma } from "@/lib/prisma";
+
+export async function POST(req: Request) {
+  const { userId } = auth();
+  if (!userId) return new Response("Unauthorized", { status: 401 });
+
+  const { niche, goal } = await req.json();
+  const user = await currentUser();
+  const email = user?.emailAddresses?.[0]?.emailAddress ?? "";
+
+  const dbUser = await prisma.user.findUnique({
+    where: { email },
+    include: { brands: true },
+  });
+  if (!dbUser) return new Response("User not provisioned", { status: 400 });
+
+  const brand = dbUser.brands[0];
+  if (!brand) return new Response("No brand", { status: 400 });
+
+  await prisma.brand.update({
+    where: { id: brand.id },
+    data: { niche, goal },
+  });
+
+  if (brand.credits < 20) {
+    await prisma.brand.update({
+      where: { id: brand.id },
+      data: { credits: 20 },
+    });
+  }
+
+  const campaign = await prisma.campaign.create({
+    data: {
+      brandId: brand.id,
+      title: `${niche} campaign`,
+      brief: `A starter campaign for ${niche} with goal: ${goal}.`,
+      niche,
+    },
+  });
+
+  return Response.json({ campaignId: campaign.id });
+}
+

--- a/apps/web/app/welcome/page.tsx
+++ b/apps/web/app/welcome/page.tsx
@@ -1,0 +1,57 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import posthog from "posthog-js";
+
+export default function WelcomePage() {
+  const r = useRouter();
+  const [loading, setLoading] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    const form = e.target as HTMLFormElement;
+    const niche = (form.elements.namedItem("niche") as HTMLInputElement).value;
+    const goal = (form.elements.namedItem("goal") as HTMLSelectElement).value;
+
+    const res = await fetch("/api/onboarding", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ niche, goal }),
+    });
+    const j = await res.json();
+    posthog.capture("onboarding_completed", { niche, goal });
+    r.push(`/campaigns/${j.campaignId}/matches?auto=1`);
+  }
+
+  return (
+    <main className="mx-auto max-w-md py-16 text-center">
+      <h1 className="text-2xl font-bold">Welcome to Siora 🎉</h1>
+      <p className="mt-2 text-white/60">Tell us a bit about your brand.</p>
+      <form onSubmit={submit} className="mt-6 space-y-3">
+        <input
+          name="niche"
+          placeholder="Your niche (e.g. skincare, fitness)"
+          required
+          className="w-full rounded border border-white/10 bg-white/5 p-3"
+        />
+        <select
+          name="goal"
+          className="w-full rounded border border-white/10 bg-white/5 p-3"
+          required
+        >
+          <option value="awareness">Grow awareness</option>
+          <option value="sales">Drive sales</option>
+          <option value="content">Get authentic content</option>
+        </select>
+        <button
+          disabled={loading}
+          className="w-full rounded-xl bg-white/90 py-3 text-gray-900"
+        >
+          {loading ? "Setting up…" : "Continue"}
+        </button>
+      </form>
+    </main>
+  );
+}
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,8 @@ model Brand {
   name       String
   website    String?
   plan       Plan      @default(FREE)
+  niche      String?
+  goal       String?
 
   stripeCustomerId     String?  @unique
   stripeSubscriptionId String?


### PR DESCRIPTION
## Summary
- redirect new Clerk signups to /welcome
- capture brand basics and create starter campaign
- auto-run Analyze+Generate to show first matches with toast & confetti
- ensure brands have at least 20 credits
- store brand niche and goal in Prisma schema

## Testing
- `pnpm run prisma:generate`
- `pnpm run lint` *(fails: Unexpected console statement, etc.)*
- `pnpm exec eslint apps/web/app/welcome/page.tsx apps/web/app/api/onboarding/route.ts apps/web/app/campaigns/[id]/matches/MatchesClient.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ac2f220a54832c863a80bcc03ead0a