### PR TITLE
fix vercel output dir to locate Next build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "buildCommand": "pnpm build",
   "installCommand": "pnpm install",
-  "outputDirectory": "apps/web/.next",
+  "outputDirectory": ".next",
   "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- adjust `vercel.json` to output `.next` relative to app root

## Testing
- `pnpm lint`
- `pnpm vercel-build`


------
https://chatgpt.com/codex/tasks/task_e_68accbbd56d0832ca77a3dd5def9b367