### PR TITLE
Handle missing Upstash config in middleware

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -3,10 +3,18 @@ import { Ratelimit } from "@upstash/ratelimit";
 import { Redis } from "@upstash/redis";
 import { NextResponse } from "next/server";
 
-const ratelimit = new Ratelimit({
-  redis: Redis.fromEnv(),
-  limiter: Ratelimit.slidingWindow(20, "1 m"),
-});
+// Initialize the rate limiter only when the required environment variables are present.
+let ratelimit: Ratelimit | null = null;
+if (process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN) {
+  const redis = new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN,
+  });
+  ratelimit = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(20, "1 m"),
+  });
+}
 
 export default clerkMiddleware({
   publicRoutes: [
@@ -28,9 +36,11 @@ export default clerkMiddleware({
     }
   },
   async afterAuth(auth, req) {
-    const ip = req.headers.get("x-forwarded-for") ?? "127.0.0.1";
-    const { success } = await ratelimit.limit(ip);
-    if (!success) return new Response("Too many requests", { status: 429 });
+    if (ratelimit) {
+      const ip = req.headers.get("x-forwarded-for") ?? "127.0.0.1";
+      const { success } = await ratelimit.limit(ip);
+      if (!success) return new Response("Too many requests", { status: 429 });
+    }
   },
 });
 


### PR DESCRIPTION
## Summary
- ensure Upstash rate limiter is only initialized when environment variables are present
- guard middleware rate limiting with a runtime check to avoid crashes

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68accf58d830832ca0be8d9edb9b2b03