### PR TITLE
fix vercel output directory to avoid missing routes manifest

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
+  "rootDirectory": "apps/web",
   "buildCommand": "pnpm build",
   "installCommand": "pnpm install",
-  "outputDirectory": "apps/web/.next",
+  "outputDirectory": ".next",
   "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- fix Vercel config for apps/web to avoid duplicated path when locating `.next/routes-manifest.json`

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68ac9fb9a7d0832c954467999f481cc9