### PR TITLE
fix: correct Vercel output path

### DIFF
--- a/vercel-fix-log.md
+++ b/vercel-fix-log.md
@@ -9,6 +9,7 @@
 - Verified Prisma generate runs in postinstall.
 - Ran `pnpm install` and `pnpm build --filter=web` to ensure `next build` succeeds.
 - Attempted `vercel link` which failed due to missing credentials.
+- Corrected `outputDirectory` to `apps/web/.next` in `vercel.json`.
 
 ## Test Commands
 ```

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "pnpm build",
   "installCommand": "pnpm install",
-  "outputDirectory": ".next",
+  "outputDirectory": "apps/web/.next",
   "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- ensure Vercel deploy reads built web app by pointing outputDirectory to `apps/web/.next`
- document outputDirectory fix in deployment log

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68acab1fcd14832ca064876ab89dbf15