### PR TITLE
fix: remove deprecated Vercel rootDirectory

### DIFF
--- a/our-time-univ.yaml
+++ b/our-time-univ.yaml
@@ -1,0 +1,2 @@
+contributions:
+  - "Removed deprecated rootDirectory from vercel.json to fix schema validation error."

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,4 @@
 {
-  "rootDirectory": "apps/web",
   "buildCommand": "pnpm build",
   "installCommand": "pnpm install",
   "outputDirectory": ".next",


### PR DESCRIPTION
## Summary
- remove deprecated `rootDirectory` from Vercel config
- note contribution in `our-time-univ.yaml`

## Testing
- `pnpm install`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68aca52ba7c0832c8511f2b68f464003