### PR TITLE
feat: add paywall ux and build safeguards

### DIFF
--- a/apps/web/app/(components)/CreditBadge.tsx
+++ b/apps/web/app/(components)/CreditBadge.tsx
@@ -1,11 +1,16 @@
-import { getBrandForUser } from "@/lib/guards";
+import { getBrand } from "@/lib/paywall";
 
 export default async function CreditBadge() {
-  const brand = await getBrandForUser();
-  const credits = brand?.credits ?? 0;
+  const b = await getBrand();
+  const n = b?.credits ?? 0;
+  const low = n <= 10;
   return (
-    <span className="rounded-lg border border-white/10 bg-white/5 px-2 py-1 text-xs text-white/80">
-      Credits: <b className="ml-1">{credits.toLocaleString()}</b>
-    </span>
+    <a
+      href="/billing"
+      className={`rounded-lg border px-2 py-1 text-xs ${low ? "border-amber-400/40 bg-amber-400/10 text-amber-200" : "border-white/10 bg-white/5 text-white/80"}`}
+    >
+      Credits: <b className="ml-1">{n.toLocaleString()}</b>
+      {low && <span className="ml-2 underline">Top up</span>}
+    </a>
   );
 }

--- a/apps/web/app/api/provision/route.ts
+++ b/apps/web/app/api/provision/route.ts
@@ -20,11 +20,13 @@ export async function POST() {
     create: { email, name, authId: userId, role: "BRAND" },
   });
 
-  const brand = await prisma.brand.findFirst({ where: { ownerId: user.id } });
+  let brand = await prisma.brand.findFirst({ where: { ownerId: user.id } });
   if (!brand) {
-    await prisma.brand.create({
-      data: { ownerId: user.id, name: `${name.split(" ")[0]}'s Brand`, plan: "FREE" },
+    brand = await prisma.brand.create({
+      data: { ownerId: user.id, name: `${name.split(" ")[0]}'s Brand`, plan: "FREE", credits: 20 },
     });
+  } else if ((brand.credits ?? 0) === 0 && brand.plan === "FREE") {
+    await prisma.brand.update({ where: { id: brand.id }, data: { credits: 20 } });
   }
 
   return Response.json({ ok: true });

--- a/apps/web/app/campaigns/[id]/matches/page.tsx
+++ b/apps/web/app/campaigns/[id]/matches/page.tsx
@@ -1,6 +1,10 @@
 import { prisma } from "@/lib/prisma";
 import { auth } from "@clerk/nextjs/server";
+import { Suspense } from "react";
 import MatchesClient from "./MatchesClient";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
 
 export default async function MatchesPage({ params }: { params: { id: string } }) {
   const { userId } = auth();
@@ -45,22 +49,24 @@ export default async function MatchesPage({ params }: { params: { id: string } }
   }
 
   return (
-    <MatchesClient
-      campaign={{
-        id: campaign.id,
-        title: campaign.title,
-        brief: campaign.brief ?? "",
-        niche: campaign.niche ?? "",
-        targetTone: campaign.targetTone ?? "",
-        analyzedAt: campaign.analyzedAt?.toISOString() ?? null,
-        credits: campaign.brand.credits ?? 0,
-        plan: campaign.brand.plan,
-      }}
-      initialMatches={campaign.matches.map((m) => ({
-        score: m.matchScore,
-        rationale: m.rationale ?? "",
-        ...m.creator,
-      }))}
-    />
+    <Suspense fallback={<div className="p-8 text-white/60">Loading…</div>}>
+      <MatchesClient
+        campaign={{
+          id: campaign.id,
+          title: campaign.title,
+          brief: campaign.brief ?? "",
+          niche: campaign.niche ?? "",
+          targetTone: campaign.targetTone ?? "",
+          analyzedAt: campaign.analyzedAt?.toISOString() ?? null,
+          credits: campaign.brand.credits ?? 0,
+          plan: campaign.brand.plan,
+        }}
+        initialMatches={campaign.matches.map((m) => ({
+          score: m.matchScore,
+          rationale: m.rationale ?? "",
+          ...m.creator,
+        }))}
+      />
+    </Suspense>
   );
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -7,6 +7,9 @@ import Testimonials from "@/components/marketing/Testimonials";
 import SiteFooter from "@/components/marketing/SiteFooter";
 import { WaitlistCount } from "./(marketing)/_components/WaitlistCount";
 
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 export const metadata: Metadata = {
   title: "Siora – Smarter, fairer brand deals",
   description: "AI-powered brand-creator partnerships that value fit and fairness.",

--- a/apps/web/app/s/[shareId]/page.tsx
+++ b/apps/web/app/s/[shareId]/page.tsx
@@ -1,10 +1,16 @@
 import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
 export default async function SharedShortlist({ params }: { params: { shareId: string } }) {
   const sl = await prisma.shortlist.findFirst({
     where: { shareId: params.shareId },
     include: { items: { include: { creator: true } } },
   });
   if (!sl) return <div className="p-8">Share not found.</div>;
+  const brand = await prisma.brand.findUnique({ where: { id: sl.brandId }, select: { plan: true } });
+  const isFree = brand?.plan !== "PRO";
   return (
     <section className="mx-auto max-w-4xl py-8">
       <h1 className="text-2xl font-semibold">{sl.name}</h1>
@@ -16,6 +22,11 @@ export default async function SharedShortlist({ params }: { params: { shareId: s
           </div>
         ))}
       </div>
+      {isFree && (
+        <div className="mt-6 text-center text-xs text-white/50">
+          Powered by <a href="/" className="underline">Siora</a>
+        </div>
+      )}
     </section>
   );
 }

--- a/apps/web/app/shortlist/page.tsx
+++ b/apps/web/app/shortlist/page.tsx
@@ -1,6 +1,7 @@
 export const dynamic = "force-dynamic";
 
 import { prisma } from "@/lib/prisma";
+import { LowCreditBanner } from "@/components/LowCreditBanner";
 
 export default async function ShortlistBoard() {
   const sl = await prisma.shortlist.findFirst({
@@ -8,9 +9,12 @@ export default async function ShortlistBoard() {
   });
   if (!sl) return <div className="p-8">No shortlist yet.</div>;
 
+  const brand = await prisma.brand.findUnique({ where: { id: sl.brandId }, select: { credits: true } });
+
   const cols = ["PROSPECT","CONTACTED","NEGOTIATING","WON","LOST"] as const;
   return (
     <section className="mx-auto max-w-6xl py-8">
+      <LowCreditBanner remaining={brand?.credits ?? 0} />
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold">{sl.name}</h1>
         <form action="/api/shortlist/share" method="POST">

--- a/apps/web/components/LowCreditBanner.tsx
+++ b/apps/web/components/LowCreditBanner.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export function LowCreditBanner({ remaining }: { remaining: number }) {
+  if (remaining > 10) return null;
+  return (
+    <div className="mb-4 rounded-xl border border-amber-400/30 bg-amber-400/10 px-3 py-2 text-sm text-amber-100">
+      You're low on credits ({remaining}). <a className="underline" href="/billing">Buy a pack</a> or <a className="underline" href="/pricing">Upgrade to Pro</a>.
+    </div>
+  );
+}

--- a/apps/web/components/UpgradeModal.tsx
+++ b/apps/web/components/UpgradeModal.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+export function UpgradeModal({ open, onClose, needed, remaining }:{
+  open: boolean; onClose: () => void; needed?: number; remaining?: number;
+}) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 grid place-items-center bg-black/50">
+      <div className="w-full max-w-md rounded-2xl border border-white/10 bg-gray-950 p-5">
+        <h3 className="text-lg font-semibold">You’ve run out of credits</h3>
+        <p className="mt-2 text-sm text-white/70">
+          {typeof needed === "number" ? `This action needs ~${needed} credits.` : null} You have {remaining ?? 0}.
+        </p>
+        <div className="mt-4 flex gap-2">
+          <a href="/pricing" className="rounded-xl bg-white/90 px-4 py-2 text-gray-900">Upgrade to Pro</a>
+          <a href="/billing" className="rounded-xl border border-white/15 bg-white/5 px-4 py-2">Buy credits</a>
+          <button onClick={onClose} className="ml-auto text-sm text-white/60 underline">Close</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/marketing/Hero.tsx
+++ b/apps/web/components/marketing/Hero.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import WaitlistForm from "./WaitlistForm";
 
 export default function Hero() {
@@ -26,7 +27,9 @@ export default function Hero() {
         </div>
       </div>
       <div className="w-full max-w-md">
-        <WaitlistForm source="hero-cta" />
+        <Suspense fallback={<div className="text-white/60">Loading…</div>}>
+          <WaitlistForm source="hero-cta" />
+        </Suspense>
       </div>
     </section>
   );

--- a/apps/web/lib/paywall.ts
+++ b/apps/web/lib/paywall.ts
@@ -1,0 +1,26 @@
+import { prisma } from "@/lib/prisma";
+import { auth, currentUser } from "@clerk/nextjs/server";
+
+export async function getBrand() {
+  const { userId } = auth();
+  if (!userId) return null;
+  const email = (await currentUser())?.emailAddresses?.[0]?.emailAddress ?? "";
+  return prisma.brand.findFirst({ where: { owner: { email } } });
+}
+
+/** true if paid plan */
+export async function isPro() {
+  const b = await getBrand();
+  return b?.plan === "PRO";
+}
+
+/** throws if not enough credits */
+export function assertCredits(credits: number, required: number) {
+  if ((credits ?? 0) < required) {
+    const err: any = new Error("Not enough credits");
+    err.code = "INSUFFICIENT_CREDITS";
+    err.required = required;
+    err.remaining = credits ?? 0;
+    throw err;
+  }
+}


### PR DESCRIPTION
## Summary
- add centralized paywall helpers and monthly credit refresh
- show credit nudges and upgrade flows for low or zero credits
- mark dynamic pages and add Suspense around search params

## Testing
- `npx eslint apps/web/lib/paywall.ts apps/web/app/(components)/CreditBadge.tsx apps/web/components/LowCreditBanner.tsx apps/web/components/UpgradeModal.tsx apps/web/app/campaigns/[id]/matches/MatchesClient.tsx apps/web/app/campaigns/[id]/matches/page.tsx apps/web/app/shortlist/page.tsx apps/web/components/marketing/Hero.tsx apps/web/app/page.tsx apps/web/app/s/[shareId]/page.tsx apps/web/app/api/provision/route.ts`
- `pnpm -F web build` *(fails: Module not found: Can't resolve 'canvas-confetti')*


------
https://chatgpt.com/codex/tasks/task_e_68ac367aa634832c818045c9ea58dc99